### PR TITLE
fix: Sandwell garden waste collection date is wrong

### DIFF
--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -1668,7 +1668,7 @@
     },
     "SandwellBoroughCouncil": {
         "skip_get_url": true,
-        "uprn": "10008755549",
+        "uprn": "32101971",
         "url": "https://www.sandwell.gov.uk",
         "wiki_name": "Sandwell Borough Council",
         "wiki_note": "Pass the UPRN. You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search)."


### PR DESCRIPTION
Fixes: https://github.com/robbrad/UKBinCollectionData/issues/1334

The id `58a1a71694992` used in the calls returns only the householde waste:
<img width="764" alt="image" src="https://github.com/user-attachments/assets/3a50a9ea-e5d0-437d-a426-02e234fb3b47" />
Before we were giving these values to all the bin types, but this is not true for the garden waste which is collected on different days.

The id `56b1cdaf6bb43` is used to retrieve the data for the garden waste:
<img width="741" alt="image" src="https://github.com/user-attachments/assets/29f53cdd-da56-4908-ae69-8ac9604496c0" />

> Note:
> Some UPRNs return an empty list for garden waste collection dates.
> I have tried to check Sandwell's website but even in their calls it is
> coming back empty (even if the data is in the UI).


As well I've introduced Batteries as a bin type for Sandwell Borough Council.

This is a sample of what now is returned by the `parse_data` now:
```
{
  'bins': [
    {'type': 'Recycling (Blue)', 'collectionDate': '18/04/2025'}, 
    {'type': 'Household Waste (Grey)', 'collectionDate': '18/04/2025'}, 
    {'type': 'Food Waste (Brown)', 'collectionDate': '18/04/2025'}, 
    {'type': 'Batteries', 'collectionDate': '18/04/2025'},
    {'type': 'Recycling (Blue)', 'collectionDate': '25/04/2025'}, 
    {'type': 'Household Waste (Grey)', 'collectionDate': '25/04/2025'}, 
    {'type': 'Food Waste (Brown)', 'collectionDate': '25/04/2025'}, 
    {'type': 'Batteries', 'collectionDate': '25/04/2025'}, 
    {'type': 'Garden Waste (Green)', 'collectionDate': '25/04/2025'}, 
    {'type': 'Garden Waste (Green)', 'collectionDate': '09/05/2025'}
]}
```
