### PR TITLE
Added NE Lincs

### DIFF
--- a/scripts/councils/NELincs.py
+++ b/scripts/councils/NELincs.py
@@ -1,0 +1,52 @@
+from bs4 import BeautifulSoup
+from get_bin_data import AbstractGetBinDataClass
+
+import pandas as pd
+
+
+class CouncilClass(AbstractGetBinDataClass):
+
+    """
+    Concrete classes have to implement all abstract operations of the
+    baseclass. They can also override some
+    operations with a default implementation.
+    """
+
+    def parse_data(self, page: str) -> dict:
+        # Make a BS4 object
+        soup = BeautifulSoup(page.text, features="html.parser")
+        soup.prettify()
+
+        data = {"bins": []}
+
+        # Get list items that can be seen on page
+        for element in soup.find_all("li", {"class": "list-group-item p-0 p-3 bin-collection-item"}):
+
+            element_text = element.text.strip().split("\n\n")
+            element_text = [x.strip() for x in element_text]
+
+            bin_type = element_text[1]
+            collection_date = pd.Timestamp(element_text[0]).strftime("%d/%m/%Y")
+
+            dict_data = {
+                "type": bin_type,
+                "collectionDate": collection_date,
+            }
+            data["bins"].append(dict_data)
+
+        # Get hidden list items too
+        for element in soup.find_all("li", {"class": "list-group-item p-0 p-3 bin-collection-item d-none"}):
+
+            element_text = element.text.strip().split("\n\n")
+            element_text = [x.strip() for x in element_text]
+
+            bin_type = element_text[1]
+            collection_date = pd.Timestamp(element_text[0]).strftime("%d/%m/%Y")
+
+            dict_data = {
+                "type": bin_type,
+                "collectionDate": collection_date,
+            }
+            data["bins"].append(dict_data)
+
+        return data

--- a/tests/input.json
+++ b/tests/input.json
@@ -7,5 +7,6 @@
     "NewcastleCityCouncil": "https://community.newcastle.gov.uk/my-neighbourhood/ajax/getBinsNew.php?uprn=XXXXXXXXXXXX",
     "bromley_borough_council": "100022887131",
     "chelmsford_city_council": "100022887131",
-    "TorridgeDistrictCouncil": "10091078762"
+    "TorridgeDistrictCouncil": "10091078762",
+    "NELincs": "https://www.nelincs.gov.uk/refuse-collection-schedule/?uprn=XXXXXXXX&view=timeline"
 }


### PR DESCRIPTION
Added support for NE Lincs' collection timeline view using the UPRN of a property in the URL:
https://www.nelincs.gov.uk/refuse-collection-schedule/?uprn=XXXXXXXX&view=timeline

This should resolve #41.