### PR TITLE
fix: Fix for Wakefield City Council custom component support

### DIFF
--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -486,7 +486,6 @@
     "wiki_name": "Vale of Glamorgan Council"
   },
   "WakefieldCityCouncil": {
-    "SKIP_GET_URL": "SKIP_GET_URL",
     "url": "https://www.wakefield.gov.uk/where-i-live/?uprn=63035490&a=115%20Elizabeth%20Drive%20Castleford%20WF10%203RR&usrn=41801243&e=445418&n=426091&p=WF10%203RR",
     "wiki_name": "Wakefield City Council",
     "wiki_command_url_override": "https://www.wakefield.gov.uk/where-i-live/?uprn=XXXXXXXXXXX&a=XXXXXXXXXXX&usrn=XXXXXXXXXXX&e=XXXXXXXXXXX&n=XXXXXXXXXXX&p=XXXXXXXXXXX",


### PR DESCRIPTION
May close #346 

A quick fix to try and get this one working for @nmcrae85

This will result in the URL being called twice (once by the get data then again by selenium) so a better solution should be implemented when possible to avoid potential issues with Imperva captcha flagging the IP address.