### PR TITLE
Fix Monmouthshire collection new line error

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/MonmouthshireCountyCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/MonmouthshireCountyCouncil.py
@@ -43,7 +43,7 @@ class CouncilClass(AbstractGetBinDataClass):
 
             # Extract collection date (e.g., "Monday 9th December")
             date_tag = panel.find("p")
-            if date_tag and "Your next collection date is" in date_tag.text:
+            if date_tag and "Your next collection date is" in date_tag.text.strip().replace("\r", "").replace("\n", ""):
                 collection_date = date_tag.find("strong").text.strip()
             else:
                 continue


### PR DESCRIPTION
For Monmouthshire council, some collection date tags have new lines in them, therefore they must also be removed before parsing to check if the line starts with "Your next collection date is"

Just copied the text function from line 42, which already does this

![image](https://github.com/user-attachments/assets/da588b4c-3155-4aab-8548-6240aa1ae724)
