### PR TITLE
Add garden waste collection dates for Basingstoke Council

### DIFF
--- a/uk_bin_collection/tests/council_schemas/BasingstokeCouncil.schema
+++ b/uk_bin_collection/tests/council_schemas/BasingstokeCouncil.schema
@@ -41,7 +41,8 @@
             "enum": [
                 "waste",
                 "recycling",
-                "glass"
+                "glass",
+                "garden"
             ],
             "title": "Type"
         }

--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -1,6 +1,6 @@
 {
   "BasingstokeCouncil": {
-    "uprn": "100060220922",
+    "uprn": "100060220926",
     "url": "https://www.basingstoke.gov.uk/bincollection",
     "wiki_name": "Basingstoke Council"
   },

--- a/uk_bin_collection/tests/outputs/BasingstokeCouncil.json
+++ b/uk_bin_collection/tests/outputs/BasingstokeCouncil.json
@@ -2,22 +2,6 @@
     "bins": [
         {
             "type": "waste",
-            "collectionDate": "07/06/2023"
-        },
-        {
-            "type": "waste",
-            "collectionDate": "14/06/2023"
-        },
-        {
-            "type": "waste",
-            "collectionDate": "21/06/2023"
-        },
-        {
-            "type": "waste",
-            "collectionDate": "28/06/2023"
-        },
-        {
-            "type": "waste",
             "collectionDate": "05/07/2023"
         },
         {
@@ -25,12 +9,20 @@
             "collectionDate": "12/07/2023"
         },
         {
-            "type": "recycling",
-            "collectionDate": "07/06/2023"
+            "type": "waste",
+            "collectionDate": "19/07/2023"
         },
         {
-            "type": "recycling",
-            "collectionDate": "21/06/2023"
+            "type": "waste",
+            "collectionDate": "26/07/2023"
+        },
+        {
+            "type": "waste",
+            "collectionDate": "02/08/2023"
+        },
+        {
+            "type": "waste",
+            "collectionDate": "09/08/2023"
         },
         {
             "type": "recycling",
@@ -49,12 +41,12 @@
             "collectionDate": "16/08/2023"
         },
         {
-            "type": "glass",
-            "collectionDate": "07/06/2023"
+            "type": "recycling",
+            "collectionDate": "30/08/2023"
         },
         {
-            "type": "glass",
-            "collectionDate": "21/06/2023"
+            "type": "recycling",
+            "collectionDate": "13/09/2023"
         },
         {
             "type": "glass",
@@ -71,6 +63,38 @@
         {
             "type": "glass",
             "collectionDate": "16/08/2023"
+        },
+        {
+            "type": "glass",
+            "collectionDate": "30/08/2023"
+        },
+        {
+            "type": "glass",
+            "collectionDate": "13/09/2023"
+        },
+        {
+            "type": "garden",
+            "collectionDate": "12/07/2023"
+        },
+        {
+            "type": "garden",
+            "collectionDate": "26/07/2023"
+        },
+        {
+            "type": "garden",
+            "collectionDate": "09/08/2023"
+        },
+        {
+            "type": "garden",
+            "collectionDate": "23/08/2023"
+        },
+        {
+            "type": "garden",
+            "collectionDate": "06/09/2023"
+        },
+        {
+            "type": "garden",
+            "collectionDate": "20/09/2023"
         }
     ]
 }

--- a/uk_bin_collection/uk_bin_collection/councils/BasingstokeCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/BasingstokeCouncil.py
@@ -8,7 +8,9 @@ from uk_bin_collection.uk_bin_collection.get_bin_data import \
 COLLECTION_KINDS = {
     "waste": "rteelem_ctl03_pnlCollections_Refuse",
     "recycling": "rteelem_ctl03_pnlCollections_Recycling",
-    "glass": "rteelem_ctl03_pnlCollections_Glass"
+    "glass": "rteelem_ctl03_pnlCollections_Glass",
+    # Garden waste data is only return is the property is subscribed to Garden Waste service
+    "garden": "rteelem_ctl03_pnlCollections_GardenWaste"
 }
 
 class CouncilClass(AbstractGetBinDataClass):

--- a/uk_bin_collection/uk_bin_collection/councils/BasingstokeCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/BasingstokeCouncil.py
@@ -9,7 +9,7 @@ COLLECTION_KINDS = {
     "waste": "rteelem_ctl03_pnlCollections_Refuse",
     "recycling": "rteelem_ctl03_pnlCollections_Recycling",
     "glass": "rteelem_ctl03_pnlCollections_Glass",
-    # Garden waste data is only return is the property is subscribed to Garden Waste service
+    # Garden waste data is only returned if the property is subscribed to the Garden Waste service
     "garden": "rteelem_ctl03_pnlCollections_GardenWaste"
 }
 


### PR DESCRIPTION
If a property in Basingstoke is subscribed to the Garden Waste Collection service, the bin collection date page additionally shows the dates for the Garden service. This change allows those to be collected (without breaking it for properties that aren't subscribed).