### PR TITLE
Expect dev mode to be run from the script folder

### DIFF
--- a/uk_bin_collection/uk_bin_collection/common.py
+++ b/uk_bin_collection/uk_bin_collection/common.py
@@ -175,8 +175,17 @@ def remove_alpha_characters(input_string: str) -> str:
 
 def write_output_json(council: str, content: str):
     cwd = os.getcwd()
-    with open(os.path.join(cwd, "uk_bin_collection", "tests", "outputs", council + ".json"), "w") as f:
-        f.write(content)
+    outputs_path = os.path.join(cwd, "..", "tests", "outputs")
+    if not os.path.exists(outputs_path) or not os.path.isdir(outputs_path):
+        outputs_path = os.path.join(
+            cwd, "uk_bin_collection", "tests", "outputs")
+    if os.path.exists(outputs_path) and os.path.isdir(outputs_path):
+        with open(os.path.join(outputs_path, council + ".json"), "w") as f:
+            f.write(content)
+    else:
+        print("Exception encountered: Unable to save Output JSON file for the council.")
+        print("Please check you're running developer mode from either the UKBinCollectionData "
+              "or uk_bin_collection/uk_bin_collection/ directories.")
 
 def validate_dates(bin_dates: dict) -> dict:
     raise NotImplementedError()


### PR DESCRIPTION
All the documentation suggest to run the script from the uk_bin_collection/uk_bin_collection/ folder, but if you add -d (dev mode) to the script it will fail unless you run it from the UKBinCollectionData folder.

Steps to reproduce
Go to script folder (ie cd UKBinCollectionData/uk_bin_collection/uk_bin_collection)
Run script in dev mode (ie, python collect_data.py <council_name> "<collection_url>" -d)
Expected result
The output.json file is created

Actual result
Traceback (most recent call last): File "/Users/ryck/Projects/UKBinCollectionData/uk_bin_collection/uk_bin_collection/collect_data.py", line 90, in <module> main(sys.argv[1:]) File "/Users/ryck/Projects/UKBinCollectionData/uk_bin_collection/uk_bin_collection/collect_data.py", line 73, in main return client_code( File "/Users/ryck/Projects/UKBinCollectionData/uk_bin_collection/uk_bin_collection/collect_data.py", line 23, in client_code return get_bin_data_class.template_method(address_url, **kwargs) File "/Users/ryck/Projects/UKBinCollectionData/uk_bin_collection/uk_bin_collection/get_bin_data.py", line 72, in template_method write_output_json(council_module_str, json_output) File "/Users/ryck/Projects/UKBinCollectionData/uk_bin_collection/uk_bin_collection/common.py", line 178, in write_output_json with open( FileNotFoundError: [Errno 2] No such file or directory: '/Users/ryck/Projects/UKBinCollectionData/uk_bin_collection/uk_bin_collection/tests/outputs/MertonCouncil.json' (uk-bin-collection-py3.10) 

This is just a new version of a previous PR (https://github.com/robbrad/UKBinCollectionData/pull/252), now including @OliverCullimore suggestions