### PR TITLE
Behave pipeline changes

### DIFF
--- a/.github/workflows/behave.yml
+++ b/.github/workflows/behave.yml
@@ -64,11 +64,11 @@ jobs:
             COUNCIL_TESTS="$COUNCIL_TESTS or $FILENAME"
           fi
         done
-        echo "Council tests to run: $COUNCIL_TESTS"
+        echo "COUNCIL_TESTS=${COUNCIL_TESTS}" >> $GITHUB_ENV
 
 
     - name: run integration-tests
-      run: make matrix=${{ matrix.python-version }} councils=${{ env.CHANGED_COUNCILS }} integration-tests 
+      run: make matrix=${{ matrix.python-version }} councils=${{ env.COUNCIL_TESTS }} integration-tests 
       continue-on-error: true
 
     - name: run unit-tests

--- a/.github/workflows/behave.yml
+++ b/.github/workflows/behave.yml
@@ -1,6 +1,7 @@
 name: Test Councils
 
 on:
+  workflow_dispatch:
   push:
     # Trigger unless only the wiki directory changed
     paths-ignore:

--- a/.github/workflows/behave.yml
+++ b/.github/workflows/behave.yml
@@ -42,17 +42,31 @@ jobs:
     - name: Install
       run: make install
 
-    - name: Identify Changed Councils
-      id: find-councils
-      run: |
-        if [ $(git rev-list --count HEAD) -gt 1 ]; then
-          CHANGED_FILES=$(git diff --name-only HEAD HEAD~1 | grep 'uk_bin_collection/uk_bin_collection/councils/' | sed 's#.*/##' | sed 's/\.py//')
-        else
-          CHANGED_FILES=$(git ls-tree --name-only -r HEAD | grep 'uk_bin_collection/uk_bin_collection/councils/' | sed 's#.*/##' | sed 's/\.py//')
-        fi
-        echo "CHANGED_COUNCILS=${CHANGED_FILES}" >> $GITHUB_ENV
+    - name: Get all councils files that have changed
+      id: changed-council-files
+      uses: tj-actions/changed-files@v41
+      with:
+        files_yaml: |
+          councils:
+            - uk_bin_collection/uk_bin_collection/councils/**.py
 
-    
+    - name: Get all councils
+      env:
+        ALL_CHANGED_FILES: ${{ steps.changed-council-files.outputs.all_changed_files }}
+      run: |
+        IFS=' ' read -ra FILES <<< "$ALL_CHANGED_FILES"
+        COUNCIL_TESTS=""
+        for file in "${FILES[@]}"; do
+          FILENAME=$(basename "$file" .py)
+          if [ -z "$COUNCIL_TESTS" ]; then
+            COUNCIL_TESTS="$FILENAME"
+          else
+            COUNCIL_TESTS="$COUNCIL_TESTS or $FILENAME"
+          fi
+        done
+        echo "Council tests to run: $COUNCIL_TESTS"
+
+
     - name: run integration-tests
       run: make matrix=${{ matrix.python-version }} councils=${{ env.CHANGED_COUNCILS }} integration-tests 
       continue-on-error: true

--- a/.github/workflows/behave.yml
+++ b/.github/workflows/behave.yml
@@ -42,8 +42,14 @@ jobs:
     - name: Install
       run: make install
 
+    - name: Identify Changed Councils
+      id: find-councils
+      run: |
+        CHANGED_FILES=$(git diff --name-only HEAD HEAD~1 | grep 'uk_bin_collection/uk_bin_collection/councils/' | sed 's#.*/##' | sed 's/\.py//')
+        echo "CHANGED_COUNCILS=${CHANGED_FILES}" >> $GITHUB_ENV
+    
     - name: run integration-tests
-      run: make matrix=${{ matrix.python-version }} integration-tests
+      run: make matrix=${{ matrix.python-version }} councils=${{ env.CHANGED_COUNCILS }} integration-tests 
       continue-on-error: true
 
     - name: run unit-tests

--- a/.github/workflows/behave.yml
+++ b/.github/workflows/behave.yml
@@ -67,7 +67,7 @@ jobs:
 
 
     - name: run integration-tests
-      run: make matrix=${{ matrix.python-version }} councils=${{ env.COUNCIL_TESTS }} integration-tests 
+      run: make matrix=${{ matrix.python-version }} councils="${{ env.COUNCIL_TESTS }}" integration-tests 
       continue-on-error: true
 
     - name: run unit-tests

--- a/.github/workflows/behave.yml
+++ b/.github/workflows/behave.yml
@@ -46,9 +46,8 @@ jobs:
       id: changed-council-files
       uses: tj-actions/changed-files@v41
       with:
-        files_yaml: |
-          councils:
-            - uk_bin_collection/uk_bin_collection/councils/**.py
+        files: |
+          uk_bin_collection/uk_bin_collection/councils/**.py
 
     - name: Get all councils
       env:

--- a/.github/workflows/behave.yml
+++ b/.github/workflows/behave.yml
@@ -7,12 +7,16 @@ on:
     paths-ignore:
       - "wiki/**"
       - "**/**.md"
+      - "**.md"
+      - "uk_bin_collection_api_server/**"
     branches: [ "master" ]
   pull_request:
     # Trigger unless only the wiki directory changed
     paths-ignore:
       - "wiki/**"
       - "**/**.md"
+      - "**.md"
+      - "uk_bin_collection_api_server/**"
     # The branches below must be a subset of the branches above
     branches: [ "master" ]
   schedule:

--- a/.github/workflows/behave.yml
+++ b/.github/workflows/behave.yml
@@ -45,8 +45,13 @@ jobs:
     - name: Identify Changed Councils
       id: find-councils
       run: |
