### PR TITLE
Wiki workflow fix to still deploy on commit/push error

### DIFF
--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -43,6 +43,7 @@ jobs:
         git add wiki
         git commit -m "Update Councils.md from input.json"
         git push
+      continue-on-error: true
 
     - name: Deploy Wiki Changes
       uses: Andrew-Chen-Wang/github-wiki-action@v3


### PR DESCRIPTION
Allow wiki updates to still be deployed on commit/push failure

Ref https://github.com/robbrad/UKBinCollectionData/issues/100#issuecomment-1452608706