### PR TITLE
Fix: #1359 - HTML Parsing error with Harrogate Borough Council

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/HarrogateBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/HarrogateBoroughCouncil.py
@@ -37,7 +37,7 @@ class CouncilClass(AbstractGetBinDataClass):
         collections = []
 
         # Find section with bins in
-        table = soup.find_all("table", {"class": "hbcRounds"})[0]
+        table = soup.find_all("table", {"class": "hbcRounds"})[-1]
 
         # For each bin section, get the text and the list elements
         for row in table.find_all("tr"):


### PR DESCRIPTION
The first table has now been re-added, so I have changed the code to look for the last table irrespective of how many tables there are, so it will always find the right one.