### PR TITLE
fix: Eastleigh Borough Council doesnt cope with "You haven't yet sign…

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/EastleighBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/EastleighBoroughCouncil.py
@@ -55,15 +55,16 @@ class CouncilClass(AbstractGetBinDataClass):
         # Process dict for valid bin types
         for bin in list(binDict):
             if bin in binTypes:
-                # Convert date
-                date = datetime.strptime(binDict[bin], "%a, %d %b %Y")
-
-                # Set bin data
-                dict_data = {
-                    "type": bin,
-                    "collectionDate": date.strftime(date_format),
-                }
-                data["bins"].append(dict_data)
+                if not binDict[bin].startswith("You haven't yet signed up for"):
+                    # Convert date
+                    date = datetime.strptime(binDict[bin], "%a, %d %b %Y")
+    
+                    # Set bin data
+                    dict_data = {
+                        "type": bin,
+                        "collectionDate": date.strftime(date_format),
+                    }
+                    data["bins"].append(dict_data)
 
         # Return bin data
         return data


### PR DESCRIPTION
…ed up for ..."

fix: Eastleigh Borough Council doesnt cope when Garden Waste service hasn't been signed up for, which gets the value "You haven't yet signed up for our garden waste collections. Find out more about our\xa0garden waste collection service" which results in  ValueError: time data

This checks for the expected case when garden waste not opted in. This fixes issue #562