### PR TITLE
Move JSON printing to main function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "uk_bin_collection"
-version = "0.7.0"
+version = "0.8.0"
 description = "Python Lib to collect UK Bin Data"
 readme = "README.md"
 authors = ["Robert Bradley <robbrad182@gmail.com>"]

--- a/uk_bin_collection/uk_bin_collection/collect_data.py
+++ b/uk_bin_collection/uk_bin_collection/collect_data.py
@@ -85,4 +85,5 @@ if __name__ == "__main__":
 
     app = UKBinCollectionApp()
     app.set_args(sys.argv[1:])
-    app.run()
+    data = app.run()
+    print(data)

--- a/uk_bin_collection/uk_bin_collection/get_bin_data.py
+++ b/uk_bin_collection/uk_bin_collection/get_bin_data.py
@@ -131,5 +131,4 @@ class AbstractGetBinDataClass(ABC):
         json_data = json.dumps(bin_data_dict, sort_keys=False, indent=4)
 
         # Output the data
-        print(json_data)
         return json_data


### PR DESCRIPTION
Prevent JSON output being printed as well as being returned when calling the library