### PR TITLE
bug: Bracknell Forest configuration incorrect

### DIFF
--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -109,6 +109,7 @@
         "wiki_note": "To get the UPRN, you will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search). Previously required single field that was UPRN and full address, now requires UPRN and postcode as separate fields."
     },
     "BracknellForestCouncil": {
+        "house_number": "13",
         "paon": "57",
         "postcode": "GU47 9BS",
         "skip_get_url": true,

--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -109,7 +109,7 @@
         "wiki_note": "To get the UPRN, you will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search). Previously required single field that was UPRN and full address, now requires UPRN and postcode as separate fields."
     },
     "BracknellForestCouncil": {
-        "house_number": "13",
+        "house_number": "57",
         "paon": "57",
         "postcode": "GU47 9BS",
         "skip_get_url": true,


### PR DESCRIPTION
fixes robbrad/UKBinCollectionData/issues/846

adds house number to input.json. HACS creation of integration using new input.json then prompts for house number which was missing previously. New entities are created and Home Assistant no longer crashes
Documentation in the wiki needs updating to reflect the requirement to specify a house number as part of the command line.