### PR TITLE
fix module name in BirminghamCityCouncil.py

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/BirminghamCityCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/BirminghamCityCouncil.py
@@ -5,7 +5,7 @@ import requests
 import logging
 import re
 from datetime import datetime
-from uk_bin_collection.common import *
+from uk_bin_collection.uk_bin_collection.common import *
 from dateutil.parser import parse
 
 from uk_bin_collection.uk_bin_collection.common import check_uprn, check_postcode


### PR DESCRIPTION
Incorrect path leads to import error:
```
Traceback (most recent call last):
  File "/lsiopy/lib/python3.12/site-packages/uk_bin_collection/uk_bin_collection/collect_data.py", line 134, in <module>
    run()
  File "/lsiopy/lib/python3.12/site-packages/uk_bin_collection/uk_bin_collection/collect_data.py", line 130, in run
    print(app.run())
          ^^^^^^^^^
  File "/lsiopy/lib/python3.12/site-packages/uk_bin_collection/uk_bin_collection/collect_data.py", line 100, in run
    council_module = import_council_module(self.parsed_args.module)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/lsiopy/lib/python3.12/site-packages/uk_bin_collection/uk_bin_collection/collect_data.py", line 19, in import_council_module
    return importlib.import_module(module_name)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/importlib/__init__.py", line 90, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 995, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/lsiopy/lib/python3.12/site-packages/uk_bin_collection/uk_bin_collection/councils/BirminghamCityCouncil.py", line 8, in <module>
    from uk_bin_collection.common import *
ModuleNotFoundError: No module named 'uk_bin_collection.common'
```