### PR TITLE
fix: Set the bin_type when different day

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/SouthOxfordshireCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/SouthOxfordshireCouncil.py
@@ -79,7 +79,7 @@ class CouncilClass(AbstractGetBinDataClass):
                             "%A %d %B -",
                         )
                     )
-                    str.capitalize(" ".join(bin_info[2:]))
+                    bin_type = str.capitalize(" ".join(bin_info[2:]))
             except:
                 continue
 


### PR DESCRIPTION
Fixes #1317

It looks like in a previous change to handle the bins being on a different day the `bin_type` variable was missed out and now causing the extension to crash on load due to unset variable.