### PR TITLE
Gedling Borough Council: Use alternative name for cleaner values

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/GedlingBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/GedlingBoroughCouncil.py
@@ -38,7 +38,7 @@ class CouncilClass(AbstractGetBinDataClass):
             for col in json_data:
                 bin_date = datetime.strptime(col.get("collectionDate"), "%Y-%m-%d").date()
                 if bin_date >= run_date:
-                    collections.append((col.get("name").replace("Collection", "").replace("Day","").strip().title(), bin_date))
+                    collections.append((col.get("alternativeName"), bin_date))
 
         # Sort the data
         ordered_data = sorted(collections, key=lambda x: x[1])


### PR DESCRIPTION
Following #763. I noticed you are having to do some replace calls on the original name generated from the iCal. There's also a bug whereby certain values that are changed collections become `Black Bin  (Changed )` after the replace calls.

All JSON endpoints now provide an `alternativeName` value for any collection, which provides a modified name value which removes the "Day" or "(Changed Collection)" values, which is cleaner for this use case. This is automatically generated at build, allowing you to simplify your codebase.

Here's the new values of name vs alternativeName:

| Name    | Alternative name |
| -------- | ------- |
| Black Bin Day (Changed Collection) | Black Bin |
| Green Bin Day | Green Bin |
| Green Bin + Glass Box Day | Green Bin + Glass Box |
| Garden Waste Collection | Garden Bin

```json
{
      "name": "Black Bin Day",
      "alternativeName": "Black Bin",
      "weekday": "Friday",
      "isOccurrence": true,
      "type": "black-bin",
      "collectionDate": "2023-12-08",
      "isChangedCollection": false
}
```

Happy to adjust the tweak the format if needed. This PR updates the column being used to the new `alternativeName` key

I have also [documented the JSON endpoints](https://www.gbcbincalendars.co.uk/json-endpoints) in full.

Hope it's useful!