### PR TITLE
Fix: #1359 - Harrogate Borough Council scraping issue

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/HarrogateBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/HarrogateBoroughCouncil.py
@@ -37,7 +37,7 @@ class CouncilClass(AbstractGetBinDataClass):
         collections = []
 
         # Find section with bins in
-        table = soup.find_all("table", {"class": "hbcRounds"})[1]
+        table = soup.find_all("table", {"class": "hbcRounds"})[0]
 
         # For each bin section, get the text and the list elements
         for row in table.find_all("tr"):


### PR DESCRIPTION

Fix for issue with Harrogate Borough Council html scraping.

I've tested the change using the python script, and also ran the tests in the dev container to prove the change fixes the issue.