### PR TITLE
Fix incorrect script path in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ pyhamcrest = "*"
 
 
 [tool.poetry.scripts]
-uk_bin_collection = "uk_bin_collection.uk_bin_collection:collect_data"
+uk_bin_collection = "uk_bin_collection.uk_bin_collection.collect_data:run"
 
 [tool.dephell.main]
 versioning = "semver"

--- a/uk_bin_collection/uk_bin_collection/collect_data.py
+++ b/uk_bin_collection/uk_bin_collection/collect_data.py
@@ -115,8 +115,13 @@ class UKBinCollectionApp:
         return get_bin_data_class.template_method(address_url, **kwargs)
 
 
-if __name__ == "__main__":
+def run():
+    global _LOGGER
     _LOGGER = setup_logging(LOGGING_CONFIG, None)
     app = UKBinCollectionApp()
     app.set_args(sys.argv[1:])
     print(app.run())
+
+
+if __name__ == "__main__":
+    run()


### PR DESCRIPTION
This fixes the issue of inability to use the script installed via pip (#642).

Do let me know if there's a good way to add an automated test for this.

