### PR TITLE
Adds North Lanarkshire Council (Scotland)

### DIFF
--- a/uk_bin_collection/tests/council_schemas/NorthLanarkshireCouncil.schema
+++ b/uk_bin_collection/tests/council_schemas/NorthLanarkshireCouncil.schema
@@ -1,0 +1,43 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$ref": "#/definitions/Welcome7",
+    "definitions": {
+        "Welcome7": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bins": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Bin"
+                    }
+                }
+            },
+            "required": [
+                "bins"
+            ],
+            "title": "Welcome7"
+        },
+        "Bin": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "type": "string"
+                },
+                "collectionDate": {
+                    "type": "string"
+                },
+                "nextCollectionDate": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "collectionDate",
+                "nextCollectionDate",
+                "type"
+            ],
+            "title": "Bin"
+        }
+    }
+}

--- a/uk_bin_collection/tests/features/validate_council_outputs.feature
+++ b/uk_bin_collection/tests/features/validate_council_outputs.feature
@@ -27,6 +27,7 @@ Feature: Test each council output matches expected results in /outputs
             | NELincs |
             | NewarkAndSherwoodDC |
             | NewcastleCityCouncil |
+            | NorthLanarkshireCouncil |
             | SouthAyrshireCouncil |
             | SouthOxfordshireCouncil |
             | SouthTynesideCouncil |

--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -61,6 +61,7 @@
     "NorthEastLincs": "https://www.nelincs.gov.uk/refuse-collection-schedule/?uprn=XXXXXXXX&view=timeline",
     "NewarkAndSherwoodDC": "http://app.newark-sherwooddc.gov.uk/bincollection/calendar?pid=200004258529",
     "NewcastleCityCouncil": "https://community.newcastle.gov.uk/my-neighbourhood/ajax/getBinsNew.php?uprn=XXXXXXXXXXXX",
+    "NorthLanarkshireCouncil": "https://www.northlanarkshire.gov.uk/bin-collection-dates/000118016164/48402118",
     "SouthAyrshireCouncil": {
         "url": "https://www.south-ayrshire.gov.uk/",
         "postcode":"KA19 7BN",

--- a/uk_bin_collection/uk_bin_collection/councils/NorthLanarkshireCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/NorthLanarkshireCouncil.py
@@ -1,0 +1,32 @@
+from bs4 import BeautifulSoup
+from uk_bin_collection.uk_bin_collection.common import *
+from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
+
+
+# import the wonderful Beautiful Soup and the URL grabber
+class CouncilClass(AbstractGetBinDataClass):
+    """
+    Concrete classes have to implement all abstract operations of the
+    base class. They can also override some operations with a default
+    implementation.
+    """
+
+    def parse_data(self, page: str, **kwargs) -> dict:
+        # Make a BS4 object
+        soup = BeautifulSoup(page.text, features="html.parser")
+        soup.prettify()
+
+        data = {"bins": []}
+        for bins in soup.select('div[class^=waste-type-container]'):
+            bin_type = bins.div.h3.text.strip()
+            collection_date = bins.select("div > p")[0].get_text(strip=True)
+            next_collection_date = bins.select("div > p")[1].get_text(strip=True)
+            dict_data = {
+                    "type": bin_type,
+                    "collectionDate": collection_date,
+                    "nextCollectionDate": next_collection_date
+                }
+            if collection_date:
+                data["bins"].append(dict_data)
+
+        return data


### PR DESCRIPTION
Adds North Lanarkshire Council support. Tested with multiple valid URLs from the North Lan website: https://www.northlanarkshire.gov.uk/bin-collection-dates