### PR TITLE
Add support for Aylesbury Vale Council

### DIFF
--- a/uk_bin_collection/tests/council_schemas/AylesburyValeCouncil.schema
+++ b/uk_bin_collection/tests/council_schemas/AylesburyValeCouncil.schema
@@ -1,148 +1,49 @@
 {
     "$schema": "http://json-schema.org/draft-06/schema#",
-    "$ref": "#/definitions/Welcome2",
+    "$ref": "#/definitions/Welcome4",
     "definitions": {
-        "Welcome2": {
+        "Welcome4": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "Envelope": {
-                    "$ref": "#/definitions/Envelope"
-                }
-            },
-            "required": [
-                "Envelope"
-            ],
-            "title": "Welcome2"
-        },
-        "Envelope": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "Body": {
-                    "$ref": "#/definitions/Body"
-                },
-                "_xmlns:soap": {
-                    "type": "string",
-                    "format": "uri",
-                    "qt-uri-protocols": [
-                        "http"
-                    ]
-                },
-                "_xmlns:xsi": {
-                    "type": "string",
-                    "format": "uri",
-                    "qt-uri-protocols": [
-                        "http"
-                    ]
-                },
-                "_xmlns:xsd": {
-                    "type": "string",
-                    "format": "uri",
-                    "qt-uri-protocols": [
-                        "http"
-                    ]
-                },
-                "__prefix": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "Body",
-                "__prefix",
-                "_xmlns:soap",
-                "_xmlns:xsd",
-                "_xmlns:xsi"
-            ],
-            "title": "Envelope"
-        },
-        "Body": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "GetCollectionsResponse": {
-                    "$ref": "#/definitions/GetCollectionsResponse"
-                },
-                "__prefix": {
-                    "type": "string"
-                }
-            },
-            "required": [
-                "GetCollectionsResponse",
-                "__prefix"
-            ],
-            "title": "Body"
-        },
-        "GetCollectionsResponse": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "GetCollectionsResult": {
-                    "$ref": "#/definitions/GetCollectionsResult"
-                },
-                "_xmlns": {
-                    "type": "string",
-                    "format": "uri",
-                    "qt-uri-protocols": [
-                        "http"
-                    ]
-                }
-            },
-            "required": [
-                "GetCollectionsResult",
-                "_xmlns"
-            ],
-            "title": "GetCollectionsResponse"
-        },
-        "GetCollectionsResult": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-                "BinCollection": {
+                "bins": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/BinCollection"
+                        "$ref": "#/definitions/Bin"
                     }
                 }
             },
             "required": [
-                "BinCollection"
+                "bins"
             ],
-            "title": "GetCollectionsResult"
+            "title": "Welcome4"
         },
-        "BinCollection": {
+        "Bin": {
             "type": "object",
             "additionalProperties": false,
             "properties": {
-                "Date": {
-                    "type": "string",
-                    "format": "date-time"
+                "type": {
+                    "$ref": "#/definitions/Type"
                 },
-                "Refuse": {
-                    "type": "string",
-                    "format": "boolean"
-                },
-                "Garden": {
-                    "type": "string",
-                    "format": "boolean"
-                },
-                "Recycling": {
-                    "type": "string",
-                    "format": "boolean"
-                },
-                "Food": {
-                    "type": "string",
-                    "format": "boolean"
+                "collectionDate": {
+                    "type": "string"
                 }
             },
             "required": [
-                "Date",
-                "Food",
-                "Garden",
+                "collectionDate",
+                "type"
+            ],
+            "title": "Bin"
+        },
+        "Type": {
+            "type": "string",
+            "enum": [
                 "Recycling",
+                "Garden",
+                "Food",
                 "Refuse"
             ],
-            "title": "BinCollection"
+            "title": "Type"
         }
     }
 }

--- a/uk_bin_collection/tests/council_schemas/AylesburyValeCouncil.schema
+++ b/uk_bin_collection/tests/council_schemas/AylesburyValeCouncil.schema
@@ -1,0 +1,148 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$ref": "#/definitions/Welcome2",
+    "definitions": {
+        "Welcome2": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "Envelope": {
+                    "$ref": "#/definitions/Envelope"
+                }
+            },
+            "required": [
+                "Envelope"
+            ],
+            "title": "Welcome2"
+        },
+        "Envelope": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "Body": {
+                    "$ref": "#/definitions/Body"
+                },
+                "_xmlns:soap": {
+                    "type": "string",
+                    "format": "uri",
+                    "qt-uri-protocols": [
+                        "http"
+                    ]
+                },
+                "_xmlns:xsi": {
+                    "type": "string",
+                    "format": "uri",
+                    "qt-uri-protocols": [
+                        "http"
+                    ]
+                },
+                "_xmlns:xsd": {
+                    "type": "string",
+                    "format": "uri",
+                    "qt-uri-protocols": [
+                        "http"
+                    ]
+                },
+                "__prefix": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "Body",
+                "__prefix",
+                "_xmlns:soap",
+                "_xmlns:xsd",
+                "_xmlns:xsi"
+            ],
+            "title": "Envelope"
+        },
+        "Body": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "GetCollectionsResponse": {
+                    "$ref": "#/definitions/GetCollectionsResponse"
+                },
+                "__prefix": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "GetCollectionsResponse",
+                "__prefix"
+            ],
+            "title": "Body"
+        },
+        "GetCollectionsResponse": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "GetCollectionsResult": {
+                    "$ref": "#/definitions/GetCollectionsResult"
+                },
+                "_xmlns": {
+                    "type": "string",
+                    "format": "uri",
+                    "qt-uri-protocols": [
+                        "http"
+                    ]
+                }
+            },
+            "required": [
+                "GetCollectionsResult",
+                "_xmlns"
+            ],
+            "title": "GetCollectionsResponse"
+        },
+        "GetCollectionsResult": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "BinCollection": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/BinCollection"
+                    }
+                }
+            },
+            "required": [
+                "BinCollection"
+            ],
+            "title": "GetCollectionsResult"
+        },
+        "BinCollection": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "Date": {
+                    "type": "string",
+                    "format": "date-time"
+                },
+                "Refuse": {
+                    "type": "string",
+                    "format": "boolean"
+                },
+                "Garden": {
+                    "type": "string",
+                    "format": "boolean"
+                },
+                "Recycling": {
+                    "type": "string",
+                    "format": "boolean"
+                },
+                "Food": {
+                    "type": "string",
+                    "format": "boolean"
+                }
+            },
+            "required": [
+                "Date",
+                "Food",
+                "Garden",
+                "Recycling",
+                "Refuse"
+            ],
+            "title": "BinCollection"
+        }
+    }
+}

