### PR TITLE
fix: don't ask for URL for Vale of White Horse Council

### DIFF
--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -777,6 +777,7 @@
         "wiki_name": "Vale of Glamorgan Council"
     },
     "ValeofWhiteHorseCouncil": {
+        "custom_component_show_url_field": false,
         "uprn": "100121391443",
         "url": "https://eform.whitehorsedc.gov.uk/ebase/BINZONE_DESKTOP.eb",
         "wiki_name": "Vale of White Horse Council"


### PR DESCRIPTION
Recently merged Vale of White Horse Council in #524 shouldn't request URL in Home Assistant