### PR TITLE
fix: High Peak have changed their cookie dialog

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/HighPeakCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/HighPeakCouncil.py
@@ -69,12 +69,6 @@ class CouncilClass(AbstractGetBinDataClass):
             driver = create_webdriver(web_driver, headless, None, __name__)
             driver.get(page)
 
-            # Hide Cookies
-            inputElement_hc = driver.find_element(
-                By.CLASS_NAME, "cookiemessage__link--close"
-            )
-            inputElement_hc.click()
-
             # Enter postcode in text box and wait
             inputElement_pc = driver.find_element(
                 By.ID, "FINDBINDAYSHIGHPEAK_POSTCODESELECT_POSTCODE"


### PR DESCRIPTION
Fixes #824 

Seems to be safe to ignore the cookie dialog now.