### PR TITLE
fix: All Councils that use Selenium - Add a default value for user_agent to fix all councils using selenium…

### DIFF
--- a/uk_bin_collection/uk_bin_collection/common.py
+++ b/uk_bin_collection/uk_bin_collection/common.py
@@ -262,7 +262,9 @@ def contains_date(string, fuzzy=False) -> bool:
         return False
 
 
-def create_webdriver(web_driver: str, headless: bool, user_agent: str) -> webdriver.Chrome:
+def create_webdriver(
+    web_driver: str, headless: bool, user_agent: str = None
+) -> webdriver.Chrome:
     """
     Create and return a headless Selenium webdriver
     :rtype: webdriver.Chrome


### PR DESCRIPTION
… and not specifying agent

dd48be701b5cfabaad0d148e23f9e6cf836b1e2e added user_agent to the create_webdriver function but didn't set the default value to None, causing a crash on every single council that did not specify a custom UA.

I went back and looked at the original PR that caused this (#558) and in the checks in there it looks like this *was* caught by the CI tests for the council but that test still got marked as 'passed' by CI. 

Looks like the CI might need modifying to actually error on things like this.
