### PR TITLE
Add support for Woking Borough Council

### DIFF
--- a/uk_bin_collection/tests/council_schemas/WokingBoroughCouncil.schema
+++ b/uk_bin_collection/tests/council_schemas/WokingBoroughCouncil.schema
@@ -1,0 +1,39 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$ref": "#/definitions/Welcome2",
+    "definitions": {
+        "Welcome2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bins": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Bin"
+                    }
+                }
+            },
+            "required": [
+                "bins"
+            ],
+            "title": "Welcome2"
+        },
+        "Bin": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "type": "string"
+                },
+                "collectionDate": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "collectionDate",
+                "type"
+            ],
+            "title": "Bin"
+        }
+    }
+}

--- a/uk_bin_collection/tests/features/validate_council_outputs.feature
+++ b/uk_bin_collection/tests/features/validate_council_outputs.feature
@@ -78,4 +78,5 @@ Feature: Test each council output matches expected results in /outputs
             | WelhatCouncil |
             | WiganBoroughCouncil |
             | WindsorAndMaidenheadCouncil |
+            | WokingBoroughCouncil |
             | YorkCouncil |

--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -408,6 +408,13 @@
     "url": "https://my.rbwm.gov.uk/special/find-your-collection-dates",
     "wiki_name": "Windsor and Maidenhead Council"
   },
