### PR TITLE
fix: update logic to account for council website change

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/BedfordshireCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/BedfordshireCouncil.py
@@ -49,9 +49,13 @@ class CouncilClass(AbstractGetBinDataClass):
         # Get the collection items on the page and strip the bits of text that we don't care for
         collections = []
         for bin in collections_div.find_all("h3"):
-            bin_type = bin.find_next("br").next_sibling
-            collection_date = datetime.strptime(bin.text, "%A, %d %B %Y")
-            collections.append((bin_type, collection_date))
+            next_bin = bin.next_sibling
+
+            while next_bin.name != "h3" and next_bin.name != "p":
+                if next_bin.name != "br":
+                    collection_date = datetime.strptime(bin.text, "%A, %d %B %Y")
+                    collections.append((next_bin, collection_date))
+                next_bin = next_bin.next_sibling
 
         # Sort the collections by date order rather than bin type, then return as a dictionary (with str date)
         ordered_data = sorted(collections, key=lambda x: x[1])

--- a/wiki/Councils.md
+++ b/wiki/Councils.md
@@ -88,6 +88,7 @@ This document is still a work in progress, don't worry if your council isn't lis
 - [North Somerset Council](#north-somerset-council)
 - [North Tyneside Council](#north-tyneside-council)
 - [Northumberland Council](#northumberland-council)
+- [Nottingham City Council](#nottingham-city-council)
 - [Oldham Council](#oldham-council)
 - [Portsmouth City Council](#portsmouth-city-council)
 - [Preston City Council](#preston-city-council)
@@ -175,7 +176,7 @@ Additional parameters:
 
 ### Barnet Council
 ```commandline
-python collect_data.py BarnetCouncil  -s -p "XXXX XXX" -n XX -w http://HOST:PORT/
+python collect_data.py BarnetCouncil https://www.barnet.gov.uk/recycling-and-waste/bin-collections/find-your-bin-collection-day -s -p "XXXX XXX" -n XX -w http://HOST:PORT/
 ```
 Additional parameters:
 - `-s` - skip get URL
@@ -1031,6 +1032,16 @@ Additional parameters:
 - `-p` - postcode
 - `-n` - house number
 - `-w` - remote Selenium web driver URL (required for Home Assistant)
+
+---
+
+### Nottingham City Council
+```commandline
+python collect_data.py NottinghamCityCouncil https://geoserver.nottinghamcity.gov.uk/myproperty/handler/proxy.ashx?https://geoserver.nottinghamcity.gov.uk/bincollections2/api/collection/100031540180 -s -u XXXXXXXX
+```
+Additional parameters:
+- `-s` - skip get URL
+- `-u` - UPRN
 
 ---
 


### PR DESCRIPTION
Now works on a variable amount of data, to account for the website changes. Example:

```bash
$ python collect_data.py BedfordshireCouncil https://www.centralbedfordshire.gov.uk/info/163/bins_and_waste_collections_-_check_bin_collection_day -p "SG19 2UP" -u "10000802040"
{
    "bins": [
        {
            "type": "Food waste",
            "collectionDate": "11/01/2024"
        },
        {
            "type": "Garden waste",
            "collectionDate": "11/01/2024"
        },
        {
            "type": "Recycling",
            "collectionDate": "11/01/2024"
        },
        {
            "type": "Food waste",
            "collectionDate": "18/01/2024"
        },
        {
            "type": "Refuse (black bin)",
            "collectionDate": "18/01/2024"
        },
        {
            "type": "Food waste",
            "collectionDate": "25/01/2024"
        },
        {
            "type": "Garden waste",
            "collectionDate": "25/01/2024"
        },
        {
            "type": "Recycling",
            "collectionDate": "25/01/2024"
        },
        {
            "type": "Food waste",
            "collectionDate": "01/02/2024"
        },
        {
            "type": "Refuse (black bin)",
            "collectionDate": "01/02/2024"
        },
        {
            "type": "Food waste",
            "collectionDate": "08/02/2024"
        },
        {
            "type": "Garden waste",
            "collectionDate": "08/02/2024"
        },
        {
            "type": "Recycling",
            "collectionDate": "08/02/2024"
        }
    ]
}
```