### PR TITLE
docs: Update council request issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/COUNCIL_ISSUE.yaml
+++ b/.github/ISSUE_TEMPLATE/COUNCIL_ISSUE.yaml
@@ -1,0 +1,19 @@
+name: Council Issue
+description: Issue with an existing council
+labels: ["bug"]
+
+body:
+    - type: input
+      id: council
+      attributes:
+          label: Name of Council
+          description: What council you were trying to use
+          placeholder: e.g. Huntingdon District Council
+      validations:
+          required: true
+    - type: textarea
+      id: extra
+      attributes:
+        label: Issue Information
+        description: What is the issue you're experiencing? How can we re-produce it?
+        placeholder: Detailed explanation of the issue along with replication steps

--- a/.github/ISSUE_TEMPLATE/COUNCIL_ISSUE.yaml
+++ b/.github/ISSUE_TEMPLATE/COUNCIL_ISSUE.yaml
@@ -17,3 +17,17 @@ body:
         label: Issue Information
         description: What is the issue you're experiencing? How can we re-produce it?
         placeholder: Detailed explanation of the issue along with replication steps
+    - type: checkboxes
+      id: verification
+      attributes:
+        label: Verification
+        description: 'Please verify that you''ve followed these steps:'
+        options:
+          - label: I searched for similar issues at https://github.com/robbrad/UKBinCollectionData/issues?q=is:issue and found no duplicates
+            required: true
+          - label: I have checked my address/postcode/UPRN works on the council's website
+            required: true
+          - label: I have provided a detailed explanation of the issue as well as steps to replicate the issue
+            required: true
+          - label: I understand that this project is run by volunteer contributors therefore completion of this issue cannot be guaranteed
+            required: true

--- a/.github/ISSUE_TEMPLATE/COUNCIL_REQUEST.yaml
+++ b/.github/ISSUE_TEMPLATE/COUNCIL_REQUEST.yaml
@@ -1,6 +1,6 @@
 name: Council Request
 description: Request for a council to be added to the repository
-labels: ['Class: enhancement']
+labels: ["council request"]
 
 body:
     - type: input

--- a/.github/ISSUE_TEMPLATE/COUNCIL_REQUEST.yaml
+++ b/.github/ISSUE_TEMPLATE/COUNCIL_REQUEST.yaml
@@ -14,8 +14,8 @@ body:
     - type: input
       id: postcode
       attributes:
-          label: Example Postcode
-          description: Please provide and example postcode for the area
+          label: Example Address/Postcode
+          description: Please provide a tested working example address/postcode for the council's area
           placeholder: e.g. PE7 3YQ
       validations:
           required: true
@@ -25,3 +25,15 @@ body:
           label: Additional Information
           description: Add any other information here
           placeholder: Links to the councils site, information you have already gathered
+    - type: checkboxes
+      id: verification
+      attributes:
+        label: Verification
+        description: 'Please verify that you''ve followed these steps:'
+        options:
+          - label: I searched for similar issues at https://github.com/robbrad/UKBinCollectionData/issues?q=is:issue and found no duplicates
+            required: true
+          - label: I have provided a tested working address/postcode/UPRN with bin collections available
+            required: true
+          - label: I understand that this project is run by volunteer contributors and completion depends on numerous factors - even with a request, we cannot guarantee if/when your council will get a script
+            required: true

--- a/.github/ISSUE_TEMPLATE/HOME_ASSISTANT_CUSTOM_COMPONENT_ISSUE.yaml
+++ b/.github/ISSUE_TEMPLATE/HOME_ASSISTANT_CUSTOM_COMPONENT_ISSUE.yaml
@@ -3,17 +3,52 @@ description: Issue with the Home Assistant custom component
 labels: ["bug", "home assistant custom component"]
 
 body:
-    - type: input
-      id: council
-      attributes:
-          label: Name of Council (if relevant)
-          description: What council you were trying to use
-          placeholder: e.g. Huntingdon District Council
-      validations:
-          required: false
-    - type: textarea
-      id: extra
-      attributes:
-          label: Issue Information
-          description: What is the issue you're experiencing? How can we re-produce it?
-          placeholder: Detailed explanation of the issue along with replication steps
+  - type: markdown
+    attributes:
+      value: If you were trying to add a specific council, please check it is listed as working [here](https://robbrad.github.io/UKBinCollectionData/3.11/) and open a [Council Issue](https://github.com/robbrad/UKBinCollectionData/issues/new/choose) instead if it's failing
+  - type: input
+    id: ha_version
+    attributes:
+      label: Home Assistant Version
+      description: What version of Home Assistant you're running
+      placeholder: e.g. 2023.10.3
+    validations:
+      required: true
+  - type: dropdown
+    id: install_method
+    attributes:
+      label: Installation Method
+      description: How did you install the custom component?
+      options:
+        - Using HACS
+        - Manually
+    validations:
+      required: true
+  - type: input
+    id: council
+    attributes:
+      label: Name of Council (if relevant)
+      description: Which council were you trying to use?
+      placeholder: e.g. Huntingdon District Council
+  - type: textarea
+    id: extra
+    attributes:
+      label: Issue Information
+      description: What issue are you experiencing? How can we re-produce it?
+      placeholder: Detailed explanation of the issue along with replication steps
+    validations:
+      required: true
+  - type: checkboxes
+    id: verification
+    attributes:
+      label: Verification
+      description: 'Please verify that you''ve followed these steps:'
+      options:
+        - label: I searched for similar issues at https://github.com/robbrad/UKBinCollectionData/issues?q=is:issue and found no duplicates
+          required: true
+        - label: If trying to add a specific council, I've checked it is listed as working at https://robbrad.github.io/UKBinCollectionData/3.11/
+          required: true
+        - label: I have provided a detailed explanation of the issue as well as steps to replicate the issue
+          required: true
+        - label: I understand that this project is run by volunteer contributors therefore completion of this issue cannot be guaranteed
+          required: true

--- a/.github/ISSUE_TEMPLATE/HOME_ASSISTANT_CUSTOM_COMPONENT_ISSUE.yaml
+++ b/.github/ISSUE_TEMPLATE/HOME_ASSISTANT_CUSTOM_COMPONENT_ISSUE.yaml
@@ -1,0 +1,19 @@
+name: Home Assistant Custom Component Issue
+description: Issue with the Home Assistant custom component
+labels: ["bug", "home assistant custom component"]
+
+body:
+    - type: input
+      id: council
+      attributes:
+          label: Name of Council (if relevant)
+          description: What council you were trying to use
+          placeholder: e.g. Huntingdon District Council
+      validations:
+          required: false
+    - type: textarea
+      id: extra
+      attributes:
+          label: Issue Information
+          description: What is the issue you're experiencing? How can we re-produce it?
+          placeholder: Detailed explanation of the issue along with replication steps


### PR DESCRIPTION
Fix auto-labeling new council requests

Add 2 new issue templates for existing council & HA custom component issues