### PR TITLE
fix: duplicate driver.quit() calls causes error

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/WakefieldCityCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/WakefieldCityCouncil.py
@@ -24,9 +24,6 @@ class CouncilClass(AbstractGetBinDataClass):
             soup = BeautifulSoup(driver.page_source, features="html.parser")
             soup.prettify()
 
-            # Quit Selenium webdriver to release session
-            driver.quit()
-
             data = {"bins": []}
             sections = soup.find_all("div", {"class": "wil_c-content-section_heading"})
             for s in sections:


### PR DESCRIPTION
Remove the duplicate `driver.quit()` call, regardless of exception, finally is always called. 

Duplicate calls of `driver.quit()` cause error described in #556