### PR TITLE
Update release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,7 @@ jobs:
           tag: ${{ env.RELEASE_VERSION }}
           generateReleaseNotes: true
           prerelease: true
+          allowUpdates: true
 
       - name: Build and publish package
         run: |


### PR DESCRIPTION
Should allow the job to rerun if it fails. Currently, it gives an error because the tag already exists.