-        CHANGED_FILES=$(git diff --name-only HEAD HEAD~1 | grep 'uk_bin_collection/uk_bin_collection/councils/' | sed 's#.*/##' | sed 's/\.py//')
+        if [ $(git rev-list --count HEAD) -gt 1 ]; then
+          CHANGED_FILES=$(git diff --name-only HEAD HEAD~1 | grep 'uk_bin_collection/uk_bin_collection/councils/' | sed 's#.*/##' | sed 's/\.py//')
+        else
+          CHANGED_FILES=$(git ls-tree --name-only -r HEAD | grep 'uk_bin_collection/uk_bin_collection/councils/' | sed 's#.*/##' | sed 's/\.py//')
+        fi
         echo "CHANGED_COUNCILS=${CHANGED_FILES}" >> $GITHUB_ENV
+
     
     - name: run integration-tests
       run: make matrix=${{ matrix.python-version }} councils=${{ env.CHANGED_COUNCILS }} integration-tests 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -16,11 +16,13 @@ on:
     # Trigger unless only the wiki directory changed
     paths:
       - "**/**.py"
+      - "**.py"
     branches: [ "master" ]
   pull_request:
     # Trigger unless only the wiki directory changed
     paths:
       - "**/**.py"
+      - "**.py"
     # The branches below must be a subset of the branches above
     branches: [ "master" ]
   schedule:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -216,8 +216,30 @@ recommended - the council's address is usually a good one).
 |--------|-----------------------------------------------------------------------------------------|
 | Modify | `UKBinCollectionData/uk_bin_collection/tests/features/validate_council_outputs.feature` |
 
-The council's name should be added to the feature file's example list. These names are alphabetically sorted, although
-`council` should always remain on line 10. The name should be wrapped in pipes.
+The council's name should be added to the feature file's example list. These names are alphabetically sorted.
+
+For example:
+
+```
+Feature: Test each council output matches expected results
+
+    Scenario Outline: Validate Council Output
+        Given the council: <council>
+        When we scrape the data from <council> using <selenium_mode> and the <selenium_url> is set
+        Then the result is valid json
+        And the output should validate against the schema
+
+
+        @AylesburyValeCouncil
+              		Examples: AylesburyValeCouncil
+              		| council | selenium_url | selenium_mode |
+              		| AylesburyValeCouncil | None  | None  |
+
+        @BarnetCouncil
+                Examples: BarnetCouncil
+                | council | selenium_url | selenium_mode |
+                | BarnetCouncil | http://selenium:4444  | local  |
+```
 
 
 ## Testing
