### PR TITLE
Update pyproject.toml and release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,9 +32,16 @@ jobs:
         id: tag
         run: echo ::set-output name=TAG_NAME::$(echo $GITHUB_REF | cut -d / -f 3)
 
-      - name: Update version in pyproject.toml
+      - name: Update pyproject.toml version
         run: |
-          sed -i "s/version = "0.1.0"/version = "${{ steps.tag.outputs.TAG_NAME }}"/g" pyproject.toml
+          sed -i -E 's/version = \"([0-9.]+)\"/version = "${{ steps.tag.outputs.TAG_NAME }}"/g' pyproject.toml
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          commit-message: Update pyproject.toml version
+          title: Update pyproject.toml version
+        continue-on-error: true
 
       - name: Build and publish package
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "uk_bin_collection"
-version = "0.9.0"
+version = "0.10.0"
 description = "Python Lib to collect UK Bin Data"
 readme = "README.md"
 authors = ["Robert Bradley <robbrad182@gmail.com>"]


### PR DESCRIPTION
Update pyproject.toml manually to get the Bolton Council fix out for @rjosborne

Update release.yml to fix auto-updating the pyproject.toml version for PyPi and also now create a PR to update the repository to match.