### PR TITLE
fix: barnet no overrides

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/BarnetCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/BarnetCouncil.py
@@ -115,7 +115,11 @@ class CouncilClass(AbstractGetBinDataClass):
             # Find the div with the specified id
             target_div = soup.find("div", {"id": target_div_id})
 
-            overrides_dict = get_seasonal_overrides()
+            # Handle the additional table of info for xmas
+            try:
+                overrides_dict = get_seasonal_overrides()
+            except Exception as e:
+                overrides_dict = {}
 
             # Check if the div is found
             if target_div:


### PR DESCRIPTION
The table of overrides for xmas has been removed, gracefully handle this - and if / when it gets recreated continue to use it