--- a/uk_bin_collection/tests/features/validate_council_outputs.feature
+++ b/uk_bin_collection/tests/features/validate_council_outputs.feature
@@ -8,6 +8,7 @@ Feature: Test each council output matches expected results in /outputs
 
         Examples: Testing : <council>
             | council |
+            | AylesburyValueCouncil |
             | BasingstokeCouncil |
             | BCPCouncil |
             | BexleyCouncil |

--- a/uk_bin_collection/tests/features/validate_council_outputs.feature
+++ b/uk_bin_collection/tests/features/validate_council_outputs.feature
@@ -8,7 +8,7 @@ Feature: Test each council output matches expected results in /outputs
 
         Examples: Testing : <council>
             | council |
-            | AylesburyValueCouncil |
+            | AylesburyValeCouncil |
             | BasingstokeCouncil |
             | BCPCouncil |
             | BexleyCouncil |

--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -1,4 +1,11 @@
 {
+  "AylesburyValeCouncil": {
+    "SKIP_GET_URL": "SKIP_GET_URL",
+    "uprn": "766252532",
+    "url": "http://avdcbins.web-labs.co.uk/RefuseApi.asmx",
+    "wiki_name": "Aylesbury Vale Council (Buckinghamshire)",
+    "wiki_note": "To get the UPRN, you will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN."
+  },
   "BasingstokeCouncil": {
     "SKIP_GET_URL": "SKIP_GET_URL",
     "uprn": "100060220926",

--- a/uk_bin_collection/tests/outputs/AylesburyValeCouncil.json
+++ b/uk_bin_collection/tests/outputs/AylesburyValeCouncil.json
@@ -1,0 +1,124 @@
+{
+    "bins": [
+        {
+            "type": "Recycling",
+            "collectionDate": "14/08/2023"
+        },
+        {
+            "type": "Garden",
+            "collectionDate": "14/08/2023"
+        },
+        {
+            "type": "Food",
+            "collectionDate": "14/08/2023"
+        },
+        {
+            "type": "Refuse",
+            "collectionDate": "21/08/2023"
+        },
+        {
+            "type": "Food",
+            "collectionDate": "21/08/2023"
+        },
+        {
+            "type": "Recycling",
+            "collectionDate": "29/08/2023"
+        },
+        {
+            "type": "Garden",
+            "collectionDate": "29/08/2023"
+        },
+        {
+            "type": "Food",
+            "collectionDate": "29/08/2023"
+        },
+        {
+            "type": "Refuse",
+            "collectionDate": "04/09/2023"
+        },
+        {
+            "type": "Food",
+            "collectionDate": "04/09/2023"
+        },
+        {
+            "type": "Recycling",
+            "collectionDate": "11/09/2023"
+        },
+        {
+            "type": "Garden",
+            "collectionDate": "11/09/2023"
+        },
+        {
+            "type": "Food",
+            "collectionDate": "11/09/2023"
+        },
+        {
+            "type": "Refuse",
+            "collectionDate": "18/09/2023"
+        },
+        {
+            "type": "Food",
+            "collectionDate": "18/09/2023"
+        },
+        {
+            "type": "Recycling",
+            "collectionDate": "25/09/2023"
+        },
+        {
+            "type": "Garden",
+            "collectionDate": "25/09/2023"
+        },
+        {
+            "type": "Food",
+            "collectionDate": "25/09/2023"
+        },
+        {
+            "type": "Refuse",
+            "collectionDate": "02/10/2023"
+        },
+        {
+            "type": "Food",
+            "collectionDate": "02/10/2023"
+        },
+        {
+            "type": "Recycling",
+            "collectionDate": "09/10/2023"
+        },
+        {
+            "type": "Garden",
+            "collectionDate": "09/10/2023"
+        },
+        {
+            "type": "Food",
+            "collectionDate": "09/10/2023"
+        },
+        {
+            "type": "Refuse",
+            "collectionDate": "16/10/2023"
+        },
+        {
+            "type": "Food",
+            "collectionDate": "16/10/2023"
+        },
+        {
+            "type": "Recycling",
+            "collectionDate": "23/10/2023"
+        },
+        {
+            "type": "Garden",
+            "collectionDate": "23/10/2023"
+        },
+        {
+            "type": "Food",
+            "collectionDate": "23/10/2023"
+        },
+        {
+            "type": "Refuse",
+            "collectionDate": "30/10/2023"
+        },
+        {
+            "type": "Food",
+            "collectionDate": "30/10/2023"
+        }
+    ]
+}

--- a/uk_bin_collection/uk_bin_collection/councils/AylesburyValeCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/AylesburyValeCouncil.py
@@ -1,0 +1,91 @@
+from bs4 import BeautifulSoup
+from uk_bin_collection.uk_bin_collection.common import *
+from uk_bin_collection.uk_bin_collection.get_bin_data import \
+    AbstractGetBinDataClass
+
+
+# import the wonderful Beautiful Soup and the URL grabber
+class CouncilClass(AbstractGetBinDataClass):
+    """
+    Concrete classes have to implement all abstract operations of the
+    base class. They can also override some operations with a default
+    implementation.
+    """
+
+    def parse_data(self, page: str, **kwargs) -> dict:
+        uprn = kwargs.get("uprn")
+        check_uprn(uprn)
+
+        # Make SOAP Request
+        headers = {
+            'Content-Type': 'text/xml; charset=UTF-8',
+            'SOAPAction': '"http://tempuri.org/GetCollections"'
+        }
+
+        post_data = '<?xml version="1.0" encoding="utf-8"?><soap:Envelope ' \
+                    'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" ' \
+                    'xmlns:xsd="http://www.w3.org/2001/XMLSchema" ' \
+                    'xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><GetCollections ' \
+                    'xmlns="http://tempuri.org/"><uprn>' + uprn + '</uprn></GetCollections></soap:Body></soap:Envelope>'
+
+        response = requests.post(
+            "http://avdcbins.web-labs.co.uk/RefuseApi.asmx",
+            data=post_data,
+            headers=headers
+        )
+
+        if response.status_code != 200:
+            raise ValueError("No collection data found for provided UPRN.")
+
+        # Make a BS4 object
+        soup = BeautifulSoup(response.text, "xml")
+        soup.prettify()
+
+        data = {"bins": []}
+
+        all_collections = soup.find_all('BinCollection')
+
+        for i in range(len(all_collections)):
+
+            collection_date = datetime.strptime(all_collections[i].Date.get_text(), "%Y-%m-%dT%H:%M:%S")
+            # Often the first BinCollection is the previous one
+            # The DateTime is set at 7AM so only compare the date element to make sure it captures today's collection at any time of day.
+            if collection_date.date() < datetime.today().date():
+                continue
+
+            if all_collections[i].Refuse.get_text() == "true":
+                bin_type = "Refuse"
+                dict_data = {
+                    "type": bin_type,
+                    "collectionDate": collection_date.strftime(date_format)
+                }
+                data["bins"].append(dict_data)
+
+            if all_collections[i].Recycling.get_text() == "true":
+                bin_type = "Recycling"
+                dict_data = {
+                    "type": bin_type,
+                    "collectionDate": collection_date.strftime(date_format)
+                }
+                data["bins"].append(dict_data)
+
+            if all_collections[i].Garden.get_text() == "true":
+                bin_type = "Garden"
+                dict_data = {
+                    "type": bin_type,
+                    "collectionDate": collection_date.strftime(date_format)
+                }
+                data["bins"].append(dict_data)
+
+            if all_collections[i].Food.get_text() == "true":
+                bin_type = "Food"
+                dict_data = {
+                    "type": bin_type,
+                    "collectionDate": collection_date.strftime(date_format)
+                }
+                data["bins"].append(dict_data)
+
+        data["bins"].sort(
+            key=lambda x: datetime.strptime(x.get("collectionDate"), date_format)
+        )
+        return data


### PR DESCRIPTION
Adding support for Aylesbury Vale (part of Bucks Council) using their SOAP endpoint which returns XML, so tests may not pass if expecting JSON.

This endpoint is used by their mobile app and works only for domestic properties, not businesses.

Addresses request #312 