@@ -231,11 +253,18 @@ Based on the [input.json](https://github.com/robbrad/UKBinCollectionData/blob/ma
 this does an actual live run against the council's site and validates if the returned data is JSON and conforms to the common format [JSON Schema](https://github.com/robbrad/UKBinCollectionData/tree/master/uk_bin_collection/tests/output.schema).
 
 
-#### Running the Behave tests
+#### Running the Behave tests for all councils
 ```commandline
 cd UKBinCollectionData
 poetry shell
 poetry run pytest uk_bin_collection/tests/step_defs/ -n logical
+```
+
+#### Running the Behave tests for a specific council
+```commandline
+cd UKBinCollectionData
+poetry shell
+poetry run pytest uk_bin_collection/tests/step_defs/ -n logical -k "BarnetCouncil"
 ```
 
 #### GitHub Actions Integration Tests

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,11 @@ pycodestyle:
 
 ## @Testing runs unit tests
 integration-tests: ## runs tests for the project
-	poetry run pytest uk_bin_collection/tests/step_defs/ -n logical --alluredir=build/$(matrix)/allure-results
+    if [ -z "$$CHANGED_COUNCILS" ]; then \
+        poetry run pytest uk_bin_collection/tests/step_defs/ -n logical --alluredir=build/$(matrix)/allure-results; \
+    else \
+        poetry run pytest uk_bin_collection/tests/step_defs/ -k "$(councils)" -n logical --alluredir=build/$(matrix)/allure-results; \
+    fi
 
 unit-tests:
 	poetry run coverage run --omit "*/tests/*" -m pytest uk_bin_collection/tests --ignore=uk_bin_collection/tests/step_defs/

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ pycodestyle:
 
 ## @Testing runs unit tests
 integration-tests: ## runs tests for the project
-    if [ -z "$$CHANGED_COUNCILS" ]; then \
+    if [ -z "$(councils)" ]; then \
         poetry run pytest uk_bin_collection/tests/step_defs/ -n logical --alluredir=build/$(matrix)/allure-results; \
     else \
         poetry run pytest uk_bin_collection/tests/step_defs/ -k "$(councils)" -n logical --alluredir=build/$(matrix)/allure-results; \

--- a/Makefile
+++ b/Makefile
@@ -23,11 +23,11 @@ pycodestyle:
 
 ## @Testing runs unit tests
 integration-tests: ## runs tests for the project
-    if [ -z "$(councils)" ]; then \
-        poetry run pytest uk_bin_collection/tests/step_defs/ -n logical --alluredir=build/$(matrix)/allure-results; \
-    else \
-        poetry run pytest uk_bin_collection/tests/step_defs/ -k "$(councils)" -n logical --alluredir=build/$(matrix)/allure-results; \
-    fi
+	if [ -z "$(councils)" ]; then \
+		poetry run pytest uk_bin_collection/tests/step_defs/ -n logical --alluredir=build/$(matrix)/allure-results; \
+	else \
+		poetry run pytest uk_bin_collection/tests/step_defs/ -k "$(councils)" -n logical --alluredir=build/$(matrix)/allure-results; \
+	fi
 
 unit-tests:
 	poetry run coverage run --omit "*/tests/*" -m pytest uk_bin_collection/tests --ignore=uk_bin_collection/tests/step_defs/

--- a/uk_bin_collection/tests/features/validate_council_outputs.feature
+++ b/uk_bin_collection/tests/features/validate_council_outputs.feature
@@ -6,131 +6,633 @@ Feature: Test each council output matches expected results
         Then the result is valid json
         And the output should validate against the schema
 
-        Examples: Testing : <council>
-            | council | selenium_url | selenium_mode |
-            | AylesburyValeCouncil | None | None |
-            | BarnetCouncil | http://selenium:4444 | local |
-            | BarnsleyMBCouncil | None | None |
-            | BasingstokeCouncil | None | None |
-            | BathAndNorthEastSomersetCouncil | None | None |
-            | BCPCouncil | None | None |
-            | BedfordshireCouncil | None | None |
-            | BexleyCouncil | http://selenium:4444 | local |
-            | BlackburnCouncil | http://selenium:4444 | local |
-            | BoltonCouncil | http://selenium:4444 | local |
-            | BrightonandHoveCityCouncil | http://selenium:4444 | local |
-            | BristolCityCouncil | None | None |
-            | BromleyBoroughCouncil | http://selenium:4444 | local |
-            | BroxtoweBoroughCouncil | http://selenium:4444 | local |
-            | BuckinghamshireCouncil | http://selenium:4444 | local |
-            | BuryCouncil | None | None |
-            | CalderdaleCouncil | http://selenium:4444 | local |
-            | CannockChaseDistrictCouncil | None | None |
-            | CardiffCouncil | None | None |
-            | CastlepointDistrictCouncil | http://selenium:4444 | local |
-            | CharnwoodBoroughCouncil | None | None |
-            | ChelmsfordCityCouncil | http://selenium:4444 | local |
-            | CheshireEastCouncil | None | None |
-            | ConwyCountyBorough | None | None |
-            | CrawleyBoroughCouncil | None | None |
-            | CroydonCouncil | None | None |
-            | DerbyshireDalesDistrictCouncil | http://selenium:4444 | local |
-            | DoncasterCouncil | None | None |
-            | DorsetCouncil | None | None |
-            | DurhamCouncil | None | None |
-            | EastCambridgeshireCouncil | None | None |
-            | EastDevonDC | None | None |
-            | EastleighBoroughCouncil | None | None |
-            | EastLindseyDistrictCouncil | http://selenium:4444 | local |
-            | EastRidingCouncil | http://selenium:4444 | local |
-            | EastSuffolkCouncil | http://selenium:4444 | local |
-            | EnvironmentFirst | None | None |
-            | ErewashBoroughCouncil | None | None |
-            | FenlandDistrictCouncil | None | None |
-            | ForestOfDeanDistrictCouncil | http://selenium:4444 | local |
-            | GatesheadCouncil | http://selenium:4444 | local |
-            | GedlingBoroughCouncil | None | None |
-            | GlasgowCityCouncil | None | None |
-            | GuildfordCouncil | http://selenium:4444 | local |
-            | HaltonBoroughCouncil | http://selenium:4444 | local |
-            | HaringeyCouncil | None | None |
-            | HarrogateBoroughCouncil | None | None |
-            | HighPeakCouncil | http://selenium:4444 | local |
-            | HuntingdonDistrictCouncil | None | None |
-            | KingstonUponThamesCouncil | None | None |
-            | LancasterCityCouncil | None | None |
-            | LeedsCityCouncil | http://selenium:4444 | local |
-            | LisburnCastlereaghCityCouncil | None | None |
-            | LiverpoolCityCouncil | None | None |
-            | LondonBoroughHounslow | None | None |
-            | LondonBoroughRedbridge | http://selenium:4444 | local | 
-            | MaldonDistrictCouncil | None | None |
-            | MalvernHillsDC | None | None |
-            | ManchesterCityCouncil | None | None |
-            | MertonCouncil | None | None |
-            | MidAndEastAntrimBoroughCouncil | http://selenium:4444 | local |
-            | MidSussexDistrictCouncil | None | None |
-            | MiltonKeynesCityCouncil | None | None |
-            | NeathPortTalbotCouncil | http://selenium:4444 | local |
-            | NewarkAndSherwoodDC | None | None |
-            | NewcastleCityCouncil | None | None |
-            | NewportCityCouncil | None | None |
-            | NorthEastDerbyshireDistrictCouncil | http://selenium:4444 | local |
-            | NorthEastLincs | None | None |
-            | NorthKestevenDistrictCouncil | None | None |
-            | NorthLanarkshireCouncil | None | None |
-            | NorthLincolnshireCouncil | None | None |
-            | NorthNorfolkDistrictCouncil | http://selenium:4444 | local |
-            | NorthNorthamptonshireCouncil | None | None |
-            | NorthSomersetCouncil | None | None |
-            | NorthTynesideCouncil | None | None |
-            | NorthumberlandCouncil | http://selenium:4444 | local |
-            | NorthWestLeicestershire | http://selenium:4444 | local |
-            | NottinghamCityCouncil | None | None |
-            | OldhamCouncil | None | None |
-            | PortsmouthCityCouncil | http://selenium:4444 | local |
-            | PrestonCityCouncil | http://selenium:4444 | local |
-            | ReadingBoroughCouncil | None | None |
-            | ReigateAndBansteadBoroughCouncil | http://selenium:4444 | local |
-            | RhonddaCynonTaffCouncil | None | None |
-            | RochdaleCouncil | None | None |
-            | RugbyBoroughCouncil | None | None |
-            | RushcliffeBoroughCouncil | http://selenium:4444 | local |
-            | RushmoorCouncil | None | None |
-            | SalfordCityCouncil | None | None |
-            | SevenoaksDistrictCouncil | http://selenium:4444 | local |
-            | SheffieldCityCouncil | None | None |
-            | ShropshireCouncil | None | None |
-            | SomersetCouncil | None | None |
-            | SouthAyrshireCouncil | None | None |
-            | SouthCambridgeshireCouncil | None | None |
-            | SouthGloucestershireCouncil | None | None |
-            | SouthLanarkshireCouncil | None | None |
-            | SouthNorfolkCouncil | None | None |
-            | SouthOxfordshireCouncil | None | None |
-            | SouthTynesideCouncil | None | None |
-            | StaffordshireMoorlandsDistrictCouncil | http://selenium:4444 | local |
-            | StHelensBC | None | None |
-            | StockportBoroughCouncil | None | None |
-            | StokeOnTrentCityCouncil | None | None |
-            | StratfordUponAvonCouncil | None | None |
-            | SwaleBoroughCouncil | None | None |
-            | TamesideMBCouncil | None | None |
-            | TonbridgeAndMallingBC | None | None |
-            | TorbayCouncil | None | None |
-            | TorridgeDistrictCouncil | None | None |
-            | ValeofGlamorganCouncil | None | None |
-            | ValeofWhiteHorseCouncil | None | None |
-            | WakefieldCityCouncil | http://selenium:4444 | local |
-            | WarwickDistrictCouncil | None | None |
-            | WaverleyBoroughCouncil | None | None |
-            | WealdenDistrictCouncil | None | None |
-            | WelhatCouncil | None | None |
-            | WestLindseyDistrictCouncil | None | None |
-            | WestLothianCouncil | http://selenium:4444 | local |
-            | WestSuffolkCouncil | http://selenium:4444 | local |
-            | WiganBoroughCouncil | None | None |
-            | WiltshireCouncil | None | None |
-            | WindsorAndMaidenheadCouncil | None | None |
-            | WokingBoroughCouncil | None | None |
-            | YorkCouncil | None | None |
+
+        @AylesburyValeCouncil
+		Examples: AylesburyValeCouncil
+		| council | selenium_url | selenium_mode |
+		| AylesburyValeCouncil | None  | None  |
+
+        @BarnetCouncil
+		Examples: BarnetCouncil
+		| council | selenium_url | selenium_mode |
+		| BarnetCouncil | http://selenium:4444  | local  |
+
+        @BarnsleyMBCouncil
+		Examples: BarnsleyMBCouncil
+		| council | selenium_url | selenium_mode |
+		| BarnsleyMBCouncil | None  | None  |
+
+        @BasingstokeCouncil
+		Examples: BasingstokeCouncil
+		| council | selenium_url | selenium_mode |
+		| BasingstokeCouncil | None  | None  |
+
+        @BathAndNorthEastSomersetCouncil
+		Examples: BathAndNorthEastSomersetCouncil
+		| council | selenium_url | selenium_mode |
+		| BathAndNorthEastSomersetCouncil | None  | None  |
+
+        @BCPCouncil
+		Examples: BCPCouncil
+		| council | selenium_url | selenium_mode |
+		| BCPCouncil | None  | None  |
+
+        @BedfordshireCouncil
+		Examples: BedfordshireCouncil
+		| council | selenium_url | selenium_mode |
+		| BedfordshireCouncil | None  | None  |
+
+        @BexleyCouncil
+		Examples: BexleyCouncil
+		| council | selenium_url | selenium_mode |
+		| BexleyCouncil | http://selenium:4444  | local  |
+
+        @BlackburnCouncil
+		Examples: BlackburnCouncil
+		| council | selenium_url | selenium_mode |
+		| BlackburnCouncil | http://selenium:4444  | local  |
+
+        @BoltonCouncil
+		Examples: BoltonCouncil
+		| council | selenium_url | selenium_mode |
+		| BoltonCouncil | http://selenium:4444  | local  |
+
+        @BrightonandHoveCityCouncil
+		Examples: BrightonandHoveCityCouncil
+		| council | selenium_url | selenium_mode |
+		| BrightonandHoveCityCouncil | http://selenium:4444  | local  |
+
+        @BristolCityCouncil
+		Examples: BristolCityCouncil
+		| council | selenium_url | selenium_mode |
+		| BristolCityCouncil | None  | None  |
+
+        @BromleyBoroughCouncil
+		Examples: BromleyBoroughCouncil
+		| council | selenium_url | selenium_mode |
+		| BromleyBoroughCouncil | http://selenium:4444  | local  |
+
+        @BroxtoweBoroughCouncil
+		Examples: BroxtoweBoroughCouncil
+		| council | selenium_url | selenium_mode |
+		| BroxtoweBoroughCouncil | http://selenium:4444  | local  |
+
+        @BuckinghamshireCouncil
+		Examples: BuckinghamshireCouncil
+		| council | selenium_url | selenium_mode |
+		| BuckinghamshireCouncil | http://selenium:4444  | local  |
+
+        @BuryCouncil
+		Examples: BuryCouncil
+		| council | selenium_url | selenium_mode |
+		| BuryCouncil | None  | None  |
+
+        @CalderdaleCouncil
+		Examples: CalderdaleCouncil
+		| council | selenium_url | selenium_mode |
+		| CalderdaleCouncil | http://selenium:4444  | local  |
+
+        @CannockChaseDistrictCouncil
+		Examples: CannockChaseDistrictCouncil
+		| council | selenium_url | selenium_mode |
+		| CannockChaseDistrictCouncil | None  | None  |
+
+        @CardiffCouncil
+		Examples: CardiffCouncil
+		| council | selenium_url | selenium_mode |
+		| CardiffCouncil | None  | None  |
+
+        @CastlepointDistrictCouncil
+		Examples: CastlepointDistrictCouncil
+		| council | selenium_url | selenium_mode |
+		| CastlepointDistrictCouncil | http://selenium:4444  | local  |
+
+        @CharnwoodBoroughCouncil
+		Examples: CharnwoodBoroughCouncil
+		| council | selenium_url | selenium_mode |
+		| CharnwoodBoroughCouncil | None  | None  |
+
+        @ChelmsfordCityCouncil
+		Examples: ChelmsfordCityCouncil
+		| council | selenium_url | selenium_mode |
+		| ChelmsfordCityCouncil | http://selenium:4444  | local  |
+
+        @CheshireEastCouncil
+		Examples: CheshireEastCouncil
+		| council | selenium_url | selenium_mode |
+		| CheshireEastCouncil | None  | None  |
+
+        @ConwyCountyBorough
+		Examples: ConwyCountyBorough
+		| council | selenium_url | selenium_mode |
+		| ConwyCountyBorough | None  | None  |
+
+        @CrawleyBoroughCouncil
+		Examples: CrawleyBoroughCouncil
+		| council | selenium_url | selenium_mode |
+		| CrawleyBoroughCouncil | None  | None  |
+
+        @CroydonCouncil
+		Examples: CroydonCouncil
+		| council | selenium_url | selenium_mode |
+		| CroydonCouncil | None  | None  |
+
+        @DerbyshireDalesDistrictCouncil
+		Examples: DerbyshireDalesDistrictCouncil
+		| council | selenium_url | selenium_mode |
+		| DerbyshireDalesDistrictCouncil | http://selenium:4444  | local  |
+
+        @DoncasterCouncil
+		Examples: DoncasterCouncil
+		| council | selenium_url | selenium_mode |
+		| DoncasterCouncil | None  | None  |
+
+        @DorsetCouncil
+		Examples: DorsetCouncil
+		| council | selenium_url | selenium_mode |
+		| DorsetCouncil | None  | None  |
+
+        @DurhamCouncil
+		Examples: DurhamCouncil
+		| council | selenium_url | selenium_mode |
+		| DurhamCouncil | None  | None  |
+
+        @EastCambridgeshireCouncil
+		Examples: EastCambridgeshireCouncil
+		| council | selenium_url | selenium_mode |
+		| EastCambridgeshireCouncil | None  | None  |
+
+        @EastDevonDC
+		Examples: EastDevonDC
+		| council | selenium_url | selenium_mode |
+		| EastDevonDC | None  | None  |
+
+        @EastleighBoroughCouncil
+		Examples: EastleighBoroughCouncil
+		| council | selenium_url | selenium_mode |
+		| EastleighBoroughCouncil | None  | None  |
+
+        @EastLindseyDistrictCouncil
+		Examples: EastLindseyDistrictCouncil
+		| council | selenium_url | selenium_mode |
+		| EastLindseyDistrictCouncil | http://selenium:4444  | local  |
+
+        @EastRidingCouncil
+		Examples: EastRidingCouncil
+		| council | selenium_url | selenium_mode |
+		| EastRidingCouncil | http://selenium:4444  | local  |
+
+        @EastSuffolkCouncil
+		Examples: EastSuffolkCouncil
+		| council | selenium_url | selenium_mode |
+		| EastSuffolkCouncil | http://selenium:4444  | local  |
+
+        @EnvironmentFirst
+		Examples: EnvironmentFirst
+		| council | selenium_url | selenium_mode |
+		| EnvironmentFirst | None  | None  |
+
+        @ErewashBoroughCouncil
+		Examples: ErewashBoroughCouncil
+		| council | selenium_url | selenium_mode |
+		| ErewashBoroughCouncil | None  | None  |
+
+        @FenlandDistrictCouncil
+		Examples: FenlandDistrictCouncil
+		| council | selenium_url | selenium_mode |
+		| FenlandDistrictCouncil | None  | None  |
+
+        @ForestOfDeanDistrictCouncil
+		Examples: ForestOfDeanDistrictCouncil
+		| council | selenium_url | selenium_mode |
+		| ForestOfDeanDistrictCouncil | http://selenium:4444  | local  |
+
+        @GatesheadCouncil
+		Examples: GatesheadCouncil
+		| council | selenium_url | selenium_mode |
+		| GatesheadCouncil | http://selenium:4444  | local  |
+
+        @GedlingBoroughCouncil
+		Examples: GedlingBoroughCouncil
+		| council | selenium_url | selenium_mode |
+		| GedlingBoroughCouncil | None  | None  |
+
+        @GlasgowCityCouncil
+		Examples: GlasgowCityCouncil
+		| council | selenium_url | selenium_mode |
+		| GlasgowCityCouncil | None  | None  |
+
+        @GuildfordCouncil
+		Examples: GuildfordCouncil
+		| council | selenium_url | selenium_mode |
+		| GuildfordCouncil | http://selenium:4444  | local  |
+
+        @HaltonBoroughCouncil
+		Examples: HaltonBoroughCouncil
+		| council | selenium_url | selenium_mode |
+		| HaltonBoroughCouncil | http://selenium:4444  | local  |
+
+        @HaringeyCouncil
+		Examples: HaringeyCouncil
+		| council | selenium_url | selenium_mode |
+		| HaringeyCouncil | None  | None  |
+
+        @HarrogateBoroughCouncil
+		Examples: HarrogateBoroughCouncil
+		| council | selenium_url | selenium_mode |
+		| HarrogateBoroughCouncil | None  | None  |
+
+        @HighPeakCouncil
+		Examples: HighPeakCouncil
+		| council | selenium_url | selenium_mode |
+		| HighPeakCouncil | http://selenium:4444  | local  |
+
+        @HuntingdonDistrictCouncil
+		Examples: HuntingdonDistrictCouncil
+		| council | selenium_url | selenium_mode |
+		| HuntingdonDistrictCouncil | None  | None  |
+
+        @KingstonUponThamesCouncil
+		Examples: KingstonUponThamesCouncil
+		| council | selenium_url | selenium_mode |
+		| KingstonUponThamesCouncil | None  | None  |
+
+        @LancasterCityCouncil
+		Examples: LancasterCityCouncil
+		| council | selenium_url | selenium_mode |
+		| LancasterCityCouncil | None  | None  |
+
+        @LeedsCityCouncil
+		Examples: LeedsCityCouncil
+		| council | selenium_url | selenium_mode |
+		| LeedsCityCouncil | http://selenium:4444  | local  |
+
+        @LisburnCastlereaghCityCouncil
+		Examples: LisburnCastlereaghCityCouncil
+		| council | selenium_url | selenium_mode |
+		| LisburnCastlereaghCityCouncil | None  | None  |
+
+        @LiverpoolCityCouncil
+		Examples: LiverpoolCityCouncil
+		| council | selenium_url | selenium_mode |
+		| LiverpoolCityCouncil | None  | None  |
+
+        @LondonBoroughHounslow
+		Examples: LondonBoroughHounslow
+		| council | selenium_url | selenium_mode |
+		| LondonBoroughHounslow | None  | None  |
+
+        @LondonBoroughRedbridge
+		Examples: LondonBoroughRedbridge
+		| council | selenium_url | selenium_mode |
+		| LondonBoroughRedbridge | http://selenium:4444  | local  |
+ 
+        @MaldonDistrictCouncil
+		Examples: MaldonDistrictCouncil
+		| council | selenium_url | selenium_mode |
+		| MaldonDistrictCouncil | None  | None  |
+
+        @MalvernHillsDC
+		Examples: MalvernHillsDC
+		| council | selenium_url | selenium_mode |
+		| MalvernHillsDC | None  | None  |
+
+        @ManchesterCityCouncil
+		Examples: ManchesterCityCouncil
+		| council | selenium_url | selenium_mode |
+		| ManchesterCityCouncil | None  | None  |
+
+        @MertonCouncil
+		Examples: MertonCouncil
+		| council | selenium_url | selenium_mode |
+		| MertonCouncil | None  | None  |
+
+        @MidAndEastAntrimBoroughCouncil
+		Examples: MidAndEastAntrimBoroughCouncil
+		| council | selenium_url | selenium_mode |
+		| MidAndEastAntrimBoroughCouncil | http://selenium:4444  | local  |
+
+        @MidSussexDistrictCouncil
+		Examples: MidSussexDistrictCouncil
+		| council | selenium_url | selenium_mode |
+		| MidSussexDistrictCouncil | None  | None  |
+
+        @MiltonKeynesCityCouncil
+		Examples: MiltonKeynesCityCouncil
+		| council | selenium_url | selenium_mode |
+		| MiltonKeynesCityCouncil | None  | None  |
+
+        @NeathPortTalbotCouncil
+		Examples: NeathPortTalbotCouncil
+		| council | selenium_url | selenium_mode |
+		| NeathPortTalbotCouncil | http://selenium:4444  | local  |
+
+        @NewarkAndSherwoodDC
+		Examples: NewarkAndSherwoodDC
+		| council | selenium_url | selenium_mode |
+		| NewarkAndSherwoodDC | None  | None  |
+
+        @NewcastleCityCouncil
+		Examples: NewcastleCityCouncil
+		| council | selenium_url | selenium_mode |
+		| NewcastleCityCouncil | None  | None  |
+
+        @NewportCityCouncil
+		Examples: NewportCityCouncil
+		| council | selenium_url | selenium_mode |
+		| NewportCityCouncil | None  | None  |
+
+        @NorthEastDerbyshireDistrictCouncil
+		Examples: NorthEastDerbyshireDistrictCouncil
+		| council | selenium_url | selenium_mode |
+		| NorthEastDerbyshireDistrictCouncil | http://selenium:4444  | local  |
+
+        @NorthEastLincs
+		Examples: NorthEastLincs
+		| council | selenium_url | selenium_mode |
+		| NorthEastLincs | None  | None  |
+
+        @NorthKestevenDistrictCouncil
+		Examples: NorthKestevenDistrictCouncil
+		| council | selenium_url | selenium_mode |
+		| NorthKestevenDistrictCouncil | None  | None  |
+
+        @NorthLanarkshireCouncil
+		Examples: NorthLanarkshireCouncil
+		| council | selenium_url | selenium_mode |
+		| NorthLanarkshireCouncil | None  | None  |
+
+        @NorthLincolnshireCouncil
+		Examples: NorthLincolnshireCouncil
+		| council | selenium_url | selenium_mode |
+		| NorthLincolnshireCouncil | None  | None  |
+
+        @NorthNorfolkDistrictCouncil
+		Examples: NorthNorfolkDistrictCouncil
+		| council | selenium_url | selenium_mode |
+		| NorthNorfolkDistrictCouncil | http://selenium:4444  | local  |
+
+        @NorthNorthamptonshireCouncil
+		Examples: NorthNorthamptonshireCouncil
+		| council | selenium_url | selenium_mode |
+		| NorthNorthamptonshireCouncil | None  | None  |
+
+        @NorthSomersetCouncil
+		Examples: NorthSomersetCouncil
+		| council | selenium_url | selenium_mode |
+		| NorthSomersetCouncil | None  | None  |
+
+        @NorthTynesideCouncil
+		Examples: NorthTynesideCouncil
+		| council | selenium_url | selenium_mode |
+		| NorthTynesideCouncil | None  | None  |
+
+        @NorthumberlandCouncil
+		Examples: NorthumberlandCouncil
+		| council | selenium_url | selenium_mode |
+		| NorthumberlandCouncil | http://selenium:4444  | local  |
+
+        @NorthWestLeicestershire
+		Examples: NorthWestLeicestershire
+		| council | selenium_url | selenium_mode |
+		| NorthWestLeicestershire | http://selenium:4444  | local  |
+
+        @NottinghamCityCouncil
+		Examples: NottinghamCityCouncil
+		| council | selenium_url | selenium_mode |
+		| NottinghamCityCouncil | None  | None  |
+
+        @OldhamCouncil
+		Examples: OldhamCouncil
+		| council | selenium_url | selenium_mode |
+		| OldhamCouncil | None  | None  |
+
+        @PortsmouthCityCouncil
+		Examples: PortsmouthCityCouncil
+		| council | selenium_url | selenium_mode |
+		| PortsmouthCityCouncil | http://selenium:4444  | local  |
+
+        @PrestonCityCouncil
+		Examples: PrestonCityCouncil
+		| council | selenium_url | selenium_mode |
+		| PrestonCityCouncil | http://selenium:4444  | local  |
+
+        @ReadingBoroughCouncil
+		Examples: ReadingBoroughCouncil
+		| council | selenium_url | selenium_mode |
+		| ReadingBoroughCouncil | None  | None  |
+
+        @ReigateAndBansteadBoroughCouncil
+		Examples: ReigateAndBansteadBoroughCouncil
+		| council | selenium_url | selenium_mode |
+		| ReigateAndBansteadBoroughCouncil | http://selenium:4444  | local  |
+
+        @RhonddaCynonTaffCouncil
+		Examples: RhonddaCynonTaffCouncil
+		| council | selenium_url | selenium_mode |
+		| RhonddaCynonTaffCouncil | None  | None  |
+
+        @RochdaleCouncil
+		Examples: RochdaleCouncil
+		| council | selenium_url | selenium_mode |
+		| RochdaleCouncil | None  | None  |
+
+        @RugbyBoroughCouncil
+		Examples: RugbyBoroughCouncil
+		| council | selenium_url | selenium_mode |
+		| RugbyBoroughCouncil | None  | None  |
+
+        @RushcliffeBoroughCouncil
+		Examples: RushcliffeBoroughCouncil
+		| council | selenium_url | selenium_mode |
+		| RushcliffeBoroughCouncil | http://selenium:4444  | local  |
+
+        @RushmoorCouncil
+		Examples: RushmoorCouncil
+		| council | selenium_url | selenium_mode |
+		| RushmoorCouncil | None  | None  |
+
+        @SalfordCityCouncil
+		Examples: SalfordCityCouncil
+		| council | selenium_url | selenium_mode |
+		| SalfordCityCouncil | None  | None  |
+
+        @SevenoaksDistrictCouncil
+		Examples: SevenoaksDistrictCouncil
+		| council | selenium_url | selenium_mode |
+		| SevenoaksDistrictCouncil | http://selenium:4444  | local  |
+
+        @SheffieldCityCouncil
+		Examples: SheffieldCityCouncil
+		| council | selenium_url | selenium_mode |
+		| SheffieldCityCouncil | None  | None  |
+
+        @ShropshireCouncil
+		Examples: ShropshireCouncil
+		| council | selenium_url | selenium_mode |
+		| ShropshireCouncil | None  | None  |
+
+        @SomersetCouncil
+		Examples: SomersetCouncil
+		| council | selenium_url | selenium_mode |
+		| SomersetCouncil | None  | None  |
+
+        @SouthAyrshireCouncil
+		Examples: SouthAyrshireCouncil
+		| council | selenium_url | selenium_mode |
+		| SouthAyrshireCouncil | None  | None  |
+
+        @SouthCambridgeshireCouncil
+		Examples: SouthCambridgeshireCouncil
+		| council | selenium_url | selenium_mode |
+		| SouthCambridgeshireCouncil | None  | None  |
+
+        @SouthGloucestershireCouncil
+		Examples: SouthGloucestershireCouncil
+		| council | selenium_url | selenium_mode |
+		| SouthGloucestershireCouncil | None  | None  |
+
+        @SouthLanarkshireCouncil
+		Examples: SouthLanarkshireCouncil
+		| council | selenium_url | selenium_mode |
+		| SouthLanarkshireCouncil | None  | None  |
+
+        @SouthNorfolkCouncil
+		Examples: SouthNorfolkCouncil
+		| council | selenium_url | selenium_mode |
+		| SouthNorfolkCouncil | None  | None  |
+
+        @SouthOxfordshireCouncil
+		Examples: SouthOxfordshireCouncil
+		| council | selenium_url | selenium_mode |
+		| SouthOxfordshireCouncil | None  | None  |
+
+        @SouthTynesideCouncil
+		Examples: SouthTynesideCouncil
+		| council | selenium_url | selenium_mode |
+		| SouthTynesideCouncil | None  | None  |
+
+        @StaffordshireMoorlandsDistrictCouncil
+		Examples: StaffordshireMoorlandsDistrictCouncil
+		| council | selenium_url | selenium_mode |
+		| StaffordshireMoorlandsDistrictCouncil | http://selenium:4444  | local  |
+
+        @StHelensBC
+		Examples: StHelensBC
+		| council | selenium_url | selenium_mode |
+		| StHelensBC | None  | None  |
+
+        @StockportBoroughCouncil
+		Examples: StockportBoroughCouncil
+		| council | selenium_url | selenium_mode |
+		| StockportBoroughCouncil | None  | None  |
+
+        @StokeOnTrentCityCouncil
+		Examples: StokeOnTrentCityCouncil
+		| council | selenium_url | selenium_mode |
+		| StokeOnTrentCityCouncil | None  | None  |
+
+        @StratfordUponAvonCouncil
+		Examples: StratfordUponAvonCouncil
+		| council | selenium_url | selenium_mode |
+		| StratfordUponAvonCouncil | None  | None  |
+
+        @SwaleBoroughCouncil
+		Examples: SwaleBoroughCouncil
+		| council | selenium_url | selenium_mode |
+		| SwaleBoroughCouncil | None  | None  |
+
+        @TamesideMBCouncil
+		Examples: TamesideMBCouncil
+		| council | selenium_url | selenium_mode |
+		| TamesideMBCouncil | None  | None  |
+
+        @TonbridgeAndMallingBC
+		Examples: TonbridgeAndMallingBC
+		| council | selenium_url | selenium_mode |
+		| TonbridgeAndMallingBC | None  | None  |
+
+        @TorbayCouncil
+		Examples: TorbayCouncil
+		| council | selenium_url | selenium_mode |
+		| TorbayCouncil | None  | None  |
+
+        @TorridgeDistrictCouncil
+		Examples: TorridgeDistrictCouncil
+		| council | selenium_url | selenium_mode |
+		| TorridgeDistrictCouncil | None  | None  |
+
+        @ValeofGlamorganCouncil
+		Examples: ValeofGlamorganCouncil
+		| council | selenium_url | selenium_mode |
+		| ValeofGlamorganCouncil | None  | None  |
+
+        @ValeofWhiteHorseCouncil
+		Examples: ValeofWhiteHorseCouncil
+		| council | selenium_url | selenium_mode |
+		| ValeofWhiteHorseCouncil | None  | None  |
+
+        @WakefieldCityCouncil
+		Examples: WakefieldCityCouncil
+		| council | selenium_url | selenium_mode |
+		| WakefieldCityCouncil | http://selenium:4444  | local  |
+
+        @WarwickDistrictCouncil
+		Examples: WarwickDistrictCouncil
+		| council | selenium_url | selenium_mode |
+		| WarwickDistrictCouncil | None  | None  |
+
+        @WaverleyBoroughCouncil
+		Examples: WaverleyBoroughCouncil
+		| council | selenium_url | selenium_mode |
+		| WaverleyBoroughCouncil | None  | None  |
+
+        @WealdenDistrictCouncil
+		Examples: WealdenDistrictCouncil
+		| council | selenium_url | selenium_mode |
+		| WealdenDistrictCouncil | None  | None  |
+
+        @WelhatCouncil
+		Examples: WelhatCouncil
+		| council | selenium_url | selenium_mode |
+		| WelhatCouncil | None  | None  |
+
+        @WestLindseyDistrictCouncil
+		Examples: WestLindseyDistrictCouncil
+		| council | selenium_url | selenium_mode |
+		| WestLindseyDistrictCouncil | None  | None  |
+
+        @WestLothianCouncil
+		Examples: WestLothianCouncil
+		| council | selenium_url | selenium_mode |
+		| WestLothianCouncil | http://selenium:4444  | local  |
+
+        @WestSuffolkCouncil
+		Examples: WestSuffolkCouncil
+		| council | selenium_url | selenium_mode |
+		| WestSuffolkCouncil | http://selenium:4444  | local  |
+
+        @WiganBoroughCouncil
+		Examples: WiganBoroughCouncil
+		| council | selenium_url | selenium_mode |
+		| WiganBoroughCouncil | None  | None  |
+
+        @WiltshireCouncil
+		Examples: WiltshireCouncil
+		| council | selenium_url | selenium_mode |
+		| WiltshireCouncil | None  | None  |
+
+        @WindsorAndMaidenheadCouncil
+		Examples: WindsorAndMaidenheadCouncil
+		| council | selenium_url | selenium_mode |
+		| WindsorAndMaidenheadCouncil | None  | None  |
+
+        @WokingBoroughCouncil
+		Examples: WokingBoroughCouncil
+		| council | selenium_url | selenium_mode |
+		| WokingBoroughCouncil | None  | None  |
+
+        @YorkCouncil
+		Examples: YorkCouncil
+		| council | selenium_url | selenium_mode |
+		| YorkCouncil | None  | None  |

--- a/uk_bin_collection/uk_bin_collection/councils/CheshireEastCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/CheshireEastCouncil.py
@@ -3,39 +3,26 @@ from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataC
 
 
 class CouncilClass(AbstractGetBinDataClass):
-    """
-    Concrete classes have to implement all abstract operations of the
-    base class. They can also override some operations with a default
-    implementation.
-    """
-
     def parse_data(self, page: str, **kwargs) -> dict:
-        # Create a BS4 object
         soup = BeautifulSoup(page.text, features="html.parser")
 
         bin_data_dict = {"bins": []}
 
-        # Search for the specific table using BS4
-        rows = soup.find("table", {"class": "job-details"}).find_all(
-            "tr", {"class": "data-row"}
-        )
+        table = soup.find("table", {"class": "job-details"})
+        if table:
+            rows = table.find_all("tr", {"class": "data-row"})
 
-        # Loop through the rows
-        for row in rows:
-            cells = row.find_all(
-                "td", {"class": lambda L: L and L.startswith("visible-cell")}
-            )
+            for row in rows:
+                cells = row.find_all("td", {"class": lambda L: L and L.startswith("visible-cell")})
+                labels = cells[0].find_all("label") if cells else []
 
-            bin_type = cells[0].find_all("label")[2].get_text(strip=True)
-            collection_date = cells[0].find_all("label")[1].get_text(strip=True)
+                if len(labels) >= 3:
+                    bin_type = labels[2].get_text(strip=True)
+                    collection_date = labels[1].get_text(strip=True)
 
-            # Create a dictionary for each Bin element in the JSON
-            dict_data = {
-                "type": bin_type,
-                "collectionDate": collection_date,
-            }
-
-            # Add data to the main JSON Wrapper
-            bin_data_dict["bins"].append(dict_data)
+                    bin_data_dict["bins"].append({
+                        "type": bin_type,
+                        "collectionDate": collection_date,
+                    })
 
         return bin_data_dict

--- a/uk_bin_collection/uk_bin_collection/councils/ConwyCountyBorough.py
+++ b/uk_bin_collection/uk_bin_collection/councils/ConwyCountyBorough.py
@@ -1,39 +1,24 @@
 from bs4 import BeautifulSoup
-from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
-import re
+from uk_bin_collection.uk_bin_collection.common import *
+from datetime import datetime
 
-
-# import the wonderful Beautiful Soup and the URL grabber
 class CouncilClass(AbstractGetBinDataClass):
-    """
-    Concrete classes have to implement all abstract operations of the
-    base class. They can also override some operations with a default
-    implementation.
-    """
-
     def parse_data(self, page: str, **kwargs) -> dict:
-        # Make a BS4 object
         soup = BeautifulSoup(page.text, features="html.parser")
-        soup.prettify()
-
-        regex_pattern = r"<li>([^<]+)<"
-
         data = {"bins": []}
 
-        for bins in soup.select('div[class*="containererf"]'):
-            collection_date = datetime.strptime(
-                bins.find(id="content").text.strip(), "%A, %d/%m/%Y"
-            )
-            bin_type_div = bins.find(id="main1")
-            bin_types = bin_type_div.findAll("li")
-            for bin_type in bin_types:
-                bin_type_name = re.sub(r"\(.*\)", "", bin_type.text).strip()
+        for bin_section in soup.select('div[class*="containererf"]'):
+            date_text = bin_section.find(id="content").text.strip()
+            collection_date = datetime.strptime(date_text, "%A, %d/%m/%Y")
 
-                dict_data = {
+            bin_types = bin_section.find(id="main1").findAll("li")
+            for bin_type in bin_types:
+                bin_type_name = bin_type.text.split('(')[0].strip()
+
+                data["bins"].append({
                     "type": bin_type_name,
                     "collectionDate": collection_date.strftime(date_format),
-                }
-                data["bins"].append(dict_data)
+                })
 
         return data


### PR DESCRIPTION
Closes #534 

The pipeline now automatically detects councils that have changed and only runs intergrations tests against them

If no councils are changed then the whole set runs