### PR TITLE
fix: Custom component web driver field label

### DIFF
--- a/custom_components/uk_bin_collection/translations/en.json
+++ b/custom_components/uk_bin_collection/translations/en.json
@@ -18,6 +18,7 @@
                     "postcode": "Postcode of the address",
                     "number": "House number of the address",
                     "usrn": "USRN (Unique Street Reference Number)",
+                    "web_driver": "URL of the remote Selenium web driver to use",
                     "submit": "Submit"
                 },
                 "description": "Please refer to your councils [wiki](https://github.com/robbrad/UKBinCollectionData/wiki/Councils) entry for details on what to enter"


### PR DESCRIPTION
Add missing line from translations to allow the custom component's web driver field to show a label