### PR TITLE
fix: fixed charnwood dates if in leap year

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/CharnwoodBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/CharnwoodBoroughCouncil.py
@@ -35,12 +35,13 @@ class CouncilClass(AbstractGetBinDataClass):
                     elif collection_date.lower() == "tomorrow":
                         collection_date = datetime.now() + timedelta(days=1)
                     else:
+                        collection_date += f" {curr_date.year}"
                         collection_date = datetime.strptime(
                             remove_ordinal_indicator_from_date_string(
                                 collection_date
                             ).strip(),
-                            "%a %d %b",
-                        ).replace(year=curr_date.year)
+                            "%a %d %b %Y",
+                        )
                         if curr_date.month == 12 and collection_date.month == 1:
                             collection_date = collection_date + relativedelta(years=1)
                     dict_data = {


### PR DESCRIPTION
moves year addition to before the parsing so it doesnt give the out of range error.