### PR TITLE
Add three new functions to common.py

### DIFF
--- a/uk_bin_collection/tests/test_common_functions.py
+++ b/uk_bin_collection/tests/test_common_functions.py
@@ -134,6 +134,32 @@ def test_is_holiday_different_region(mock_holidays_func):
     assert is_holiday(datetime(2023, 11, 30), Region.ENG) is False
 
 
+def test_is_weekend_when_true():
+    weekend_date = datetime(2024, 12, 7)
+    assert is_weekend(weekend_date) is True
+
+
+def test_is_weekend_when_false():
+    weekend_date = datetime(2024, 12, 6)
+    assert is_weekend(weekend_date) is False
+
+
+def test_is_working_day_when_true():
+    working_day_date = datetime(2024, 12, 6)
+    assert is_working_day(working_day_date) is True
+
+
+def test_is_working_day_when_false():
+    working_day_date = datetime(2024, 12, 7)
+    assert is_working_day(working_day_date) is False
+
+
+def test_get_next_working_day():
+    sample_date = datetime(2024, 12, 7)
+    next_working_day = get_next_working_day(sample_date)
+    assert next_working_day == datetime(2024, 12, 9)
+
+
 def test_remove_alpha_characters():
     test_string = "12345abc12345"
     result = remove_alpha_characters(test_string)

--- a/uk_bin_collection/uk_bin_collection/collect_data.py
+++ b/uk_bin_collection/uk_bin_collection/collect_data.py
@@ -2,7 +2,7 @@ import argparse
 import importlib
 import os
 import sys
-import logging
+import logging, logging.config
 from uk_bin_collection.uk_bin_collection.get_bin_data import (
     setup_logging,
     LOGGING_CONFIG,

--- a/uk_bin_collection/uk_bin_collection/collect_data.py
+++ b/uk_bin_collection/uk_bin_collection/collect_data.py
@@ -2,7 +2,7 @@ import argparse
 import importlib
 import os
 import sys
-import logging, logging.config
+import logging
 from uk_bin_collection.uk_bin_collection.get_bin_data import (
     setup_logging,
     LOGGING_CONFIG,


### PR DESCRIPTION
A few more functions for common.py - these may be useful for calendars where we know the collection day, but have no way of scraping data and have to use our own functions to generate them.

## is_weekend()
A counterpart to is_holiday(), provides an easy way of finding out if a date is on a Saturday/Sunday.

## is_working_day()
I'm defining 'working day' as any day Monday to Friday that is not a holiday. This function is a wrapper for both is_holiday and is_weekend - if one is True for the given date, false is returned.

## get_next_working_day()
Could be useful when used with the above - returns the next working day according to the criteria above
