### PR TITLE
fix: correctly handle year increment for January dates (Broxbourne Council)

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/BroxbourneCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/BroxbourneCouncil.py
@@ -43,6 +43,7 @@ class CouncilClass(AbstractGetBinDataClass):
         rows = table.find_all("tr")
 
         current_year = datetime.now().year
+        current_month = datetime.now().month 
 
         # Process each row into a list of dictionaries
         for row in rows[1:]:  # Skip the header row
@@ -56,7 +57,7 @@ class CouncilClass(AbstractGetBinDataClass):
             if collection_date_text:
                 try:
                     collection_date = datetime.strptime(collection_date_text, "%a %d %b")
-                    if collection_date.month == 1:
+                    if collection_date.month == 1 and current_month != 1:
                         collection_date = collection_date.replace(year=current_year + 1)
                     else:
                         collection_date = collection_date.replace(year=current_year)


### PR DESCRIPTION
I've missed this in my previous PR. 

The council's dates are provided in `day/month` format, and the script was incrementing the year if the current month was January. This worked fine for December or November but caused issues when viewing dates in January. 

I've updated the script to increment the year for January dates only when parsed in a month other than January.