### PR TITLE
Added Lisburn and Castlereagh City Council

### DIFF
--- a/uk_bin_collection/tests/council_schemas/LisburnCastlereaghCityCouncil.schema
+++ b/uk_bin_collection/tests/council_schemas/LisburnCastlereaghCityCouncil.schema
@@ -1,0 +1,48 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$ref": "#/definitions/Welcome5",
+    "definitions": {
+        "Welcome5": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bins": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Bin"
+                    }
+                }
+            },
+            "required": [
+                "bins"
+            ],
+            "title": "Welcome5"
+        },
+        "Bin": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "$ref": "#/definitions/Type"
+                },
+                "collectionDate": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "collectionDate",
+                "type"
+            ],
+            "title": "Bin"
+        },
+        "Type": {
+            "type": "string",
+            "enum": [
+                "RecycleBin",
+                "BrownBin",
+                "ResidualBin"
+            ],
+            "title": "Type"
+        }
+    }
+}

--- a/uk_bin_collection/tests/features/validate_council_outputs.feature
+++ b/uk_bin_collection/tests/features/validate_council_outputs.feature
@@ -36,6 +36,7 @@ Feature: Test each council output matches expected results in /outputs
             | HuntingdonDistrictCouncil |
             | KingstonUponThamesCouncil |
             | LeedsCityCouncil |
+            | LisburnCastlereaghCityCouncil |
             | LondonBoroughHounslow |
             | MaldonDistrictCouncil |
             | MalvernHillsDC |

--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -163,6 +163,13 @@
     "url": "https://www.leeds.gov.uk/residents/bins-and-recycling/check-your-bin-day",
     "wiki_name": "Leeds City Council"
   },
+  "LisburnCastlereaghCityCouncil": {
+    "SKIP_GET_URL": "SKIP_GET_URL",
+    "house_number": "97",
+    "postcode": "BT28 1JN",
+    "url": "https://lisburn.isl-fusion.com",
+    "wiki_name": "Lisburn and Castlereagh City Council"
+  },
   "LondonBoroughHounslow": {
     "uprn": "100021577765",
     "url": "https://www.hounslow.gov.uk/homepage/86/recycling_and_waste_collection_day_finder",

--- a/uk_bin_collection/tests/outputs/LisburnCastlereaghCityCouncil.json
+++ b/uk_bin_collection/tests/outputs/LisburnCastlereaghCityCouncil.json
@@ -1,0 +1,20 @@
+{
+    "bins": [
+        {
+            "type": "ResidualBin",
+            "collectionDate": "27/04/2023"
+        },
+        {
+            "type": "RecycleBin",
+            "collectionDate": "04/05/2023"
+        },
+        {
+            "type": "BrownBin",
+            "collectionDate": "04/05/2023"
+        },
+        {
+            "type": "ResidualBin",
+            "collectionDate": "11/05/2023"
+        }
+    ]
+}

--- a/uk_bin_collection/uk_bin_collection/councils/LisburnCastlereaghCityCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/LisburnCastlereaghCityCouncil.py
@@ -1,0 +1,93 @@
+from bs4 import BeautifulSoup
+from uk_bin_collection.uk_bin_collection.common import *
+from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
+
+import requests
+import difflib
+from datetime import date, datetime
+
+
+# import the wonderful Beautiful Soup and the URL grabber
+class CouncilClass(AbstractGetBinDataClass):
+    """
+    Concrete classes have to implement all abstract operations of the
+    base class. They can also override some operations with a default
+    implementation.
+    """
+
+    base_url = "https://lisburn.isl-fusion.com"
+
+    def parse_data(self, page: str, **kwargs) -> dict:
+        """
+        This function will make a request to the search endpoint with the postcode, extract the
+        house numbers from the responses, then retrieve the ID of the entry with the house number that matches,
+        to then retrieve the bin schedule.
+
+        The API here is a weird combination of HTML in json responses.
+        """
+        postcode = kwargs.get("postcode")
+        paon = kwargs.get("paon")
+
+        if not postcode: 
+            raise ValueError("Must provide a postcode") 
+
+        if not paon:
+            raise ValueError("Must provide a house number")
+
+        search_url = f"{self.base_url}/address/{postcode}"
+
+        s = requests.Session()
+        response = s.get(search_url)
+        response.raise_for_status()
+
+        address_data = response.json()
+
+        address_list = address_data['html']
+
+        soup = BeautifulSoup(address_list, features="html.parser")
+
+        address_by_id = {}
+
+        for li in soup.findAll("li"):
+            link = li.findAll("a")[0]
+            address_id = link.attrs["href"]
+            address = link.text
+
+            address_by_id[address_id] = address
+
+        addresses = list(address_by_id.values())
+
+        common = difflib.SequenceMatcher(a=addresses[0], b=addresses[1]).find_longest_match()
+        extra_bit = addresses[0][common.a:common.a+common.size]
+
+        ids_by_paon = {
+            a.replace(extra_bit, ""): a_id.replace("/view/", "").replace("/", "") for a_id, a in address_by_id.items()
+        }
+
+        property_id = ids_by_paon.get(paon)
+        if not property_id:
+            raise ValueError(f"Invalid house number, valid values are {', '.join(ids_by_paon.keys())}")
+
+        today = date.today()
+        calendar_url = f"{self.base_url}/calendar/{property_id}/{today.strftime('%Y-%m-%d')}"
+        response = s.get(calendar_url)
+        response.raise_for_status()
+        calendar_data = response.json()
+        next_collections = calendar_data["nextCollections"]
+
+        collections = list(next_collections["collections"].values())
+
+        data = {"bins": []}
+
+        for collection in collections:
+            collection_date = datetime.strptime(collection["date"], "%Y-%m-%d")
+            bins = [c["name"] for c in collection["collections"].values()]
+
+            for bin in bins:
+                data["bins"].append(
+                    {
+                        "type": bin,
+                        "collectionDate": collection_date.strftime(date_format)
+                    }
+                )
+        return data


### PR DESCRIPTION
I've added a class to retrieve data for the Lisburn and Castlereagh City Council.

A bit of a weird API, but the interactive flow can be seen by going to https://lisburn.isl-fusion.com/ and entering a postcode, eg. BT26 6LR, and then selecting an address, eg. 32 Ballyworfy Rd.

This class basically replicates that flow, using requests and some parsing of the results. The API seems to return it's payloads as `application/json`, but it includes a `html` key in the JSON object, which I had to parse to match up with a house number. I use that house number of retrieve a unique identifier for an address, which can then be used to look up the bin schedule. The response for the bin schedule includes a `nextCollections` item in the JSON response, so I use that to get the next three weeks of bin collections.