+  "WokingBoroughCouncil": {
+    "url": "https://asjwsw-wrpwokingmunicipal-live.whitespacews.com/",
+    "wiki_name": "Woking Borough Council/Joint Waste Solutions",
+    "wiki_note": "Works with all collection areas that use Joint Waste Solutions. Just use the correct URL.",
+    "house_number": "2",
+    "postcode": "GU214JY"
+  },
   "YorkCouncil": {
     "uprn": "100050535540",
     "url": "https://waste-api.york.gov.uk/api/Collections/GetBinCollectionDataForUprn/",

--- a/uk_bin_collection/tests/outputs/WokingBoroughCouncil.json
+++ b/uk_bin_collection/tests/outputs/WokingBoroughCouncil.json
@@ -1,0 +1,64 @@
+{
+    "bins": [
+        {
+            "type": "Recycling",
+            "collectionDate": "17/05/2023"
+        },
+        {
+            "type": "Food waste",
+            "collectionDate": "17/05/2023"
+        },
+        {
+            "type": "Batteries/small electricals/textiles",
+            "collectionDate": "17/05/2023"
+        },
+        {
+            "type": "Rubbish",
+            "collectionDate": "24/05/2023"
+        },
+        {
+            "type": "Food waste",
+            "collectionDate": "24/05/2023"
+        },
+        {
+            "type": "Batteries/small electricals/textiles",
+            "collectionDate": "24/05/2023"
+        },
+        {
+            "type": "Recycling",
+            "collectionDate": "31/05/2023"
+        },
+        {
+            "type": "Food waste",
+            "collectionDate": "31/05/2023"
+        },
+        {
+            "type": "Batteries/small electricals/textiles",
+            "collectionDate": "31/05/2023"
+        },
+        {
+            "type": "Rubbish",
+            "collectionDate": "07/06/2023"
+        },
+        {
+            "type": "Food waste",
+            "collectionDate": "07/06/2023"
+        },
+        {
+            "type": "Batteries/small electricals/textiles",
+            "collectionDate": "07/06/2023"
+        },
+        {
+            "type": "Recycling",
+            "collectionDate": "14/06/2023"
+        },
+        {
+            "type": "Food waste",
+            "collectionDate": "14/06/2023"
+        },
+        {
+            "type": "Batteries/small electricals/textiles",
+            "collectionDate": "14/06/2023"
+        }
+    ]
+}

--- a/uk_bin_collection/uk_bin_collection/councils/WokingBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/WokingBoroughCouncil.py
@@ -1,0 +1,98 @@
+from bs4 import BeautifulSoup
+import urllib
+from uk_bin_collection.uk_bin_collection.common import *
+from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
+
+
+class CouncilClass(AbstractGetBinDataClass):
+    """
+    Concrete classes have to implement all abstract operations of the
+    base class. They can also override some operations with a default
+    implementation.
+    """
+
+    def parse_data(self, page: str, **kwargs) -> dict:
+        # Get the house number and postcode from the commandline
+        user_paon = kwargs.get("paon")
+        user_postcode = kwargs.get("postcode")
+        check_postcode(user_postcode)
+        root_url = kwargs.get("url")
+
+        # Start a new session for the form, and get the chosen URL from the commandline
+        session = requests.Session()
+        req = session.get(root_url)
+
+        # Parse the requested URL to get a link to the "View My Collections" portal with a unique service ID
+        start = BeautifulSoup(req.text, features="html.parser")
+        start.prettify()
+        base_link = start.select(
+            "#menu-content > div > div:nth-child(1) > p.govuk-body.govuk-\!-margin-bottom-0.colorblue.lineheight15 > a")[
+            0].attrs.get("href")
+
+        # We need to reorder the query parts from the unique URL, so split them up to make it easier
+        query_parts = urllib.parse.urlparse(base_link).query.split("&")
+        parts = base_link.split("?")
+        addr_link = parts[0] + "/mop.php?" + query_parts[1] + "&" + query_parts[0] + "&seq=2"
+
+        # Bring in some headers to emulate a browser, and put the UPRN and postcode into the form data.
+        # This is sent in a POST request, emulating browser behaviour.
+        headers = {
+            'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7',
+            'Accept-Language': 'en-GB,en;q=0.9',
+            'Cache-Control': 'no-cache',
+            'Connection': 'keep-alive',
+            'Content-Type': 'application/x-www-form-urlencoded',
+            'Origin': 'https://asjwsw-wrpwokingmunicipal-live.whitespacews.com',
+            'Pragma': 'no-cache',
+            'Referer': 'https://asjwsw-wrpwokingmunicipal-live.whitespacews.com/',
+            'Sec-Fetch-Dest': 'document',
+            'Sec-Fetch-Mode': 'navigate',
+            'Sec-Fetch-Site': 'same-origin',
+            'Sec-Fetch-User': '?1',
+            'Upgrade-Insecure-Requests': '1',
+            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36 OPR/98.0.0.0',
+            'sec-ch-ua': '"Chromium";v="112", "Not_A Brand";v="24", "Opera GX";v="98"',
+            'sec-ch-ua-mobile': '?0',
+            'sec-ch-ua-platform': '"Windows"',
+        }
+        data = {
+            'address_name_number': user_paon,
+            'address_street': '',
+            'street_town': '',
+            'address_postcode': user_postcode,
+        }
+        addr_page = session.post(addr_link, headers=headers, data=data)
+        addr = BeautifulSoup(addr_page.text, features="html.parser")
+        addr.prettify()
+
+        # This page should only have one address, but regardless, select the first one and make a request to load the
+        # calendar page.
+        cal_link = root_url + addr.select("#property_list > ul > li > a")[0].attrs.get("href")
+        cal_page = session.get(cal_link)
+
+        # Parse the calendar page
+        soup = BeautifulSoup(cal_page.text, features="html.parser")
+        soup.prettify()
+        data = {"bins": []}
+
+        # For whatever reason, each row contains all the information for that row, and each one after it. This code
+        # essentially gets all items from each row, but ignores the whitespace that you get when splitting using \n.
+        # This produces a big list of dates then bin types, so we split them up into a list of lists - each pair is
+        # a date and the bin type.
+        items = [i for i in soup.find("u1", {"class": "displayinlineblock justifycontentleft alignitemscenter margin0 padding0"}).text.split("\n") if i != ""]
+        pairs = [items[i:i+2] for i in range(0, len(items), 2)]
+
+        # Loop through the paired bin dates and types
+        for pair in pairs:
+            # This isn't necessary, but better safe than sorry
+            collection_date = datetime.strptime(pair[0], date_format).strftime(date_format)
+            # Change the formatting of the purple bins to replace the hyphens with slashes
+            if pair[1] == "Batteries-small electricals-textiles":
+                bin_type = pair[1].replace("-", "/").strip()
+            else:
+                bin_type = pair[1]
+
+            # Add the data into the dictionary
+            data["bins"].append({"type": bin_type, "collectionDate": collection_date})
+
+        return data

--- a/uk_bin_collection/uk_bin_collection/get_bin_data.py
+++ b/uk_bin_collection/uk_bin_collection/get_bin_data.py
@@ -47,6 +47,7 @@ class AbstractGetBinDataClass(ABC):
         Keyword arguments:
         address_url -- the url to get the data from
         """
+        this_url = address_url
         this_postcode = kwargs.get("postcode", None)
         this_paon = kwargs.get("paon", None)
         this_uprn = kwargs.get("uprn", None)
@@ -58,7 +59,7 @@ class AbstractGetBinDataClass(ABC):
         ):  # we will not use the generic way to get data - needs a get data in the council class itself
             page = self.get_data(address_url)
             bin_data_dict = self.parse_data(
-                page, postcode=this_postcode, paon=this_paon, uprn=this_uprn
+                page, postcode=this_postcode, paon=this_paon, uprn=this_uprn, url=this_url
             )
             json_output = self.output_json(bin_data_dict)
         else:

--- a/wiki/Councils.md
+++ b/wiki/Councils.md
@@ -38,6 +38,7 @@ This document is still a work in progress, don't worry if your council isn't lis
 - [Huntingdon District Council](#huntingdon-district-council)
 - [Kingston Upon Thames Council](#kingston-upon-thames-council)
 - [Leeds City Council](#leeds-city-council)
+- [Lisburn and Castlereagh City Council](#lisburn-and-castlereagh-city-council)
 - [London Borough Hounslow](#london-borough-hounslow)
 - [Maldon District Council](#maldon-district-council)
 - [Malvern Hills District Council](#malvern-hills-district-council)
@@ -354,6 +355,17 @@ Note: Follow the instructions [here](https://waste-services.kingston.gov.uk/wast
 python collect_data.py LeedsCityCouncil https://www.leeds.gov.uk/residents/bins-and-recycling/check-your-bin-day -p "XXXX XXX" -n XX
 ```
 Additional parameters:
+- `-p` - postcode
+- `-n` - house number
+
+---
+
+### Lisburn and Castlereagh City Council
+```commandline
+python collect_data.py LisburnCastlereaghCityCouncil https://lisburn.isl-fusion.com -s -p "XXXX XXX" -n XX
+```
+Additional parameters:
+- `-s` - skip get URL
 - `-p` - postcode
 - `-n` - house number
 

--- a/wiki/Councils.md
+++ b/wiki/Councils.md
@@ -41,7 +41,9 @@ This document is still a work in progress, don't worry if your council isn't lis
 - [Maldon District Council](#maldon-district-council)
 - [Malvern Hills District Council](#malvern-hills-district-council)
 - [Manchester City Council](#manchester-city-council)
+- [Merton Council](#merton-council)
 - [Mid Sussex District Council](#mid-sussex-district-council)
+- [Milton Keynes City Council](#milton-keynes-city-council)
 - [Newark and Sherwood District Council](#newark-and-sherwood-district-council)
 - [Newcastle City Council](#newcastle-city-council)
 - [North East Lincolnshire Council](#north-east-lincolnshire-council)
@@ -70,6 +72,7 @@ This document is still a work in progress, don't worry if your council isn't lis
 - [Warwick District Council](#warwick-district-council)
 - [Waverley Borough Council](#waverley-borough-council)
 - [Wealden District Council](#wealden-district-council)
+- [Welhat Council](#welhat-council)
 - [Wigan Borough Council](#wigan-borough-council)
 - [Windsor and Maidenhead Council](#windsor-and-maidenhead-council)
 - [York Council](#york-council)
@@ -383,6 +386,15 @@ Additional parameters:
 
 ---
 
+### Merton Council
+```commandline
+python collect_data.py MertonCouncil https://myneighbourhood.merton.gov.uk/Wasteservices/WasteServices.aspx?ID=XXXXXXXX
+```
+
+Note: Follow the instructions [here](https://myneighbourhood.merton.gov.uk/Wasteservices/WasteServicesSearch.aspx) until you get the "Your recycling and rubbish collection days" page then copy the URL and replace the URL in the command (the Address parameter is optional).
+
+---
+
 ### Mid Sussex District Council
 ```commandline
 python collect_data.py MidSussexDistrictCouncil https://www.midsussex.gov.uk/waste-recycling/bin-collection/ -p "XXXX XXX" -n XX
@@ -392,6 +404,17 @@ Additional parameters:
 - `-n` - house number
 
 Note: Pass the name of the street with the house number parameter, wrapped in double quotes
+
+---
+
+### Milton Keynes City Council
+```commandline
+python collect_data.py MiltonKeynesCityCouncil https://www.milton-keynes.gov.uk/waste-and-recycling/collection-days -u XXXXXXXX
+```
+Additional parameters:
+- `-u` - UPRN
+
+Note: Pass the name of the estate with the UPRN parameter, wrapped in double quotes
 
 ---
 
@@ -660,6 +683,16 @@ python collect_data.py WealdenDistrictCouncil https://www.wealden.gov.uk/recycli
 ```
 Additional parameters:
 - `-u` - UPRN
+
+---
+
+### Welhat Council
+```commandline
+python collect_data.py WelhatCouncil https://www.welhat.gov.uk/xfp/form/214 -u XXXXXXXX -p "XXXX XXX"
+```
+Additional parameters:
+- `-u` - UPRN
+- `-p` - postcode
 
 ---
 

--- a/wiki/Councils.md
+++ b/wiki/Councils.md
@@ -28,6 +28,7 @@ This document is still a work in progress, don't worry if your council isn't lis
 - [Durham Council](#durham-council)
 - [East Cambridgeshire Council](#east-cambridgeshire-council)
 - [East Devon District Council](#east-devon-district-council)
+- [Eastleigh Borough Council](#eastleigh-borough-council)
 - [East Northamptonshire Council](#east-northamptonshire-council)
 - [East Riding Council](#east-riding-council)
 - [Erewash Borough Council](#erewash-borough-council)
@@ -52,17 +53,20 @@ This document is still a work in progress, don't worry if your council isn't lis
 - [North Lincolnshire Council](#north-lincolnshire-council)
 - [North Somerset Council](#north-somerset-council)
 - [North Tyneside Council](#north-tyneside-council)
+- [Northumberland Council](#northumberland-council)
 - [Rochdale Council](#rochdale-council)
 - [Salford City Council](#salford-city-council)
 - [Sheffield City Council](#sheffield-city-council)
 - [Somerset Council](#somerset-council)
 - [South Ayrshire Council](#south-ayrshire-council)
+- [South Cambridgeshire Council](#south-cambridgeshire-council)
 - [South Lanarkshire Council](#south-lanarkshire-council)
 - [South Norfolk Council](#south-norfolk-council)
 - [South Oxfordshire Council](#south-oxfordshire-council)
 - [South Tyneside Council](#south-tyneside-council)
 - [St Helens Borough Council](#st-helens-borough-council)
 - [Stockport Borough Council](#stockport-borough-council)
+- [Swale Borough Council](#swale-borough-council)
 - [Tameside Metropolitan Borough Council](#tameside-metropolitan-borough-council)
 - [Tonbridge and Malling Borough Council](#tonbridge-and-malling-borough-council)
 - [Torbay Council](#torbay-council)
@@ -133,10 +137,8 @@ Additional parameters:
 
 ### Bromley Borough Council
 ```commandline
-python collect_data.py BromleyBoroughCouncil https://recyclingservices.bromley.gov.uk/waste/XXXXXXX -u XXXXXXXX
+python collect_data.py BromleyBoroughCouncil https://recyclingservices.bromley.gov.uk/waste/XXXXXXX
 ```
-Additional parameters:
-- `-u` - UPRN
 
 Note: Follow the instructions [here](https://recyclingservices.bromley.gov.uk/waste) until the "Your bin days" page then copy the URL and replace the URL in the command.
 
@@ -172,12 +174,10 @@ Note: Replace XXXXXXXX with UPRN keeping "cbc" before it.
 
 ### Chelmsford City Council
 ```commandline
-python collect_data.py ChelmsfordCityCouncil https://mychelmsford.secure.force.com/WasteServices/WM_WasteViewProperty?id=XXXXXXXX -u XXXXXXXX
+python collect_data.py ChelmsfordCityCouncil https://www.chelmsford.gov.uk/myhome/XXXXXX
 ```
-Additional parameters:
-- `-u` - UPRN
 
-Note: Replace XXXXXXXX with UPRN.
+Note: Follow the instructions [here](https://www.chelmsford.gov.uk/myhome/) until you get the page listing your "Address", "Ward" etc then copy the URL and replace the URL in the command.
 
 ---
 
@@ -261,6 +261,15 @@ python collect_data.py EastDevonDC https://eastdevon.gov.uk/recycling-and-waste/
 ```
 
 Note: Replace XXXXXXXX with UPRN.
+
+---
+
+### Eastleigh Borough Council
+```commandline
+python collect_data.py EastleighBoroughCouncil https://www.eastleigh.gov.uk/waste-bins-and-recycling/collection-dates/your-waste-bin-and-recycling-collections?uprn= -u XXXXXXXX
+```
+Additional parameters:
+- `-u` - UPRN
 
 ---
 
@@ -494,6 +503,16 @@ Additional parameters:
 
 ---
 
+### Northumberland Council
+```commandline
+python collect_data.py NorthumberlandCouncil https://www.northumberland.gov.uk/Waste/Bins/Bin-Calendars.aspx -p "XXXX XXX" -n XX
+```
+Additional parameters:
+- `-p` - postcode
+- `-n` - house number
+
+---
+
 ### Rochdale Council
 ```commandline
 python collect_data.py RochdaleCouncil https://webforms.rochdale.gov.uk/BinCalendar -u XXXXXXXX -p "XXXX XXX"
@@ -539,6 +558,16 @@ python collect_data.py SouthAyrshireCouncil https://www.south-ayrshire.gov.uk/ -
 Additional parameters:
 - `-u` - UPRN
 - `-p` - postcode
+
+---
+
+### South Cambridgeshire Council
+```commandline
+python collect_data.py SouthCambridgeshireCouncil https://www.scambs.gov.uk/recycling-and-bins/find-your-household-bin-collection-day/ -p "XXXX XXX" -n XX
+```
+Additional parameters:
+- `-p` - postcode
+- `-n` - house number
 
 ---
 
@@ -594,6 +623,16 @@ python collect_data.py StockportBoroughCouncil https://myaccount.stockport.gov.u
 ```
 
 Note: Replace XXXXXXXX with UPRN.
+
+---
+
+### Swale Borough Council
+```commandline
+python collect_data.py SwaleBoroughCouncil https://swale.gov.uk/bins-littering-and-the-environment/bins/collection-days -u XXXXXXXX -p "XXXX XXX"
+```
+Additional parameters:
+- `-u` - UPRN
+- `-p` - postcode
 
 ---
 


### PR DESCRIPTION
Closes #263. Listed as support for Woking, but it should work for any council with waste management provided by Joint Waste Solutions as explained in the original request.

Also adds a change to pass the URL through to the scraper class (used here).