### PR TITLE
Simplify Wyre Council script

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/WyreCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/WyreCouncil.py
@@ -41,17 +41,8 @@ class CouncilClass(AbstractGetBinDataClass):
             "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.6167.186 Safari/537.36",
             "x-requested-with": "XMLHttpRequest",
         }
-        postcode_api = f"https://www.wyre.gov.uk/singlepoint_ajax/{urllib.parse.quote(user_postcode)}"
-        addr_res = requests.post(postcode_api, headers=headers)
-        json_data = addr_res.json()
 
-        for v in json_data.values():
-            v_uprn = v.get("uprn")
-            if v_uprn == user_uprn:
-                addr_line = v.get("label")
-                break
-
-        api_url = f"https://www.wyre.gov.uk/bincollections?uprn={user_uprn}&address={urllib.parse.quote(addr_line)}&submit="
+        api_url = f"https://www.wyre.gov.uk/bincollections?uprn={user_uprn}"
         res = requests.get(api_url, headers=headers)
 
         soup = BeautifulSoup(res.text, features="html.parser")


### PR DESCRIPTION
This PR Fixes #1245 by simplifying the Wyre Council script. Instead of looking up the address from the UPRN, we just send the UPRN in the request to get the same result. 

To test this, I used my [incredible VI skills](https://preview.redd.it/i-have-been-using-vim-for-the-past-2-years-not-because-i-v0-ud43pn6gn52b1.png?auto=webp&s=15ec594a315087222f5ae74b458a8e59a76c0d18) to modify the python file in the running Home Assistant container:

<img width="773" alt="Screenshot 2025-02-21 at 10 23 54 pm" src="https://github.com/user-attachments/assets/ff7e666b-3c9c-48b0-8b2b-2787747ce82d" />

Instead of receiving the error, my dashboard populated with the correct sensors (although I need to configure the colours):

<img width="1018" alt="Screenshot 2025-02-21 at 10 27 46 pm" src="https://github.com/user-attachments/assets/da78a7cd-e143-42f1-9834-dd9a7dfaad23" />
<img width="373" alt="Screenshot 2025-02-21 at 10 28 12 pm" src="https://github.com/user-attachments/assets/f04772b9-9fe9-4909-9bb9-5182cb490da5" />
