### PR TITLE
Fix parse error in Warwick council

### DIFF
--- a/scripts/councils/WarwickDistrictCouncil.py
+++ b/scripts/councils/WarwickDistrictCouncil.py
@@ -25,8 +25,8 @@ class CouncilClass(AbstractGetBinDataClass):
 
             bin_type = element.next_element
             bin_type = bin_type.lstrip()
-            collectionDate = element.next_sibling.next_element.next_element
-
+            collectionDateElement = element.next_sibling.next_element.next_element
+            collectionDate = collectionDateElement.getText()
             dict_data = {
                 "type": bin_type,
                 "collectionDate": collectionDate,


### PR DESCRIPTION
Use getText() for the the collection date to return the raw text instead of the beautifulsoup class as the collectionDate