### PR TITLE
Fix duplicate driver.quit call resulting in selenium exception and failure to collect data

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/BroxtoweBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/BroxtoweBoroughCouncil.py
@@ -67,9 +67,6 @@ class CouncilClass(AbstractGetBinDataClass):
 
             soup = BeautifulSoup(driver.page_source, features="html.parser")
 
-            # Quit Selenium webdriver to release session
-            driver.quit()
-
             bins_div = soup.find("div", id="ctl00_ContentPlaceHolder1_FF5686FormGroup")
             if bins_div:
                 bins_table = bins_div.find("table")

--- a/uk_bin_collection/uk_bin_collection/councils/BuckinghamshireCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/BuckinghamshireCouncil.py
@@ -81,9 +81,6 @@ class CouncilClass(AbstractGetBinDataClass):
             df = pd.read_html(table, header=[1])
             df = df[0]
 
-            # Quit Selenium webdriver to release session
-            driver.quit()
-
             # Parse data into dict
             data = self.get_data(df)
         except Exception as e:

--- a/uk_bin_collection/uk_bin_collection/councils/ChorleyCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/ChorleyCouncil.py
@@ -93,9 +93,6 @@ class CouncilClass(AbstractGetBinDataClass):
 
             soup = BeautifulSoup(driver.page_source, features="html.parser")
 
-            # Quit Selenium webdriver to release session
-            driver.quit()
-
             # Get the property details
             property_details = soup.find(
                 "table",

--- a/uk_bin_collection/uk_bin_collection/councils/DerbyshireDalesDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/DerbyshireDalesDistrictCouncil.py
@@ -67,9 +67,6 @@ class CouncilClass(AbstractGetBinDataClass):
 
             soup = BeautifulSoup(driver.page_source, features="html.parser")
 
-            # Quit Selenium webdriver to release session
-            driver.quit()
-
             bin_rows = (
                 soup.find("div", id="ctl00_ContentPlaceHolder1_pnlConfirmation")
                 .find("div", {"class": "row"})

--- a/uk_bin_collection/uk_bin_collection/councils/EastLindseyDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/EastLindseyDistrictCouncil.py
@@ -75,9 +75,6 @@ class CouncilClass(AbstractGetBinDataClass):
 
             soup = BeautifulSoup(driver.page_source, features="html.parser")
 
-            # Quit Selenium webdriver to release session
-            driver.quit()
-
             # Get collections
             for collection in soup.find_all("div", {"class": "waste-result"}):
                 ptags = collection.find_all("p")

--- a/uk_bin_collection/uk_bin_collection/councils/GatesheadCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/GatesheadCouncil.py
@@ -69,9 +69,6 @@ class CouncilClass(AbstractGetBinDataClass):
 
             soup = BeautifulSoup(driver.page_source, features="html.parser")
 
-            # Quit Selenium webdriver to release session
-            driver.quit()
-
             # Get collections table
             table = soup.find("table", {"class": "bincollections__table"})
 

--- a/uk_bin_collection/uk_bin_collection/councils/HighPeakCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/HighPeakCouncil.py
@@ -120,9 +120,6 @@ class CouncilClass(AbstractGetBinDataClass):
                 By.ID, "FINDBINDAYSHIGHPEAK_CALENDAR_MAINCALENDAR"
             ).get_attribute("outerHTML")
 
-            # Quit Selenium webdriver to release session
-            driver.quit()
-
             # Parse data into dict
             data = self.get_data(table)
         except Exception as e:

--- a/uk_bin_collection/uk_bin_collection/councils/NeathPortTalbotCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/NeathPortTalbotCouncil.py
@@ -90,9 +90,6 @@ class CouncilClass(AbstractGetBinDataClass):
 
             soup = BeautifulSoup(driver.page_source, features="html.parser")
 
-            # Quit Selenium webdriver to release session
-            driver.quit()
-
             # Get the property details
             property_details = soup.find(
                 "div",

--- a/uk_bin_collection/uk_bin_collection/councils/NorthNorfolkDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/NorthNorfolkDistrictCouncil.py
@@ -70,9 +70,6 @@ class CouncilClass(AbstractGetBinDataClass):
 
                 soup = BeautifulSoup(driver.page_source, features="html.parser")
 
-                # Quit Selenium webdriver to release session
-                driver.quit()
-
                 bins_text = soup.find("div", id="Search_result_details_cps_hd")
 
                 if bins_text:

--- a/uk_bin_collection/uk_bin_collection/councils/NorthumberlandCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/NorthumberlandCouncil.py
@@ -66,9 +66,6 @@ class CouncilClass(AbstractGetBinDataClass):
 
             soup = BeautifulSoup(driver.page_source, features="html.parser")
 
-            # Quit Selenium webdriver to release session
-            driver.quit()
-
             # Work out which bins can be collected for this address. Glass bins are only on some houses due to pilot programme.
             bins_collected = list(
                 map(

--- a/uk_bin_collection/uk_bin_collection/councils/PrestonCityCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/PrestonCityCouncil.py
@@ -64,9 +64,6 @@ class CouncilClass(AbstractGetBinDataClass):
 
             soup = BeautifulSoup(driver.page_source, features="html.parser")
 
-            # Quit Selenium webdriver to release session
-            driver.quit()
-
             topLevelSpan = soup.find("span", id="MainContent_lblMoreCollectionDates")
 
             collectionDivs = topLevelSpan.find_all("div", {"id": "container"})

--- a/uk_bin_collection/uk_bin_collection/councils/ReigateAndBansteadBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/ReigateAndBansteadBoroughCouncil.py
@@ -47,9 +47,6 @@ class CouncilClass(AbstractGetBinDataClass):
             soup = BeautifulSoup(driver.page_source, features="html.parser")
             soup.prettify()
 
-            # Quit Selenium webdriver to release session
-            driver.quit()
-
             data = {"bins": []}
             section = soup.find("span", {"data-name": "html2"})
             dates = section.find_all("div")

--- a/uk_bin_collection/uk_bin_collection/councils/RushcliffeBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/RushcliffeBoroughCouncil.py
@@ -67,9 +67,6 @@ class CouncilClass(AbstractGetBinDataClass):
 
             soup = BeautifulSoup(driver.page_source, features="html.parser")
 
-            # Quit Selenium webdriver to release session
-            driver.quit()
-
             bins_text = soup.find("div", id="ctl00_ContentPlaceHolder1_pnlConfirmation")
 
             if bins_text:

--- a/uk_bin_collection/uk_bin_collection/councils/WestLothianCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/WestLothianCouncil.py
@@ -73,9 +73,6 @@ class CouncilClass(AbstractGetBinDataClass):
 
             soup = BeautifulSoup(driver.page_source, features="html.parser")
 
-            # Quit Selenium webdriver to release session
-            driver.quit()
-
             # Get collections
             for collection in soup.find_all("div", {"class": "bin-collect"}):
                 dict_data = {


### PR DESCRIPTION
This PR ensures we're always consitently only calling driver.quit in the new finally block introduced in #543.

Where driver.quit() has already been called in the council module, the finally block calls it again a second time, resulting in a second call to DELETE /session/<id> and the exception:

```
org.openqa.selenium.NoSuchSessionException: Unable to find session with ID: <session_id>
```

