### PR TITLE
Add East Devon District Council

### DIFF
--- a/scripts/councils/EastDevonDC.py
+++ b/scripts/councils/EastDevonDC.py
@@ -1,0 +1,65 @@
+from bs4 import BeautifulSoup
+from get_bin_data import AbstractGetBinDataClass
+from datetime import datetime
+
+import pandas as pd
+import re
+
+
+class CouncilClass(AbstractGetBinDataClass):
+    """
+    Concrete classes have to implement all abstract operations of the
+    baseclass. They can also override some
+    operations with a default implementation.
+    """
+
+    def parse_data(self, page: str) -> dict:
+        # Make a BS4 object
+        soup = BeautifulSoup(page.text, features="html.parser")
+        soup.prettify()
+
+        data = {"bins": []}
+        month_class_name = 'class="eventmonth"'
+        regular_collection_class_name = "collectiondate regular-collection"
+        holiday_collection_class_name = "collectiondate bankholiday-change"
+        regex_string = "[^0-9]"
+
+        calendar_collection = soup.find("ol", {"class": "nonumbers news collections"})
+        calendar_list = calendar_collection.find_all("li")
+        current_month = ""
+        current_year = ""
+
+        for element in calendar_list:
+            element_tag = str(element)
+            if month_class_name in element_tag:
+                current_month = datetime.strptime(element.text, "%B %Y").strftime("%m")
+                current_year = datetime.strptime(element.text, "%B %Y").strftime("%Y")
+            elif regular_collection_class_name in element_tag:
+                week_value = element.find_next("span", {"class": f"{regular_collection_class_name}"})
+                day_of_week = re.sub(regex_string, "", week_value.text).strip()
+                collection_date = datetime(int(current_year), int(current_month), int(day_of_week)).strftime("%d/%m/%Y")
+                collections = week_value.find_next_siblings("span")
+                for item in collections:
+                    x = item.text
+                    bin_type = item.text.strip()
+                    if len(bin_type) > 1:
+                        dict_data = {
+                            "type":           bin_type,
+                            "collectionDate": collection_date,
+                        }
+                        data["bins"].append(dict_data)
+            elif holiday_collection_class_name in element_tag:
+                week_value = element.find_next("span", {"class": f"{holiday_collection_class_name}"})
+                day_of_week = re.sub(regex_string, "", week_value.text).strip()
+                collection_date = datetime(int(current_year), int(current_month), int(day_of_week)).strftime("%d/%m/%Y")
+                collections = week_value.find_next_siblings("span")
+                for item in collections:
+                    x = item.text
+                    bin_type = item.text.strip()
+                    if len(bin_type) > 1:
+                        dict_data = {
+                            "type":           bin_type + " (bank holiday replacement)",
+                            "collectionDate": collection_date,
+                        }
+                        data["bins"].append(dict_data)
+        return data

--- a/tests/input.json
+++ b/tests/input.json
@@ -2,6 +2,7 @@
     "bromley_borough_council": "100022887131",
     "chelmsford_city_council": "100022887131",
     "CheshireEastCouncil": "https://online.cheshireeast.gov.uk/MyCollectionDay/SearchByAjax/GetBartecJobList?uprn=100012791226&onelineaddress=3%20COBBLERS%20YARD,%20SK9%207DZ&_=1621149987573",
+    "EastDevonDC": "https://eastdevon.gov.uk/recycling-and-waste/recycling-and-waste-information/when-is-my-bin-collected/future-collections-calendar/?UPRN=XXXXXXXX",
     "HuntingdonDistrictCouncil": "http://www.huntingdonshire.gov.uk/refuse-calendar/10012048679",
     "LeedsCityCouncil": "https://www.leeds.gov.uk/residents/bins-and-recycling/check-your-bin-day",
     "NELincs": "https://www.nelincs.gov.uk/refuse-collection-schedule/?uprn=XXXXXXXX&view=timeline",


### PR DESCRIPTION
Saw this one requested in HA forum thread. It works with the URL:
> https://eastdevon.gov.uk/recycling-and-waste/recycling-and-waste-information/when-is-my-bin-collected/future-collections-calendar/?UPRN=XXXXXXXXX

It should support parsing for both regular and bank holiday replacement collections.