### PR TITLE
Added support for Lancaster City Council

### DIFF
--- a/uk_bin_collection/tests/council_schemas/LancasterCityCouncil.schema
+++ b/uk_bin_collection/tests/council_schemas/LancasterCityCouncil.schema
@@ -1,0 +1,48 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$ref": "#/definitions/Welcome5",
+    "definitions": {
+        "Welcome5": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "bins": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Bin"
+                    }
+                }
+            },
+            "required": [
+                "bins"
+            ],
+            "title": "Welcome5"
+        },
+        "Bin": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "type": {
+                    "$ref": "#/definitions/Type"
+                },
+                "collectionDate": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "collectionDate",
+                "type"
+            ],
+            "title": "Bin"
+        },
+        "Type": {
+            "type": "string",
+            "enum": [
+                "Domestic Waste",
+                "Garden Waste",
+                "Recycling"
+            ],
+            "title": "Type"
+        }
+    }
+}

--- a/uk_bin_collection/tests/features/validate_council_outputs.feature
+++ b/uk_bin_collection/tests/features/validate_council_outputs.feature
@@ -39,6 +39,7 @@ Feature: Test each council output matches expected results in /outputs
             | HighPeakCouncil |
             | HuntingdonDistrictCouncil |
             | KingstonUponThamesCouncil |
+            | LancasterCityCouncil |
             | LeedsCityCouncil |
             | LisburnCastlereaghCityCouncil |
             | LondonBoroughHounslow |

--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -198,6 +198,13 @@
     "wiki_command_url_override": "https://waste-services.kingston.gov.uk/waste/XXXXXXX",
     "wiki_note": "Follow the instructions [here](https://waste-services.kingston.gov.uk/waste) until the \"Your bin days\" page then copy the URL and replace the URL in the command."
   },
+  "LancasterCityCouncil": {
+    "SKIP_GET_URL": "SKIP_GET_URL",
+    "house_number": "1",
+    "postcode": "LA1 1RS",
+    "wiki_name": "Lancaster City Council",
+    "url": "https://lcc-wrp.whitespacews.com"
+  },
   "LeedsCityCouncil": {
     "SKIP_GET_URL": "SKIP_GET_URL",
     "house_number": "1",

--- a/uk_bin_collection/tests/outputs/LancasterCityCouncil.json
+++ b/uk_bin_collection/tests/outputs/LancasterCityCouncil.json
@@ -1,0 +1,32 @@
+{
+  "bins": [
+    {
+      "type": "Domestic Waste",
+      "collectionDate": "18/08/2023"
+    },
+    {
+      "type": "Garden Waste",
+      "collectionDate": "25/08/2023"
+    },
+    {
+      "type": "Recycling",
+      "collectionDate": "25/08/2023"
+    },
+    {
+      "type": "Domestic Waste",
+      "collectionDate": "01/09/2023"
+    },
+    {
+      "type": "Garden Waste",
+      "collectionDate": "08/09/2023"
+    },
+    {
+      "type": "Recycling",
+      "collectionDate": "08/09/2023"
+    },
+    {
+      "type": "Domestic Waste",
+      "collectionDate": "15/09/2023"
+    }
+  ]
+}

--- a/uk_bin_collection/uk_bin_collection/councils/LancasterCityCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/LancasterCityCouncil.py
@@ -1,0 +1,65 @@
+from uk_bin_collection.uk_bin_collection.get_bin_data import \
+    AbstractGetBinDataClass
+from uk_bin_collection.uk_bin_collection.common import *
+from bs4 import BeautifulSoup
+from datetime import datetime
+import requests
+
+
+class CouncilClass(AbstractGetBinDataClass):
+    """
+    Concrete classes have to implement all abstract operations of the
+    base class. They can also override some operations with a default
+    implementation.
+    """
+
+    def parse_data(self, page: str, **kwargs) -> dict:
+
+        # data to return
+        data = {"bins": []}
+
+        # start session
+        # note: this ignores the given url
+        base_url = "https://lcc-wrp.whitespacews.com"
+        session = requests.session()
+        response = session.get(base_url + "/#!")
+        links = [a["href"] for a in BeautifulSoup(response.text, features="html.parser").select("a")]
+        portal_link = ""
+        for l in links:
+            if "seq=1" in l:
+                portal_link = l
+
+        # fill address form
+        response = session.get(portal_link)
+        form = BeautifulSoup(response.text, features="html.parser").find("form")
+        form_url = dict(form.attrs).get("action")
+        payload = {
+            "address_name_number": kwargs.get("number"),
+            "address_street": "",
+            "address_postcode": kwargs.get("postcode"),
+        }
+
+        # get (first) found address
+        response = session.post(form_url, data=payload)
+        links = [a["href"] for a in BeautifulSoup(response.text, features="html.parser").select("a")]
+        addr_link = ""
+        for l in links:
+            if "seq=3" in l:
+                addr_link = base_url + "/" + l
+
+        # get json formatted bin data for addr
+        response = session.get(addr_link)
+        new_soup = BeautifulSoup(response.text, features="html.parser")
+        services = new_soup.find("section", {"id": "scheduled-collections"})
+        services_sub = services.find_all("li")
+        for i in range(0, len(services_sub), 3):
+            dt = datetime.strptime(services_sub[i + 1].text.strip(), "%d/%m/%Y").date()
+            bin_type = BeautifulSoup(services_sub[i + 2].text, features="lxml").find("p")
+            data['bins'].append(
+                {
+                    "type": bin_type.text.strip().removesuffix(" Collection Service"),
+                    "collectionDate": dt.strftime(date_format)
+                }
+            )
+
+        return data


### PR DESCRIPTION
Adds support for collecting waste collection dates from the Lancaster City Council website.

Sadly, most of the process to obtain the dates relies on a session in which the state is server-side... 