### PR TITLE
Add release action to build and publish to PyPi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,42 @@
+name: Build and publish package to PyPi
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: release
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+
+      - name: Run image
+        uses: abatilo/actions-poetry@v2.3.0
+        with:
+          poetry-version: '1.3.1'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install wheel twine
+
+      - name: Install
+        run: make install
+
+      - name: Extract tag name
+        id: tag
+        run: echo ::set-output name=TAG_NAME::$(echo $GITHUB_REF | cut -d / -f 3)
+
+      - name: Update version in pyproject.toml
+        run: |
+          sed -i "s/version = "0.1.0"/version = "${{ steps.tag.outputs.TAG_NAME }}"/g" pyproject.toml
+
+      - name: Build and publish package
+        run: |
+          poetry config pypi-token.pypi "${{ secrets.PYPI_API_KEY }}"
+          poetry publish --build


### PR DESCRIPTION
Closes #56 (if all goes well)

@robbrad This will need you to set up a PyPi account if you don't already have one and then I believe to set up another environment with the PYPI_API_KEY secret added containing the secret from your account.

The action will only run on tag creation at present so we'll be controlling when new releases happen manually.

It should replace `version = "0.1.0"` in `pyproject.toml` with the tag version that's being released automatically, not sure if this is the best practice as the repo's `pyproject.toml` will remain as 0.10 always unless we automate that changing/commit upping that as part of creating a new tag.

Let me know if there's any issues with the action/any of this.