### PR TITLE
fix: East Suffolk Council - remove extra driver.quit() to prevent errors

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/EastSuffolkCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/EastSuffolkCouncil.py
@@ -84,9 +84,6 @@ class CouncilClass(AbstractGetBinDataClass):
                 data_table.get_attribute("innerHTML"), features="html.parser"
             )
 
-            # Quit Selenium webdriver to release session
-            driver.quit()
-
             data = {"bins": []}
 
             rows = soup.find("table").find("tbody").find_all("tr")


### PR DESCRIPTION
additional driver.quit() left in this council is causing errors -- maybe there's more councils with this too?