### PR TITLE
Fixes dev mode so it can run from the script folder

### DIFF
--- a/uk_bin_collection/uk_bin_collection/common.py
+++ b/uk_bin_collection/uk_bin_collection/common.py
@@ -175,9 +175,14 @@ def remove_alpha_characters(input_string: str) -> str:
 
 def write_output_json(council: str, content: str):
     cwd = os.getcwd()
-    with open(os.path.join(cwd, "..", "tests", "outputs", council + ".json"), "w") as f:
-        f.write(content)
-
-def validate_dates(bin_dates: dict) -> dict:
-    raise NotImplementedError()
-    # If a date is in December and the next is in January, increase the year
+    outputs_path = os.path.join(cwd, "..", "tests", "outputs")
+    if not os.path.exists(outputs_path) or not os.path.isdir(outputs_path):
+        outputs_path = os.path.join(
+            cwd, "uk_bin_collection", "tests", "outputs")
+    if os.path.exists(outputs_path) and os.path.isdir(outputs_path):
+        with open(os.path.join(outputs_path, council + ".json"), "w") as f:
+            f.write(content)
+    else:
+        print("Exception encountered: Unable to save Output JSON file for the council.")
+        print("Please check you're running developer mode from either the UKBinCollectionData "
+              "or uk_bin_collection/uk_bin_collection/ directories.")

--- a/uk_bin_collection/uk_bin_collection/common.py
+++ b/uk_bin_collection/uk_bin_collection/common.py
@@ -175,5 +175,5 @@ def remove_alpha_characters(input_string: str) -> str:
 
 def write_output_json(council: str, content: str):
     cwd = os.getcwd()
-    with open(os.path.join(cwd, "uk_bin_collection", "tests", "outputs", council + ".json"), "w") as f:
+    with open(os.path.join(cwd, "..", "tests", "outputs", council + ".json"), "w") as f:
         f.write(content)


### PR DESCRIPTION
All the documentation suggest to run the script from the `uk_bin_collection/uk_bin_collection/` folder, but if you add -d (dev mode) to the script it will fail unless you run it from the `UKBinCollectionData` folder.

### Steps to reproduce

1. Go to script folder (ie `cd UKBinCollectionData/uk_bin_collection/uk_bin_collection`)
2. Run script in dev mode (ie, `python collect_data.py <council_name> "<collection_url>" -d`)

### Expected result

The output.json file is created

### Actual result

`Traceback (most recent call last):
  File "/Users/ryck/Projects/UKBinCollectionData/uk_bin_collection/uk_bin_collection/collect_data.py", line 90, in <module>
    main(sys.argv[1:])
  File "/Users/ryck/Projects/UKBinCollectionData/uk_bin_collection/uk_bin_collection/collect_data.py", line 73, in main
    return client_code(
  File "/Users/ryck/Projects/UKBinCollectionData/uk_bin_collection/uk_bin_collection/collect_data.py", line 23, in client_code
    return get_bin_data_class.template_method(address_url, **kwargs)
  File "/Users/ryck/Projects/UKBinCollectionData/uk_bin_collection/uk_bin_collection/get_bin_data.py", line 72, in template_method
    write_output_json(council_module_str, json_output)
  File "/Users/ryck/Projects/UKBinCollectionData/uk_bin_collection/uk_bin_collection/common.py", line 178, in write_output_json
    with open(
FileNotFoundError: [Errno 2] No such file or directory: '/Users/ryck/Projects/UKBinCollectionData/uk_bin_collection/uk_bin_collection/tests/outputs/MertonCouncil.json'
(uk-bin-collection-py3.10) `

Just a small nitpick, so if it does not make sense, feel free to close it :)