### PR TITLE
fix: used canonical 'nice name'

### DIFF
--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -3,7 +3,7 @@
         "LAD24CD": "S12000033",
         "uprn": "9051156186",
         "url": "https://www.aberdeencity.gov.uk",
-        "wiki_name": "Aberdeen City Council",
+        "wiki_name": "Aberdeen City",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN."
     },
     "AberdeenshireCouncil": {
@@ -11,20 +11,20 @@
         "uprn": "151176430",
         "url": "https://online.aberdeenshire.gov.uk",
         "wiki_command_url_override": "https://online.aberdeenshire.gov.uk",
-        "wiki_name": "Aberdeenshire Council",
+        "wiki_name": "Aberdeenshire",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN."
     },
     "AdurAndWorthingCouncils": {
         "url": "https://www.adur-worthing.gov.uk/bin-day/?brlu-selected-address=100061878829",
         "wiki_command_url_override": "https://www.adur-worthing.gov.uk/bin-day/?brlu-selected-address=XXXXXXXX",
-        "wiki_name": "Adur and Worthing Councils",
+        "wiki_name": "Adur",
         "wiki_note": "Replace XXXXXXXX with your UPRN. You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find it.",
         "LAD24CD": "E07000223"
     },
     "AmberValleyBoroughCouncil": {
         "uprn": "100030026621",
         "url": "https://ambervalley.gov.uk",
-        "wiki_name": "Amber Valley Borough Council",
+        "wiki_name": "Amber Valley",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "E07000032"
     },
@@ -32,14 +32,14 @@
         "LAD24CD": "N09000001",
         "url": "https://antrimandnewtownabbey.gov.uk/residents/bins-recycling/bins-schedule/?Id=643",
         "wiki_command_url_override": "https://antrimandnewtownabbey.gov.uk/residents/bins-recycling/bins-schedule/?Id=XXXX",
-        "wiki_name": "Antrim & Newtonabbey Council",
+        "wiki_name": "Antrim and Newtownabbey",
         "wiki_note": "Navigate to [https://antrimandnewtownabbey.gov.uk/residents/bins-recycling/bins-schedule] and search for your street name. Use the URL with the ID to replace XXXXXXXX with your specific ID."
     },
     "ArdsAndNorthDownCouncil": {
         "uprn": "187136177",
         "url": "https://www.ardsandnorthdown.gov.uk",
         "wiki_command_url_override": "https://www.ardsandnorthdown.gov.uk",
-        "wiki_name": "Ards and North Down Council",
+        "wiki_name": "Ards and North Down",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "N09000011"
     },
@@ -49,7 +49,7 @@
         "uprn": "000125011723",
         "url": "https://www.argyll-bute.gov.uk/rubbish-and-recycling/household-waste/bin-collection",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Argyll and Bute Council",
+        "wiki_name": "Argyll and Bute",
         "wiki_note": "Pass the UPRN. You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "S12000035"
     },
@@ -58,7 +58,7 @@
         "uprn": "185625284",
         "url": "https://www.armaghbanbridgecraigavon.gov.uk/",
         "wiki_command_url_override": "https://www.armaghbanbridgecraigavon.gov.uk/",
-        "wiki_name": "Armagh Banbridge Craigavon Council",
+        "wiki_name": "Armagh City, Banbridge and Craigavon",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN."
     },
     "ArunCouncil": {
@@ -67,7 +67,7 @@
         "skip_get_url": true,
         "url": "https://www1.arun.gov.uk/when-are-my-bins-collected",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Arun Council",
+        "wiki_name": "Arun",
         "wiki_note": "Pass the house name/number and postcode in their respective parameters, both wrapped in double quotes. This parser requires a Selenium webdriver.",
         "LAD24CD": "E07000224"
     },
@@ -76,7 +76,7 @@
         "postcode": "NG16 6RH",
         "url": "https://www.ashfield.gov.uk",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Ashfield District Council",
+        "wiki_name": "Ashfield",
         "wiki_note": "Pass the house name/number and postcode in their respective parameters, both wrapped in double quotes. This parser requires a Selenium webdriver",
         "LAD24CD": "E07000170"
     },
@@ -86,7 +86,7 @@
         "url": "https://ashford.gov.uk",
         "web_driver": "http://selenium:4444",
         "wiki_command_url_override": "https://ashford.gov.uk",
-        "wiki_name": "Ashford Borough Council",
+        "wiki_name": "Ashford",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "E07000105"
     },
@@ -94,7 +94,7 @@
         "skip_get_url": true,
         "uprn": "766252532",
         "url": "http://avdcbins.web-labs.co.uk/RefuseApi.asmx",
-        "wiki_name": "Aylesbury Vale Council (Buckinghamshire)",
+        "wiki_name": "Buckinghamshire",
         "wiki_note": "To get the UPRN, please use [FindMyAddress](https://www.findmyaddress.co.uk/search). Returns all published collections in the past, present, future.",
         "LAD24CD": "E06000060"
     },
@@ -103,7 +103,7 @@
         "skip_get_url": true,
         "uprn": "100040810214",
         "url": "https://online.bcpcouncil.gov.uk/bindaylookup/",
-        "wiki_name": "BCP Council",
+        "wiki_name": "Bournemouth, Christchurch and Poole",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN."
     },
     "BaberghDistrictCouncil": {
@@ -112,7 +112,7 @@
         "skip_get_url": true,
         "uprn": "Tuesday",
         "url": "https://www.babergh.gov.uk",
-        "wiki_name": "Babergh District Council",
+        "wiki_name": "Babergh",
         "wiki_note": "Use the House Number field to pass the DAY of the week for your NORMAL collections. [Monday/Tuesday/Wednesday/Thursday/Friday]. [OPTIONAL] Use the 'postcode' field to pass the WEEK for your garden collection. [Week 1/Week 2]. [OPTIONAL] Use the 'uprn' field to pass the DAY for your garden collection. [Monday/Tuesday/Wednesday/Thursday/Friday]",
         "LAD24CD": "E07000200"
     },
@@ -122,7 +122,7 @@
         "skip_get_url": true,
         "web_driver": "http://selenium:4444",
         "url": "https://www.lbbd.gov.uk/rubbish-recycling/household-bin-collection/check-your-bin-collection-days",
-        "wiki_name": "BarkingDagenham",
+        "wiki_name": "Barking and Dagenham",
         "wiki_note": "Use the full address as it appears on the drop-down on the site when you search by postcode.",
         "LAD24CD": "E09000002"
     },
@@ -132,7 +132,7 @@
         "skip_get_url": true,
         "url": "https://www.barnet.gov.uk/recycling-and-waste/bin-collections/find-your-bin-collection-day",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Barnet Council",
+        "wiki_name": "Barnet",
         "wiki_note": "Follow the instructions [here](https://www.barnet.gov.uk/recycling-and-waste/bin-collections/find-your-bin-collection-day) until you get the page listing your address, then copy the entire address text and use that in the house number field. This parser requires a Selenium webdriver.",
         "LAD24CD": "E09000003"
     },
@@ -141,7 +141,7 @@
         "skip_get_url": true,
         "uprn": "2007004502",
         "url": "https://waste.barnsley.gov.uk/ViewCollection/Collections",
-        "wiki_name": "Barnsley Metropolitan Borough Council",
+        "wiki_name": "Barnsley",
         "wiki_note": "To get the UPRN, you will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E08000016"
     },
@@ -149,7 +149,7 @@
         "skip_get_url": true,
         "uprn": "10013350430",
         "url": "https://basildonportal.azurewebsites.net/api/getPropertyRefuseInformation",
-        "wiki_name": "Basildon Council",
+        "wiki_name": "Basildon",
         "wiki_note": "To get the UPRN, you will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E07000066"
     },
@@ -158,14 +158,14 @@
         "skip_get_url": true,
         "uprn": "100060220926",
         "url": "https://www.basingstoke.gov.uk/bincollection",
-        "wiki_name": "Basingstoke Council",
+        "wiki_name": "Basingstoke and Deane",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN."
     },
     "BathAndNorthEastSomersetCouncil": {
         "skip_get_url": true,
         "uprn": "100120000855",
         "url": "https://www.bathnes.gov.uk/webforms/waste/collectionday/",
-        "wiki_name": "Bath and North East Somerset Council",
+        "wiki_name": "Bath and North East Somerset",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "E06000022"
     },
@@ -173,7 +173,7 @@
         "skip_get_url": true,
         "uprn": "10024232065",
         "url": "https://www.bedford.gov.uk/bins-and-recycling/household-bins-and-recycling/check-your-bin-day",
-        "wiki_name": "Bedford Borough Council",
+        "wiki_name": "Bedford",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "E06000055"
     },
@@ -182,7 +182,7 @@
         "skip_get_url": true,
         "uprn": "10000802040",
         "url": "https://www.centralbedfordshire.gov.uk/info/163/bins_and_waste_collections_-_check_bin_collection_day",
-        "wiki_name": "Bedfordshire Council",
+        "wiki_name": "Central Bedfordshire",
         "wiki_note": "In order to use this parser, you must provide a valid postcode and a UPRN retrieved from the council's website for your specific address.",
         "LAD24CD": "E06000056"
     },
@@ -191,7 +191,7 @@
         "skip_get_url": true,
         "uprn": "185086469",
         "url": "https://online.belfastcity.gov.uk/find-bin-collection-day/Default.aspx",
-        "wiki_name": "Belfast City Council",
+        "wiki_name": "Belfast",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "N09000003"
     },
@@ -201,7 +201,7 @@
         "skip_get_url": true,
         "url": "https://waste.bexley.gov.uk/waste",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Bexley Council",
+        "wiki_name": "Bexley",
         "wiki_note": "In order to use this parser, you will need to sign up to [Bexley's @Home app](https://www.bexley.gov.uk/services/rubbish-and-recycling/bexley-home-recycling-app/about-app). Complete the setup by entering your email and setting your address with postcode and address line. Once you can see the calendar, you should be good to run the parser. Just pass the email you used in quotes in the UPRN parameter.",
         "LAD24CD": "E09000004"
     },
@@ -209,7 +209,7 @@
         "postcode": "B5 7XE",
         "uprn": "100070445256",
         "url": "https://www.birmingham.gov.uk/xfp/form/619",
-        "wiki_name": "Birmingham City Council",
+        "wiki_name": "Birmingham",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "E08000025"
     },
@@ -217,7 +217,7 @@
         "uprn": "100030401782",
         "url": "https://www.blaby.gov.uk",
         "wiki_command_url_override": "https://www.blaby.gov.uk",
-        "wiki_name": "Blaby District Council",
+        "wiki_name": "Blaby",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "E07000129"
     },
@@ -228,7 +228,7 @@
         "url": "https://mybins.blackburn.gov.uk/api/mybins/getbincollectiondays?uprn=100010733027&month=8&year=2022",
         "web_driver": "http://selenium:4444",
         "wiki_command_url_override": "https://www.blackburn.gov.uk",
-        "wiki_name": "Blackburn Council",
+        "wiki_name": "Blackburn with Darwen",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN."
     },
     "BlaenauGwentCountyBoroughCouncil": {
@@ -237,14 +237,14 @@
         "uprn": "100100471367",
         "url": "https://www.blaenau-gwent.gov.uk",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Blaenau Gwent County Borough Council",
+        "wiki_name": "Blaenau Gwent",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "W06000019"
     },
     "BolsoverCouncil": {
         "uprn": "100030066827",
         "url": "https://bolsover.gov.uk",
-        "wiki_name": "Bolsover Council",
+        "wiki_name": "Bolsover",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "E07000033"
     },
@@ -254,7 +254,7 @@
         "uprn": "100010886936",
         "url": "https://carehomes.bolton.gov.uk/bins.aspx",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Bolton Council",
+        "wiki_name": "Bolton",
         "wiki_note": "To get the UPRN, you will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search). Previously required a single field that was UPRN and full address; now requires UPRN and postcode as separate fields.",
         "LAD24CD": "E08000001"
     },
@@ -264,7 +264,7 @@
         "skip_get_url": true,
         "url": "https://www.boston.gov.uk/findwastecollections",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Boston Borough Council",
+        "wiki_name": "Boston",
         "wiki_note": "Provide your house number in the `house_number` parameter and postcode in the `postcode` parameter.",
         "LAD24CD": "E07000136"
     },
@@ -274,7 +274,7 @@
         "postcode": "GU47 9BS",
         "skip_get_url": true,
         "url": "https://selfservice.mybfc.bracknell-forest.gov.uk/w/webpage/waste-collection-days",
-        "wiki_name": "Bracknell Forest Council",
+        "wiki_name": "Bracknell Forest",
         "wiki_note": "Pass the house number and postcode in their respective parameters.",
         "LAD24CD": "E06000036"
     },
@@ -283,7 +283,7 @@
         "skip_get_url": true,
         "uprn": "100051146921",
         "url": "https://onlineforms.bradford.gov.uk/ufs/collectiondates.eb",
-        "wiki_name": "Bradford MDC",
+        "wiki_name": "Bradford",
         "wiki_note": "To get the UPRN, you will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search). Postcode isn't parsed by this script, but you can pass it in double quotes.",
         "LAD24CD": "E08000032"
     },
@@ -292,7 +292,7 @@
         "skip_get_url": true,
         "uprn": "10006930172",
         "url": "https://www.braintree.gov.uk/",
-        "wiki_name": "Braintree District Council",
+        "wiki_name": "Braintree",
         "wiki_note": "Provide your UPRN and postcode. Use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find your UPRN.",
         "LAD24CD": "E07000067"
     },
@@ -300,7 +300,7 @@
         "uprn": "100091495479",
         "url": "https://www.breckland.gov.uk",
         "wiki_command_url_override": "https://www.breckland.gov.uk",
-        "wiki_name": "Breckland Council",
+        "wiki_name": "Breckland",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "E07000143"
     },
@@ -308,7 +308,7 @@
         "house_number": "25",
         "postcode": "HA3 0QU",
         "url": "https://recyclingservices.brent.gov.uk/waste",
-        "wiki_name": "Brent Council",
+        "wiki_name": "Brent",
         "wiki_note": "Pass the house number and postcode in their respective parameters.",
         "LAD24CD": "E09000005"
     },
@@ -316,10 +316,9 @@
         "house_number": "44 Carden Avenue, Brighton, BN1 8NE",
         "postcode": "BN1 8NE",
         "skip_get_url": true,
-        "uprn": "22060199",
         "url": "https://cityclean.brighton-hove.gov.uk/link/collections",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Brighton and Hove City Council",
+        "wiki_name": "Brighton and Hove",
         "wiki_note": "Use the full address as it appears on the drop-down on the site when you search by postcode.",
         "LAD24CD": "E06000043"
     },
@@ -328,7 +327,7 @@
         "skip_get_url": true,
         "uprn": "116638",
         "url": "https://bristolcouncil.powerappsportals.com/completedynamicformunauth/?servicetypeid=7dce896c-b3ba-ea11-a812-000d3a7f1cdc",
-        "wiki_name": "Bristol City Council",
+        "wiki_name": "City of Bristol",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN."
     },
     "BroadlandDistrictCouncil": {
@@ -337,7 +336,7 @@
         "postcode": "NR10 3FD",
         "url": "https://area.southnorfolkandbroadland.gov.uk/FindAddress",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Broadland District Council",
+        "wiki_name": "Broadland",
         "wiki_note": "Use the full address as it appears on the drop-down on the site when you search by postcode.",
         "LAD24CD": "E07000144"
     },
@@ -345,7 +344,7 @@
         "url": "https://recyclingservices.bromley.gov.uk/waste/6087017",
         "web_driver": "http://selenium:4444",
         "wiki_command_url_override": "https://recyclingservices.bromley.gov.uk/waste/XXXXXXX",
-        "wiki_name": "Bromley Borough Council",
+        "wiki_name": "Bromley",
         "wiki_note": "Follow the instructions [here](https://recyclingservices.bromley.gov.uk/waste) until the \"Your bin days\" page then copy the URL and replace the URL in the command.",
         "LAD24CD": "E09000006"
     },
@@ -353,7 +352,7 @@
         "uprn": "100120584652",
         "url": "https://www.bromsgrove.gov.uk",
         "wiki_command_url_override": "https://www.bromsgrove.gov.uk",
-        "wiki_name": "Bromsgrove District Council",
+        "wiki_name": "Bromsgrove",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "E07000234"
     },
@@ -361,7 +360,7 @@
         "postcode": "EN8 7FL",
         "uprn": "148048608",
         "url": "https://www.broxbourne.gov.uk",
-        "wiki_name": "Broxbourne Council",
+        "wiki_name": "Broxbourne",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "E07000095"
     },
@@ -371,7 +370,7 @@
         "uprn": "100031325997",
         "url": "https://www.broxtowe.gov.uk/",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Broxtowe Borough Council",
+        "wiki_name": "Broxtowe",
         "wiki_note": "Pass the UPRN and postcode. To get the UPRN, you can use [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E07000172"
     },
@@ -381,14 +380,14 @@
         "skip_get_url": true,
         "url": "https://iapp.itouchvision.com/iappcollectionday/collection-day/?uuid=FA353FC74600CBE61BE409534D00A8EC09BDA3AC&lang=en",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Buckinghamshire Council (Chiltern, South Bucks, Wycombe)",
+        "wiki_name": "Buckinghamshire",
         "wiki_note": "Pass the house name/number and postcode in their respective arguments, both wrapped in quotes.",
         "LAD24CD": "E06000060"
     },
     "BurnleyBoroughCouncil": {
         "uprn": "100010347165",
         "url": "https://www.burnley.gov.uk",
-        "wiki_name": "Burnley Borough Council",
+        "wiki_name": "Burnley",
         "wiki_note": "Pass the UPRN. You can find it using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E07000117"
     },
@@ -397,7 +396,7 @@
         "postcode": "M26 3XY",
         "skip_get_url": true,
         "url": "https://www.bury.gov.uk/waste-and-recycling/bin-collection-days-and-alerts",
-        "wiki_name": "Bury Council",
+        "wiki_name": "Bury",
         "wiki_note": "Pass the postcode and house number in their respective arguments, both wrapped in quotes.",
         "LAD24CD": "E08000002"
     },
@@ -407,14 +406,14 @@
         "uprn": "010035034598",
         "url": "https://www.calderdale.gov.uk/environment/waste/household-collections/collectiondayfinder.jsp",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Calderdale Council",
+        "wiki_name": "Calderdale",
         "wiki_note": "Pass the UPRN and postcode. To get the UPRN, you can use [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E08000033"
     },
     "CambridgeCityCouncil": {
         "uprn": "200004159750",
         "url": "https://www.cambridge.gov.uk/",
-        "wiki_name": "Cambridge City Council",
+        "wiki_name": "Cambridge",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "E07000008"
     },
@@ -423,7 +422,7 @@
         "skip_get_url": true,
         "uprn": "200003095389",
         "url": "https://www.cannockchasedc.gov.uk/",
-        "wiki_name": "Cannock Chase District Council",
+        "wiki_name": "Cannock Chase",
         "wiki_note": "To get the UPRN, you can use [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E07000192"
     },
@@ -431,7 +430,7 @@
         "uprn": "10094583181",
         "url": "https://www.canterbury.gov.uk",
         "wiki_command_url_override": "https://www.canterbury.gov.uk",
-        "wiki_name": "Canterbury City Council",
+        "wiki_name": "Canterbury",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "E07000106"
     },
@@ -439,7 +438,7 @@
         "skip_get_url": true,
         "uprn": "100100112419",
         "url": "https://www.gov.uk",
-        "wiki_name": "Cardiff Council",
+        "wiki_name": "Cardiff",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "W06000015"
     },
@@ -447,7 +446,7 @@
         "uprn": "10004859302",
         "url": "https://www.carmarthenshire.gov.wales",
         "wiki_command_url_override": "https://www.carmarthenshire.gov.wales",
-        "wiki_name": "Carmarthenshire County Council",
+        "wiki_name": "Carmarthenshire",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "W06000010"
     },
@@ -455,7 +454,7 @@
         "skip_get_url": true,
         "uprn": "4525",
         "url": "https://apps.castlepoint.gov.uk/cpapps/index.cfm?fa=wastecalendar",
-        "wiki_name": "Castlepoint District Council",
+        "wiki_name": "Castle Point",
         "wiki_note": "For this council, 'uprn' is actually a 4-digit code for your street. Go [here](https://apps.castlepoint.gov.uk/cpapps/index.cfm?fa=wastecalendar) and inspect the source of the dropdown box to find the 4-digit number for your street.",
         "LAD24CD": "E07000069"
     },
@@ -464,14 +463,14 @@
         "postcode": "SY23 4RQ",
         "url": "https://www.ceredigion.gov.uk/resident/bins-recycling/",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Ceredigion County Council",
+        "wiki_name": "Ceredigion",
         "wiki_note": "House Number is the full address as it appears on the drop-down on the site when you search by postcode. This parser requires a Selenium webdriver.",
         "LAD24CD": "W06000008"
     },
     "CharnwoodBoroughCouncil": {
         "url": "https://my.charnwood.gov.uk/location?put=cbc10070067259&rememberme=0&redirect=%2F",
         "wiki_command_url_override": "https://my.charnwood.gov.uk/location?put=cbcXXXXXXXX&rememberme=0&redirect=%2F",
-        "wiki_name": "Charnwood Borough Council",
+        "wiki_name": "Charnwood",
         "wiki_note": "Replace XXXXXXXX with your UPRN, keeping \"cbc\" before it.",
         "LAD24CD": "E07000130"
     },
@@ -480,7 +479,7 @@
         "postcode": "CM3 7AE",
         "url": "https://www.chelmsford.gov.uk/myhome/",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Chelmsford City Council",
+        "wiki_name": "Chelmsford",
         "wiki_note": "Follow the instructions [here](https://www.chelmsford.gov.uk/myhome/) until you get the page listing your address, then copy the entire address text and use that in the house number field.",
         "LAD24CD": "E07000070"
     },
@@ -489,21 +488,21 @@
         "skip_get_url": true,
         "uprn": "100120372027",
         "url": "https://www.cheltenham.gov.uk",
-        "wiki_name": "Cheltenham Borough Council",
+        "wiki_name": "Cheltenham",
         "wiki_note": "Pass the UPRN. You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E07000078"
     },
     "CherwellDistrictCouncil": {
         "uprn": "100121292407",
         "url": "https://www.cherwell.gov.uk",
-        "wiki_name": "Cherwell District Council",
+        "wiki_name": "Cherwell",
         "wiki_note": "Use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find your UPRN.",
         "LAD24CD": "E07000177"
     },
     "CheshireEastCouncil": {
         "url": "https://online.cheshireeast.gov.uk/MyCollectionDay/SearchByAjax/GetBartecJobList?uprn=100012791226&onelineaddress=3%20COBBLERS%20YARD,%20SK9%207DZ&_=1689413260149",
         "wiki_command_url_override": "https://online.cheshireeast.gov.uk/MyCollectionDay/SearchByAjax/GetBartecJobList?uprn=XXXXXXXX&onelineaddress=XXXXXXXX&_=1689413260149",
-        "wiki_name": "Cheshire East Council",
+        "wiki_name": "Cheshire East",
         "wiki_note": "Both the UPRN and a one-line address are passed in the URL, which needs to be wrapped in double quotes. The one-line address is made up of the house number, street name, and postcode. Use the form [here](https://online.cheshireeast.gov.uk/mycollectionday/) to find them, then take the first line and postcode and replace all spaces with `%20`.",
         "LAD24CD": "E06000049"
     },
@@ -511,7 +510,7 @@
         "skip_get_url": true,
         "uprn": "100012346655",
         "url": "https://my.cheshirewestandchester.gov.uk",
-        "wiki_name": "Cheshire West and Chester Council",
+        "wiki_name": "Cheshire West and Chester",
         "wiki_note": "Pass the UPRN. You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E06000050"
     },
@@ -519,7 +518,7 @@
         "skip_get_url": true,
         "uprn": "74008234",
         "url": "https://www.chesterfield.gov.uk",
-        "wiki_name": "Chesterfield Borough Council",
+        "wiki_name": "Chesterfield",
         "wiki_note": "Pass the UPRN. You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E07000034"
     },
@@ -529,7 +528,7 @@
         "skip_get_url": true,
         "url": "https://www.chichester.gov.uk/checkyourbinday",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Chichester District Council",
+        "wiki_name": "Chichester",
         "wiki_note": "Needs the full address and postcode as it appears on [this page](https://www.chichester.gov.uk/checkyourbinday).",
         "LAD24CD": "E07000225"
     },
@@ -539,7 +538,7 @@
         "uprn": "UPRN100010382247",
         "url": "https://myaccount.chorley.gov.uk/wastecollections.aspx",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Chorley Council",
+        "wiki_name": "Chorley",
         "wiki_note": "Chorley needs to be passed both a Postcode & UPRN in the format of UPRNXXXXXX to work. Find this on [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E07000118"
     },
@@ -550,14 +549,14 @@
         "skip_get_url": false,
         "url": "https://www.colchester.gov.uk/your-recycling-calendar",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Colchester City Council",
+        "wiki_name": "Colchester",
         "wiki_note": "Pass the house name/number in the house number parameter, wrapped in double quotes.",
         "LAD24CD": "E07000071"
     },
     "ConwyCountyBorough": {
         "uprn": "100100429249",
         "url": "https://www.conwy.gov.uk",
-        "wiki_name": "Conwy County Borough Council",
+        "wiki_name": "Conwy",
         "wiki_note": "Use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find your UPRN.",
         "LAD24CD": "W06000003"
     },
@@ -565,14 +564,14 @@
         "LAD24CD": "E07000028",
         "uprn": "100110734613",
         "url": "https://www.copeland.gov.uk",
-        "wiki_name": "Copeland Borough Council",
+        "wiki_name": "Copeland",
         "wiki_note": "*****This has now been replaced by Cumberland Council****"
     },
     "CornwallCouncil": {
         "skip_get_url": true,
         "uprn": "100040128734",
         "url": "https://www.cornwall.gov.uk/my-area/",
-        "wiki_name": "Cornwall Council",
+        "wiki_name": "Cornwall",
         "wiki_note": "Use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find your UPRN.",
         "LAD24CD": "E06000052"
     },
@@ -582,14 +581,14 @@
         "skip_get_url": true,
         "url": "https://community.cotswold.gov.uk/s/waste-collection-enquiry",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Cotswold District Council",
+        "wiki_name": "Cotswold",
         "wiki_note": "Pass the full address in the house number and postcode in",
         "LAD24CD": "E07000079"
     },
     "CoventryCityCouncil": {
         "url": "https://www.coventry.gov.uk/directory-record/62310/abberton-way-",
         "wiki_command_url_override": "https://www.coventry.gov.uk/directory_record/XXXXXX/XXXXXX",
-        "wiki_name": "Coventry City Council",
+        "wiki_name": "Coventry",
         "wiki_note": "Follow the instructions [here](https://www.coventry.gov.uk/bin-collection-calendar) until you get the page that shows the weekly collections for your address then copy the URL and replace the URL in the command.",
         "LAD24CD": "E08000026"
     },
@@ -598,7 +597,7 @@
         "skip_get_url": true,
         "uprn": "100061785321",
         "url": "https://my.crawley.gov.uk/",
-        "wiki_name": "Crawley Borough Council",
+        "wiki_name": "Crawley",
         "wiki_note": "Crawley needs to be passed both a UPRN and a USRN to work. Find these on [FindMyAddress](https://www.findmyaddress.co.uk/search) or [FindMyStreet](https://www.findmystreet.co.uk/map).",
         "LAD24CD": "E07000226"
     },
@@ -607,7 +606,7 @@
         "postcode": "SE25 5DW",
         "skip_get_url": true,
         "url": "https://service.croydon.gov.uk/wasteservices/w/webpage/bin-day-enter-address",
-        "wiki_name": "Croydon Council",
+        "wiki_name": "Croydon",
         "wiki_note": "Pass the house number and postcode in their respective parameters.",
         "LAD24CD": "E09000008"
     },
@@ -615,14 +614,14 @@
         "house_number": "2",
         "postcode": "CA13 0DE",
         "url": "https://www.allerdale.gov.uk",
-        "wiki_name": "Cumberland Council - Allerdale District",
+        "wiki_name": "Cumberland",
         "wiki_note": "Pass the house number and postcode in their respective parameters.",
         "LAD24CD": "E06000063"
     },
     "CumberlandCouncil": {
         "uprn": "100110734613",
         "url": "https://waste.cumberland.gov.uk",
-        "wiki_name": "Cumberland Borough Council",
+        "wiki_name": "Cumberland",
         "wiki_note": "Use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find your UPRN.",
         "LAD24CD": "E06000063"
     },
@@ -632,28 +631,28 @@
         "skip_get_url": true,
         "url": "https://webapps.dacorum.gov.uk/bincollections/",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Dacorum Borough Council",
+        "wiki_name": "Dacorum",
         "wiki_note": "Pass the house number and postcode in their respective parameters. This parser requires a Selenium webdriver.",
         "LAD24CD": "E07000096"
     },
     "DartfordBoroughCouncil": {
         "uprn": "010094157511",
         "url": "https://windmz.dartford.gov.uk/ufs/WS_CHECK_COLLECTIONS.eb?UPRN=010094157511",
-        "wiki_name": "Dartford Borough Council",
+        "wiki_name": "Dartford",
         "wiki_note": "Use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find your UPRN.",
         "LAD24CD": "E07000107"
     },
     "DenbighshireCouncil": {
         "uprn": "200004299351",
         "url": "https://www.denbighshire.gov.uk/",
-        "wiki_name": "Denbighshire Council",
+        "wiki_name": "Denbighshire",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "W06000004"
     },
     "DerbyCityCouncil": {
         "uprn": "10010684240",
         "url": "https://www.derby.gov.uk",
-        "wiki_name": "Derby City Council",
+        "wiki_name": "Derby",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "E06000015"
     },
@@ -662,7 +661,7 @@
         "skip_get_url": true,
         "uprn": "10070102161",
         "url": "https://www.derbyshiredales.gov.uk/",
-        "wiki_name": "Derbyshire Dales District Council",
+        "wiki_name": "Derbyshire Dales",
         "wiki_note": "Pass the UPRN and postcode. To get the UPRN, you can use [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E07000035"
     },
@@ -670,7 +669,7 @@
         "skip_get_url": true,
         "uprn": "100050768956",
         "url": "https://www.doncaster.gov.uk/Compass/Entity/Launch/D3/",
-        "wiki_name": "Doncaster Council",
+        "wiki_name": "Doncaster",
         "wiki_note": "Pass the UPRN. You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E08000017"
     },
@@ -685,7 +684,7 @@
     "DoverDistrictCouncil": {
         "url": "https://collections.dover.gov.uk/property/100060908340",
         "wiki_command_url_override": "https://collections.dover.gov.uk/property/XXXXXXXXXXX",
-        "wiki_name": "Dover District Council",
+        "wiki_name": "Dover",
         "wiki_note": "Replace XXXXXXXXXXX with your UPRN. To get the UPRN, you can use [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E07000108"
     },
@@ -693,14 +692,14 @@
         "uprn": "90014244",
         "url": "https://my.dudley.gov.uk",
         "wiki_command_url_override": "https://my.dudley.gov.uk",
-        "wiki_name": "Dudley Council",
+        "wiki_name": "Dudley",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "E08000027"
     },
     "DundeeCityCouncil": {
         "uprn": "9059043390",
         "url": "https://www.dundeecity.gov.uk/",
-        "wiki_name": "Dundee City Council",
+        "wiki_name": "Dundee City",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "S12000042"
     },
@@ -709,14 +708,14 @@
         "skip_get_url": true,
         "uprn": "200003218818",
         "url": "https://www.durham.gov.uk/bincollections?uprn=",
-        "wiki_name": "Durham Council",
+        "wiki_name": "County Durham",
         "wiki_note": "Pass the UPRN. You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search)."
     },
     "EalingCouncil": {
         "skip_get_url": true,
         "uprn": "12073883",
         "url": "https://www.ealing.gov.uk/site/custom_scripts/WasteCollectionWS/home/FindCollection",
-        "wiki_name": "Ealing Council",
+        "wiki_name": "Ealing",
         "wiki_note": "Pass the UPRN. You can find it using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E09000009"
     },
@@ -724,7 +723,7 @@
         "uprn": "127074727",
         "url": "https://www.east-ayrshire.gov.uk",
         "wiki_command_url_override": "https://www.east-ayrshire.gov.uk",
-        "wiki_name": "East Ayrshire Council",
+        "wiki_name": "East Ayrshire",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "S12000008"
     },
@@ -732,14 +731,14 @@
         "skip_get_url": true,
         "uprn": "10002597178",
         "url": "https://www.eastcambs.gov.uk/",
-        "wiki_name": "East Cambridgeshire Council",
+        "wiki_name": "East Cambridgeshire",
         "wiki_note": "Pass the UPRN. You can find it using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E07000009"
     },
     "EastDevonDC": {
         "url": "https://eastdevon.gov.uk/recycling-and-waste/recycling-waste-information/when-is-my-bin-collected/future-collections-calendar/?UPRN=010090909915",
         "wiki_command_url_override": "https://eastdevon.gov.uk/recycling-and-waste/recycling-waste-information/when-is-my-bin-collected/future-collections-calendar/?UPRN=XXXXXXXX",
-        "wiki_name": "East Devon District Council",
+        "wiki_name": "East Devon",
         "wiki_note": "Replace XXXXXXXX with your UPRN.",
         "LAD24CD": "E07000040"
     },
@@ -759,7 +758,7 @@
         "skip_get_url": true,
         "url": "https://www.e-lindsey.gov.uk/",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "East Lindsey District Council",
+        "wiki_name": "East Lindsey",
         "wiki_note": "Pass the house name/number and postcode in their respective parameters. This parser requires a Selenium webdriver.",
         "LAD24CD": "E07000137"
     },
@@ -768,7 +767,7 @@
         "postcode": "EH21 6QA",
         "skip_get_url": true,
         "url": "https://eastlothian.gov.uk",
-        "wiki_name": "East Lothian Council",
+        "wiki_name": "East Lothian",
         "wiki_note": "Pass the house number and postcode in their respective parameters",
         "LAD24CD": "S12000010"
     },
@@ -778,7 +777,7 @@
         "skip_get_url": true,
         "url": "https://eastrenfrewshire.gov.uk/",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "East Renfrewshire Council",
+        "wiki_name": "East Renfrewshire",
         "wiki_note": "Pass the house name/number and postcode in their respective parameters. This parser requires a Selenium webdriver.",
         "LAD24CD": "S12000011"
     },
@@ -789,13 +788,13 @@
         "skip_get_url": true,
         "url": "https://wasterecyclingapi.eastriding.gov.uk",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "East Riding Council",
+        "wiki_name": "East Riding of Yorkshire",
         "wiki_note": "Put the full address as it displays on the council website dropdown when you do the check manually."
     },
     "EastStaffordshireBoroughCouncil": {
         "url": "https://www.eaststaffsbc.gov.uk/bins-rubbish-recycling/collection-dates/68382",
         "wiki_command_url_override": "https://www.eaststaffsbc.gov.uk/bins-rubbish-recycling/collection-dates/XXXXX",
-        "wiki_name": "East Staffordshire Borough Council",
+        "wiki_name": "East Staffordshire",
         "wiki_note": "Replace `XXXXX` with your property's ID when selecting from https://www.eaststaffsbc.gov.uk/bins-rubbish-recycling/collection-dates.",
         "LAD24CD": "E07000193"
     },
@@ -805,7 +804,7 @@
         "uprn": "10093544720",
         "url": "https://my.eastsuffolk.gov.uk/service/Bin_collection_dates_finder",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "East Suffolk Council",
+        "wiki_name": "East Suffolk",
         "wiki_note": "To get the UPRN, you can use [FindMyAddress](https://www.findmyaddress.co.uk/search). This parser requires a Selenium webdriver.",
         "LAD24CD": "E07000244"
     },
@@ -813,7 +812,7 @@
         "skip_get_url": true,
         "uprn": "100060303535",
         "url": "https://www.eastleigh.gov.uk/waste-bins-and-recycling/collection-dates/your-waste-bin-and-recycling-collections?uprn=",
-        "wiki_name": "Eastleigh Borough Council",
+        "wiki_name": "Eastleigh",
         "wiki_note": "Pass the UPRN. You can find it using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E07000086"
     },
@@ -823,14 +822,14 @@
         "postcode": "Week 1",
         "skip_get_url": true,
         "url": "https://www.edinburgh.gov.uk",
-        "wiki_name": "Edinburgh City Council",
+        "wiki_name": "City of Edinburgh",
         "wiki_note": "Use the House Number field to pass the DAY of the week for your collections. Monday/Tuesday/Wednesday/Thursday/Friday. Use the 'postcode' field to pass the WEEK for your collection. [Week 1/Week 2]"
     },
     "ElmbridgeBoroughCouncil": {
         "uprn": "10013119164",
         "url": "https://www.elmbridge.gov.uk",
         "wiki_command_url_override": "https://www.elmbridge.gov.uk",
-        "wiki_name": "Elmbridge Borough Council",
+        "wiki_name": "Elmbridge",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "E07000207"
     },
@@ -840,7 +839,7 @@
         "skip_get_url": true,
         "url": "https://www.enfield.gov.uk/services/rubbish-and-recycling/find-my-collection-day",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Enfield Council",
+        "wiki_name": "Enfield",
         "wiki_note": "Pass the house number and postcode in their respective parameters. This parser requires a Selenium webdriver.",
         "LAD24CD": "E09000010"
     },
@@ -854,14 +853,14 @@
         "postcode": "IG9 6EP",
         "url": "https://eppingforestdc.maps.arcgis.com/apps/instant/lookup/index.html?appid=bfca32b46e2a47cd9c0a84f2d8cdde17&find=IG9%206EP",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Epping Forest District Council",
+        "wiki_name": "Epping Forest",
         "wiki_note": "Replace the postcode in the URL with your own.",
         "LAD24CD": "E07000072"
     },
     "EpsomandEwellBoroughCouncil": {
         "uprn": "100061349083",
         "url": "https://www.epsom-ewell.gov.uk",
-        "wiki_name": "Epsom and Ewell Borough Council",
+        "wiki_name": "Epsom and Ewell",
         "wiki_note": "Use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find your UPRN.",
         "LAD24CD": "E07000208"
     },
@@ -869,14 +868,14 @@
         "skip_get_url": true,
         "uprn": "10003582028",
         "url": "https://map.erewash.gov.uk/isharelive.web/myerewash.aspx",
-        "wiki_name": "Erewash Borough Council",
+        "wiki_name": "Erewash",
         "wiki_note": "Pass the UPRN. You can find it using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E07000036"
     },
     "ExeterCityCouncil": {
         "uprn": "100040212270",
         "url": "https://www.exeter.gov.uk",
-        "wiki_name": "Exeter City Council",
+        "wiki_name": "Exeter",
         "wiki_note": "Pass the UPRN. You can find it using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E07000041"
     },
@@ -884,7 +883,7 @@
         "uprn": "136065818",
         "url": "https://www.falkirk.gov.uk",
         "wiki_command_url_override": "https://www.falkirk.gov.uk",
-        "wiki_name": "Falkirk Council",
+        "wiki_name": "Falkirk",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "S12000014"
     },
@@ -892,7 +891,7 @@
         "postcode": "PO14 4NR",
         "skip_get_url": true,
         "url": "https://www.fareham.gov.uk/internetlookups/search_data.aspx?type=JSON&list=DomesticBinCollections&Road=&Postcode=PO14%204NR",
-        "wiki_name": "Fareham Borough Council",
+        "wiki_name": "Fareham",
         "wiki_note": "Pass the postcode in the postcode parameter, wrapped in double quotes.",
         "LAD24CD": "E07000087"
     },
@@ -900,7 +899,7 @@
         "skip_get_url": true,
         "uprn": "200002981143",
         "url": "https://www.fenland.gov.uk/article/13114/",
-        "wiki_name": "Fenland District Council",
+        "wiki_name": "Fenland",
         "wiki_note": "Pass the UPRN. You can find it using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E07000010"
     },
@@ -908,7 +907,7 @@
         "uprn": "320203521",
         "url": "https://www.fife.gov.uk",
         "wiki_command_url_override": "https://www.fife.gov.uk",
-        "wiki_name": "Fife Council",
+        "wiki_name": "Fife",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "S12000047"
     },
@@ -916,7 +915,7 @@
         "uprn": "100100213710",
         "url": "https://digital.flintshire.gov.uk",
         "wiki_command_url_override": "https://digital.flintshire.gov.uk",
-        "wiki_name": "Flintshire County Council",
+        "wiki_name": "Flintshire",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "W06000005"
     },
@@ -925,7 +924,7 @@
         "skip_get_url": true,
         "uprn": "50032097",
         "url": "https://www.folkestone-hythe.gov.uk",
-        "wiki_name": "Folkstone and Hythe District Council",
+        "wiki_name": "Folkestone and Hythe",
         "wiki_note": "Use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find your UPRN."
     },
     "ForestOfDeanDistrictCouncil": {
@@ -934,7 +933,7 @@
         "skip_get_url": true,
         "url": "https://community.fdean.gov.uk/s/waste-collection-enquiry",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Forest of Dean District Council",
+        "wiki_name": "Forest of Dean",
         "wiki_note": "Pass the full address in the house number and postcode parameters. This parser requires a Selenium webdriver.",
         "LAD24CD": "E07000080"
     },
@@ -942,7 +941,7 @@
         "uprn": "100010402452",
         "url": "https://www.fylde.gov.uk",
         "wiki_command_url_override": "https://www.fylde.gov.uk",
-        "wiki_name": "Fylde Council",
+        "wiki_name": "Fylde",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "E07000119"
     },
@@ -952,7 +951,7 @@
         "skip_get_url": true,
         "url": "https://www.gateshead.gov.uk/",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Gateshead Council",
+        "wiki_name": "Gateshead",
         "wiki_note": "Pass the house name/number and postcode in their respective parameters. This parser requires a Selenium webdriver.",
         "LAD24CD": "E08000037"
     },
@@ -960,14 +959,14 @@
         "house_number": "Friday G4, Friday J",
         "skip_get_url": true,
         "url": "https://www.gedling.gov.uk/",
-        "wiki_name": "Gedling Borough Council",
+        "wiki_name": "Gedling",
         "wiki_note": "Use [this site](https://www.gbcbincalendars.co.uk/) to find the collections for your address. Use the `-n` parameter to add them in a comma-separated list inside quotes, such as: 'Friday G4, Friday J'.",
         "LAD24CD": "E07000173"
     },
     "GlasgowCityCouncil": {
         "url": "https://onlineservices.glasgow.gov.uk/forms/RefuseAndRecyclingWebApplication/CollectionsCalendar.aspx?UPRN=906700034497",
         "wiki_command_url_override": "https://onlineservices.glasgow.gov.uk/forms/RefuseAndRecyclingWebApplication/CollectionsCalendar.aspx?UPRN=XXXXXXXX",
-        "wiki_name": "Glasgow City Council",
+        "wiki_name": "Glasgow City",
         "wiki_note": "Replace XXXXXXXX with your UPRN.",
         "LAD24CD": "S12000049"
     },
@@ -978,7 +977,7 @@
         "uprn": "100120479507",
         "url": "https://gloucester-self.achieveservice.com/service/Bins___Check_your_bin_day",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Gloucester City Council",
+        "wiki_name": "Gloucester",
         "wiki_note": "Pass the house number, postcode, and UPRN in their respective parameters. This parser requires a Selenium webdriver.",
         "LAD24CD": "E07000081"
     },
@@ -1023,7 +1022,7 @@
         "skip_get_url": true,
         "uprn": "100060927046",
         "url": "https://www.gravesham.gov.uk",
-        "wiki_name": "Gravesham Borough Council",
+        "wiki_name": "Gravesham",
         "wiki_note": "Pass the UPRN. You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E07000109"
     },
@@ -1033,7 +1032,7 @@
         "uprn": "100090834792",
         "url": "https://myaccount.great-yarmouth.gov.uk/article/6456/Find-my-waste-collection-days",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Great Yarmouth Borough Council",
+        "wiki_name": "Great Yarmouth",
         "wiki_note": "Pass the postcode, and UPRN in their respective parameters. This parser requires a Selenium webdriver.",
         "LAD24CD": "E07000145"
     },
@@ -1044,14 +1043,14 @@
         "uprn": "100061372691",
         "url": "https://my.guildford.gov.uk/customers/s/view-bin-collections",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Guildford Council",
+        "wiki_name": "Guildford",
         "wiki_note": "If the bin day is 'today' then the collectionDate will only show today's date if before 7 AM; else the date will be in 'previousCollectionDate'. To get the UPRN, you will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E07000209"
     },
     "GwyneddCouncil": {
         "uprn": "10070350463",
         "url": "https://diogel.gwynedd.llyw.cymru",
-        "wiki_name": "Gwynedd Council",
+        "wiki_name": "Gwynedd",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "W06000002"
     },
@@ -1059,7 +1058,7 @@
         "house_number": "101",
         "postcode": "N16 9AS",
         "url": "https://www.hackney.gov.uk",
-        "wiki_name": "Hackney Council",
+        "wiki_name": "Hackney",
         "wiki_note": "Pass the postcode and house number in their respective arguments, both wrapped in quotes.",
         "LAD24CD": "E09000012"
     },
@@ -1069,7 +1068,7 @@
         "skip_get_url": true,
         "url": "https://webapp.halton.gov.uk/PublicWebForms/WasteServiceSearchv1.aspx#collections",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Halton Borough Council",
+        "wiki_name": "Halton",
         "wiki_note": "Pass the house number and postcode. This parser requires a Selenium webdriver.",
         "LAD24CD": "E06000006"
     },
@@ -1077,7 +1076,7 @@
         "uprn": "100030489072",
         "url": "https://www.harborough.gov.uk",
         "wiki_command_url_override": "https://www.harborough.gov.uk",
-        "wiki_name": "Harborough District Council",
+        "wiki_name": "Harborough",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "E07000131"
     },
@@ -1085,7 +1084,7 @@
         "skip_get_url": true,
         "uprn": "100021203052",
         "url": "https://wastecollections.haringey.gov.uk/property",
-        "wiki_name": "Haringey Council",
+        "wiki_name": "Haringey",
         "wiki_note": "Pass the UPRN, which can be found at `https://wastecollections.haringey.gov.uk/property/{uprn}`.",
         "LAD24CD": "E09000014"
     },
@@ -1094,21 +1093,21 @@
         "skip_get_url": true,
         "uprn": "100050414307",
         "url": "https://secure.harrogate.gov.uk/inmyarea",
-        "wiki_name": "Harrogate Borough Council",
+        "wiki_name": "Harrogate",
         "wiki_note": "Pass the UPRN, which can be found at [this site](https://secure.harrogate.gov.uk/inmyarea). URL doesn't need to be passed."
     },
     "HartDistrictCouncil": {
         "skip_get_url": true,
         "uprn": "100062349291",
         "url": "https://www.hart.gov.uk/",
-        "wiki_name": "Hart District Council",
+        "wiki_name": "Hart",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "E07000089"
     },
     "HartlepoolBoroughCouncil": {
         "uprn": "100110019551",
         "url": "https://www.hartlepool.gov.uk",
-        "wiki_name": "Hartlepool Borough Council",
+        "wiki_name": "Hartlepool",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find your UPRN.",
         "LAD24CD": "E06000001"
     },
@@ -1116,14 +1115,14 @@
         "uprn": "100060038877",
         "url": "https://www.hastings.gov.uk",
         "wiki_command_url_override": "https://www.hastings.gov.uk",
-        "wiki_name": "Hastings Borough Council",
+        "wiki_name": "Hastings",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "E07000062"
     },
     "HerefordshireCouncil": {
         "url": "https://www.herefordshire.gov.uk/rubbish-recycling/check-bin-collection-day?blpu_uprn=10096232662",
         "wiki_command_url_override": "https://www.herefordshire.gov.uk/rubbish-recycling/check-bin-collection-day?blpu_uprn=XXXXXXXXXXXX",
-        "wiki_name": "Herefordshire Council",
+        "wiki_name": "Herefordshire",
         "wiki_note": "Replace 'XXXXXXXXXX' with your property's UPRN. You can find it using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E06000019"
     },
@@ -1133,7 +1132,7 @@
         "skip_get_url": true,
         "url": "https://www.hertsmere.gov.uk",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Hertsmere Borough Council",
+        "wiki_name": "Hertsmere",
         "wiki_note": "Provide your house number in the `house_number` parameter and postcode in the `postcode` parameter.",
         "LAD24CD": "E07000098"
     },
@@ -1143,7 +1142,7 @@
         "skip_get_url": true,
         "url": "https://www.highpeak.gov.uk/findyourbinday",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "High Peak Council",
+        "wiki_name": "High Peak",
         "wiki_note": "Pass the name of the street with the house number parameter, wrapped in double quotes. This parser requires a Selenium webdriver.",
         "LAD24CD": "E07000037"
     },
@@ -1151,7 +1150,7 @@
         "uprn": "130072429",
         "url": "https://www.highland.gov.uk",
         "wiki_command_url_override": "https://www.highland.gov.uk",
-        "wiki_name": "Highland Council",
+        "wiki_name": "Highland",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "S12000017"
     },
@@ -1161,13 +1160,14 @@
         "skip_get_url": true,
         "url": "https://www.hillingdon.gov.uk/collection-day",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "High Peak Council",
-        "wiki_note": "Pass the postcode and the full address as it appears in the address pulldown menu."
+        "wiki_name": "Hillingdon",
+        "wiki_note": "Pass the postcode and the full address as it appears in the address pulldown menu.",
+        "LAD24CD": "E09000017"
     },
     "HinckleyandBosworthBoroughCouncil": {
         "uprn": "100030533512",
         "url": "https://www.hinckley-bosworth.gov.uk",
-        "wiki_name": "Hinckley and Bosworth Borough Council",
+        "wiki_name": "Hinckley and Bosworth",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "E07000132"
     },
@@ -1178,7 +1178,7 @@
         "uprn": "010013792717",
         "url": "https://www.horsham.gov.uk/waste-recycling-and-bins/household-bin-collections/check-your-bin-collection-day",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Horsham District Council",
+        "wiki_name": "Horsham",
         "wiki_note": "Pass the UPRN. You can find it using [FindMyAddress](https://www.findmyaddress.co.uk/search). This parser requires a Selenium webdriver."
     },
     "HullCityCouncil": {
@@ -1186,20 +1186,20 @@
         "skip_get_url": true,
         "uprn": "21033995",
         "url": "https://www.hull.gov.uk/bins-and-recycling/bin-collections/bin-collection-day-checker",
-        "wiki_name": "Hull City Council",
+        "wiki_name": "Kingston upon Hull",
         "wiki_note": "Pass the UPRN. You can find it using [FindMyAddress](https://www.findmyaddress.co.uk/search)."
     },
     "HuntingdonDistrictCouncil": {
         "LAD24CD": "E07000011",
         "url": "http://www.huntingdonshire.gov.uk/refuse-calendar/10012048679",
         "wiki_command_url_override": "https://www.huntingdonshire.gov.uk/refuse-calendar/XXXXXXXX",
-        "wiki_name": "Huntingdon District Council",
+        "wiki_name": "Huntingdonshire",
         "wiki_note": "Replace XXXXXXXX with your UPRN."
     },
     "IpswichBoroughCouncil": {
         "house_number": "Siloam Place",
         "url": "https://app.ipswich.gov.uk/bin-collection/",
-        "wiki_name": "Ipswich Borough Council",
+        "wiki_name": "Ipswich",
         "wiki_note": "Provide only the street name (no house number) as the PAON",
         "LAD24CD": "E07000202"
     },
@@ -1207,14 +1207,14 @@
         "uprn": "5300094897",
         "url": "https://www.islington.gov.uk/your-area?Postcode=unused&Uprn=5300094897",
         "wiki_command_url_override": "https://www.islington.gov.uk/your-area?Postcode=unused&Uprn=XXXXXXXX",
-        "wiki_name": "Islington Council",
+        "wiki_name": "Islington",
         "wiki_note": "Replace XXXXXXXX with your UPRN.",
         "LAD24CD": "E09000019"
     },
     "KingsLynnandWestNorfolkBC": {
         "uprn": "10023636886",
         "url": "https://www.west-norfolk.gov.uk/",
-        "wiki_name": "Kings Lynn and West Norfolk Borough Council",
+        "wiki_name": "Kings Lynn and West Norfolk",
         "wiki_note": "Provide your UPRN. Find your UPRN using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E07000146"
     },
@@ -1222,7 +1222,7 @@
         "url": "https://waste-services.kingston.gov.uk/waste/2701097",
         "web_driver": "http://selenium:4444",
         "wiki_command_url_override": "https://waste-services.kingston.gov.uk/waste/XXXXXXX",
-        "wiki_name": "Kingston Upon Thames Council",
+        "wiki_name": "Kingston upon Thames",
         "wiki_note": "Follow the instructions [here](https://waste-services.kingston.gov.uk/waste) until the \"Your bin days\" page, then copy the URL and replace the URL in the command.",
         "LAD24CD": "E09000021"
     },
@@ -1230,7 +1230,7 @@
         "skip_get_url": true,
         "uprn": "83002937",
         "url": "https://www.kirklees.gov.uk/beta/your-property-bins-recycling/your-bins",
-        "wiki_name": "Kirklees Council",
+        "wiki_name": "Kirklees",
         "wiki_note": "Provide your UPRN. Find your UPRN using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E08000034"
     },
@@ -1240,7 +1240,7 @@
         "skip_get_url": true,
         "url": "https://knowsleytransaction.mendixcloud.com/link/youarebeingredirected?target=bincollectioninformation",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Knowsley Metropolitan Borough Council",
+        "wiki_name": "Knowsley",
         "wiki_note": "Pass the postcode in the postcode parameter, wrapped in double quotes and with a space.",
         "LAD24CD": "E08000011"
     },
@@ -1249,7 +1249,7 @@
         "postcode": "LA1 1RS",
         "skip_get_url": true,
         "url": "https://lcc-wrp.whitespacews.com",
-        "wiki_name": "Lancaster City Council",
+        "wiki_name": "Lancaster",
         "wiki_note": "Pass the house number and postcode in their respective parameters.",
         "LAD24CD": "E07000121"
     },
@@ -1260,14 +1260,14 @@
         "uprn": "72506983",
         "url": "https://www.leeds.gov.uk/residents/bins-and-recycling/check-your-bin-day",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Leeds City Council",
+        "wiki_name": "Leeds",
         "wiki_note": "Pass the house number, postcode, and UPRN. This parser requires a Selenium webdriver.",
         "LAD24CD": "E08000035"
     },
     "LeicesterCityCouncil": {
         "uprn": "2465027976",
         "url": "https://biffaleicester.co.uk",
-        "wiki_name": "Leicester City Council",
+        "wiki_name": "Leicester",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "E06000016"
     },
@@ -1275,7 +1275,7 @@
         "uprn": "100031694085",
         "url": "https://www.lichfielddc.gov.uk",
         "wiki_command_url_override": "https://www.lichfielddc.gov.uk",
-        "wiki_name": "Lichfield District Council",
+        "wiki_name": "Lichfield",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "E07000194"
     },
@@ -1284,7 +1284,7 @@
         "uprn": "000235024846",
         "url": "https://lincoln.gov.uk",
         "wiki_command_url_override": "https://lincoln.gov.uk",
-        "wiki_name": "Lincoln Council",
+        "wiki_name": "City of Lincoln",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "E07000138"
     },
@@ -1293,14 +1293,14 @@
         "postcode": "BT28 1JN",
         "skip_get_url": true,
         "url": "https://lisburn.isl-fusion.com",
-        "wiki_name": "Lisburn and Castlereagh City Council",
+        "wiki_name": "Lisburn and Castlereagh",
         "wiki_note": "Pass the house number and postcode in their respective parameters.",
         "LAD24CD": "N09000007"
     },
     "LiverpoolCityCouncil": {
         "url": "https://liverpool.gov.uk/Bins/BinDatesTable?UPRN=38164600",
         "wiki_command_url_override": "https://liverpool.gov.uk/Bins/BinDatesTable?UPRN=XXXXXXXX",
-        "wiki_name": "Liverpool City Council",
+        "wiki_name": "Liverpool",
         "wiki_note": "Replace XXXXXXXX with your property's UPRN.",
         "LAD24CD": "E08000012"
     },
@@ -1308,7 +1308,7 @@
         "skip_get_url": true,
         "uprn": "12081498",
         "url": "https://www.ealing.gov.uk/site/custom_scripts/WasteCollectionWS/home/FindCollection",
-        "wiki_name": "London Borough Ealing",
+        "wiki_name": "Ealing",
         "wiki_note": "Pass the UPRN. You can find it using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E09000009"
     },
@@ -1316,14 +1316,14 @@
         "uprn": "100021298754",
         "url": "https://www.harrow.gov.uk",
         "wiki_command_url_override": "https://www.harrow.gov.uk",
-        "wiki_name": "London Borough Harrow",
+        "wiki_name": "Harrow",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "E09000015"
     },
     "LondonBoroughHavering": {
         "uprn": "100021380730",
         "url": "https://www.havering.gov.uk",
-        "wiki_name": "London Borough Havering",
+        "wiki_name": "Havering",
         "wiki_note": "Pass the UPRN. You can find it using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E09000016"
     },
@@ -1331,7 +1331,7 @@
         "skip_get_url": true,
         "uprn": "100021577765",
         "url": "https://www.hounslow.gov.uk/homepage/86/recycling_and_waste_collection_day_finder",
-        "wiki_name": "Hounslow Council",
+        "wiki_name": "Hounslow",
         "wiki_note": "Pass the UPRN. You can find it using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E09000018"
     },
@@ -1339,7 +1339,7 @@
         "skip_get_url": true,
         "uprn": "100021881738",
         "url": "https://wasteservice.lambeth.gov.uk/WhitespaceComms/GetServicesByUprn",
-        "wiki_name": "London Borough Lambeth",
+        "wiki_name": "Lambeth",
         "wiki_note": "Pass the UPRN. You can find it using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E09000022"
     },
@@ -1349,7 +1349,7 @@
         "uprn": "100021954849",
         "url": "https://www.lewisham.gov.uk",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "London Borough Lewisham",
+        "wiki_name": "Lewisham",
         "wiki_note": "Pass the UPRN and postcode. To get the UPRN, you can use [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E09000023"
     },
@@ -1358,7 +1358,7 @@
         "skip_get_url": true,
         "url": "https://www.richmond.gov.uk/services/waste_and_recycling/collection_days/",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "London Borough Of Richmond Upon Thames",
+        "wiki_name": "Richmond upon Thames",
         "wiki_note": "Pass the name of the street ONLY in the house number parameter, unfortunately post code's are not allowed. ",
         "LAD24CD": "E09000027"
     },
@@ -1367,7 +1367,7 @@
         "uprn": "10023770353",
         "url": "https://my.redbridge.gov.uk/RecycleRefuse",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "London Borough Redbridge",
+        "wiki_name": "Redbridge",
         "wiki_note": "Follow the instructions [here](https://my.redbridge.gov.uk/RecycleRefuse) until you get the page listing your address, then copy the entire address text and use that in the house number field.",
         "LAD24CD": "E09000026"
     },
@@ -1375,7 +1375,7 @@
         "uprn": "4473006",
         "url": "https://waste-services.sutton.gov.uk/waste",
         "wiki_command_url_override": "https://waste-services.sutton.gov.uk/waste",
-        "wiki_name": "London Borough Sutton",
+        "wiki_name": "Sutton",
         "wiki_note": "You will need to find your unique property reference by going to (https://waste-services.sutton.gov.uk/waste), entering your details and then using the 7 digit reference in the URL as your UPRN",
         "LAD24CD": "E09000029"
     },
@@ -1383,7 +1383,7 @@
         "uprn": "100080155778",
         "url": "https://myforms.luton.gov.uk",
         "wiki_command_url_override": "https://myforms.luton.gov.uk",
-        "wiki_name": "Luton Borough Council",
+        "wiki_name": "Luton",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "E06000032"
     },
@@ -1391,7 +1391,7 @@
         "skip_get_url": true,
         "uprn": "100090557253",
         "url": "https://maldon.suez.co.uk/maldon/ServiceSummary",
-        "wiki_name": "Maldon District Council",
+        "wiki_name": "Maldon",
         "wiki_note": "Pass the UPRN. You can find it using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E07000074"
     },
@@ -1399,7 +1399,7 @@
         "skip_get_url": true,
         "uprn": "100121348457",
         "url": "https://swict.malvernhills.gov.uk/mhdcroundlookup/HandleSearchScreen",
-        "wiki_name": "Malvern Hills District Council",
+        "wiki_name": "Malvern Hills",
         "wiki_note": "Pass the UPRN. You can find it using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E07000235"
     },
@@ -1407,7 +1407,7 @@
         "skip_get_url": true,
         "uprn": "77127089",
         "url": "https://www.manchester.gov.uk/bincollections",
-        "wiki_name": "Manchester City Council",
+        "wiki_name": "Manchester",
         "wiki_note": "Pass the UPRN. You can find it using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E08000003"
     },
@@ -1415,7 +1415,7 @@
         "skip_get_url": true,
         "uprn": "100031396580",
         "url": "https://www.mansfield.gov.uk/xfp/form/1327",
-        "wiki_name": "Mansfield District Council",
+        "wiki_name": "Mansfield",
         "wiki_note": "Pass the UPRN. You can find it using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E07000174"
     },
@@ -1423,14 +1423,14 @@
         "skip_get_url": true,
         "uprn": "200000907059",
         "url": "https://www.medway.gov.uk/homepage/45/check_your_waste_collection_day",
-        "wiki_name": "MedwayCouncil",
+        "wiki_name": "Medway",
         "wiki_note": "Pass the UPRN. You can find it using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E06000035"
     },
     "MertonCouncil": {
         "url": "https://myneighbourhood.merton.gov.uk/wasteservices/WasteServices.aspx?ID=25936129",
         "wiki_command_url_override": "https://myneighbourhood.merton.gov.uk/Wasteservices/WasteServices.aspx?ID=XXXXXXXX",
-        "wiki_name": "Merton Council",
+        "wiki_name": "Merton",
         "wiki_note": "Follow the instructions [here](https://myneighbourhood.merton.gov.uk/Wasteservices/WasteServicesSearch.aspx) until you get the \"Your recycling and rubbish collection days\" page, then copy the URL and replace the URL in the command.",
         "LAD24CD": "E09000024"
     },
@@ -1439,7 +1439,7 @@
         "skip_get_url": true,
         "url": "https://www.midandeastantrim.gov.uk/resident/waste-recycling/collection-dates/",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Mid and East Antrim Borough Council",
+        "wiki_name": "Mid and East Antrim",
         "wiki_note": "Pass the house name/number plus the name of the street with the postcode parameter, wrapped in double quotes. Check the address on the website first. This version will only pick the first SHOW button returned by the search or if it is fully unique.",
         "LAD24CD": "N09000008"
     },
@@ -1447,7 +1447,7 @@
         "uprn": "200003997770",
         "url": "https://www.middevon.gov.uk",
         "wiki_command_url_override": "https://www.middevon.gov.uk",
-        "wiki_name": "Mid Devon Council",
+        "wiki_name": "Mid Devon",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "E07000042"
     },
@@ -1457,7 +1457,7 @@
         "skip_get_url": true,
         "uprn": "Monday",
         "url": "https://www.midsuffolk.gov.uk",
-        "wiki_name": "Mid Suffolk District Council",
+        "wiki_name": "Mid Suffolk",
         "wiki_note": "Use the House Number field to pass the DAY of the week for your NORMAL collections. [Monday/Tuesday/Wednesday/Thursday/Friday]. [OPTIONAL] Use the 'postcode' field to pass the WEEK for your garden collection. [Week 1/Week 2]. [OPTIONAL] Use the 'uprn' field to pass the DAY for your garden collection. [Monday/Tuesday/Wednesday/Thursday/Friday]",
         "LAD24CD": "E07000203"
     },
@@ -1467,7 +1467,7 @@
         "skip_get_url": true,
         "url": "https://www.midsussex.gov.uk/waste-recycling/bin-collection/",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Mid Sussex District Council",
+        "wiki_name": "Mid Sussex",
         "wiki_note": "Pass the name of the street with the house number parameter, wrapped in double quotes. This parser requires a Selenium webdriver.",
         "LAD24CD": "E07000228"
     },
@@ -1476,7 +1476,7 @@
         "skip_get_url": true,
         "url": "https://www.midsussex.gov.uk/waste-recycling/bin-collection/",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Middlesbrough Council",
+        "wiki_name": "Middlesbrough",
         "wiki_note": "Pass the entire address without postcode as it appears when you type it on the website. This parser requires a Selenium webdriver.",
         "LAD24CD": "E06000002"
     },
@@ -1485,7 +1485,7 @@
         "postcode": "EH19 2EB",
         "skip_get_url": true,
         "url": "https://www.midlothian.gov.uk/info/1054/bins_and_recycling/343/bin_collection_days",
-        "wiki_name": "Midlothian Council",
+        "wiki_name": "Midlothian",
         "wiki_note": "Pass the house name/number wrapped in double quotes along with the postcode parameter.",
         "LAD24CD": "S12000019"
     },
@@ -1495,14 +1495,14 @@
         "skip_get_url": true,
         "url": "https://www.midulstercouncil.org",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Mid Ulster District Council",
+        "wiki_name": "Mid Ulster",
         "wiki_note": "Pass the full address of the house postcode as displayed on the site. This parser requires a Selenium webdriver.",
         "LAD24CD": "N09000009"
     },
     "MiltonKeynesCityCouncil": {
         "uprn": "25109551",
         "url": "https://mycouncil.milton-keynes.gov.uk/en/service/Waste_Collection_Round_Checker",
-        "wiki_name": "Milton Keynes City Council",
+        "wiki_name": "Milton Keynes",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "E06000042"
     },
@@ -1511,21 +1511,21 @@
         "skip_get_url": true,
         "uprn": "200000171235",
         "url": "https://myproperty.molevalley.gov.uk/molevalley/",
-        "wiki_name": "Mole Valley District Council",
+        "wiki_name": "Mole Valley",
         "wiki_note": "UPRN can only be parsed with a valid postcode.",
         "LAD24CD": "E07000210"
     },
     "MonmouthshireCountyCouncil": {
         "uprn": "100100266220",
         "url": "https://maps.monmouthshire.gov.uk",
-        "wiki_name": "Monmouthshire County Council",
+        "wiki_name": "Monmouthshire",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "W06000021"
     },
     "MorayCouncil": {
         "uprn": "28841",
         "url": "https://bindayfinder.moray.gov.uk/",
-        "wiki_name": "Moray Council",
+        "wiki_name": "Moray",
         "wiki_note": "Find your property ID by going to (https://bindayfinder.moray.gov.uk), search for your property and extracting the ID from the URL. i.e. (https://bindayfinder.moray.gov.uk/disp_bins.php?id=00028841)",
         "LAD24CD": "S12000020"
     },
@@ -1535,7 +1535,7 @@
         "skip_get_url": true,
         "url": "https://www.npt.gov.uk",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Neath Port Talbot Council",
+        "wiki_name": "Neath Port Talbot",
         "wiki_note": "Pass the house number and postcode in their respective parameters. This parser requires a Selenium webdriver.",
         "LAD24CD": "W06000012"
     },
@@ -1545,14 +1545,14 @@
         "uprn": "100060482345",
         "url": "https://forms.newforest.gov.uk/id/FIND_MY_COLLECTION",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "New Forest Council",
+        "wiki_name": "New Forest",
         "wiki_note": "Pass the postcode and UPRN. This parser requires a Selenium webdriver.",
         "LAD24CD": "E07000091"
     },
     "NewarkAndSherwoodDC": {
         "url": "http://app.newark-sherwooddc.gov.uk/bincollection/calendar?pid=200004258529",
         "wiki_command_url_override": "http://app.newark-sherwooddc.gov.uk/bincollection/calendar?pid=XXXXXXXX",
-        "wiki_name": "Newark and Sherwood District Council",
+        "wiki_name": "Newark and Sherwood",
         "wiki_note": "Replace XXXXXXXX with your UPRN.",
         "LAD24CD": "E07000175"
     },
@@ -1560,20 +1560,20 @@
         "LAD24CD": "E08000021",
         "url": "https://community.newcastle.gov.uk/my-neighbourhood/ajax/getBinsNew.php?uprn=004510730634",
         "wiki_command_url_override": "https://community.newcastle.gov.uk/my-neighbourhood/ajax/getBinsNew.php?uprn=XXXXXXXX",
-        "wiki_name": "Newcastle City Council",
+        "wiki_name": "Newcastle upon Tyne",
         "wiki_note": "Replace XXXXXXXX with your UPRN. UPRNs need to be 12 digits long so please pad the left hand side with 0s if your UPRN is not long enough"
     },
     "NewcastleUnderLymeCouncil": {
         "uprn": "100031725433",
         "url": "https://www.newcastle-staffs.gov.uk",
-        "wiki_name": "Newcastle Under Lyme Council",
+        "wiki_name": "Newcastle-under-Lyme",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find your UPRN.",
         "LAD24CD": "E07000195"
     },
     "NewhamCouncil": {
         "url": "https://bincollection.newham.gov.uk/Details/Index/000046002133",
         "wiki_command_url_override": "https://bincollection.newham.gov.uk/Details/Index/XXXXXXXXXXX",
-        "wiki_name": "Newham Council",
+        "wiki_name": "Newham",
         "wiki_note": "Follow the instructions [here](https://bincollection.newham.gov.uk/) until you get the \"Rubbish and Recycling Collections\" page, then copy the URL and replace the URL in the command.",
         "LAD24CD": "E09000025"
     },
@@ -1582,7 +1582,7 @@
         "skip_get_url": true,
         "uprn": "100100688837",
         "url": "https://www.newport.gov.uk/",
-        "wiki_name": "Newport City Council",
+        "wiki_name": "Newport",
         "wiki_note": "Pass the postcode and UPRN. You can find the UPRN using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "W06000022"
     },
@@ -1590,7 +1590,7 @@
         "uprn": "126045552",
         "url": "https://www.north-ayrshire.gov.uk/",
         "wiki_command_url_override": "https://www.north-ayrshire.gov.uk/",
-        "wiki_name": "North Ayrshire Council",
+        "wiki_name": "North Ayrshire",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "S12000021"
     },
@@ -1601,7 +1601,7 @@
         "uprn": "100040249471",
         "url": "https://my.northdevon.gov.uk/service/WasteRecyclingCollectionCalendar",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "North Devon County Council",
+        "wiki_name": "North Devon",
         "wiki_note": "Pass the house number and postcode in their respective parameters. This parser requires a Selenium webdriver.",
         "LAD24CD": "E07000043"
     },
@@ -1611,7 +1611,7 @@
         "uprn": "010034492221",
         "url": "https://myselfservice.ne-derbyshire.gov.uk/service/Check_your_Bin_Day",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "North East Derbyshire District Council",
+        "wiki_name": "North East Derbyshire",
         "wiki_note": "Pass the postcode and UPRN. This parser requires a Selenium webdriver.",
         "LAD24CD": "E07000038"
     },
@@ -1619,7 +1619,7 @@
         "uprn": "11062649",
         "url": "https://www.nelincs.gov.uk/refuse-collection-schedule/?view=timeline&uprn=11062649",
         "wiki_command_url_override": "https://www.nelincs.gov.uk/refuse-collection-schedule/?view=timeline&uprn=XXXXXXXX",
-        "wiki_name": "North East Lincolnshire Council",
+        "wiki_name": "North East Lincolnshire",
         "wiki_note": "Replace XXXXXXXX with your UPRN.",
         "LAD24CD": "E06000012"
     },
@@ -1627,21 +1627,21 @@
         "house_number": "2",
         "postcode": "SG6 4BJ",
         "url": "https://www.north-herts.gov.uk",
-        "wiki_name": "North Hertfordshire District Council",
+        "wiki_name": "North Hertfordshire",
         "wiki_note": "Pass the house number and postcode in their respective parameters.",
         "LAD24CD": "E07000099"
     },
     "NorthKestevenDistrictCouncil": {
         "url": "https://www.n-kesteven.org.uk/bins/display?uprn=100030869513",
         "wiki_command_url_override": "https://www.n-kesteven.org.uk/bins/display?uprn=XXXXXXXX",
-        "wiki_name": "North Kesteven District Council",
+        "wiki_name": "North Kesteven",
         "wiki_note": "Replace XXXXXXXX with your UPRN.",
         "LAD24CD": "E07000139"
     },
     "NorthLanarkshireCouncil": {
         "url": "https://www.northlanarkshire.gov.uk/bin-collection-dates/000118016164/48402118",
         "wiki_command_url_override": "https://www.northlanarkshire.gov.uk/bin-collection-dates/XXXXXXXXXXX/XXXXXXXXXXX",
-        "wiki_name": "North Lanarkshire Council",
+        "wiki_name": "North Lanarkshire",
         "wiki_note": "Follow the instructions [here](https://www.northlanarkshire.gov.uk/bin-collection-dates) until you get the \"Next collections\" page, then copy the URL and replace the URL in the command.",
         "LAD24CD": "S12000050"
     },
@@ -1649,7 +1649,7 @@
         "skip_get_url": true,
         "uprn": "100050194170",
         "url": "https://www.northlincs.gov.uk/bins-waste-and-recycling/bin-and-box-collection-dates/",
-        "wiki_name": "North Lincolnshire Council",
+        "wiki_name": "North Lincolnshire",
         "wiki_note": "Pass the UPRN. You can find it using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E06000013"
     },
@@ -1659,7 +1659,7 @@
         "skip_get_url": true,
         "url": "https://www.north-norfolk.gov.uk/",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "North Norfolk District Council",
+        "wiki_name": "North Norfolk",
         "wiki_note": "Pass the name of the street with the house number parameter, wrapped in double quotes. This parser requires a Selenium webdriver.",
         "LAD24CD": "E07000147"
     },
@@ -1667,7 +1667,7 @@
         "skip_get_url": true,
         "uprn": "100031021317",
         "url": "https://cms.northnorthants.gov.uk/bin-collection-search/calendarevents/100031021318/2023-10-17/2023-10-01",
-        "wiki_name": "North Northamptonshire Council",
+        "wiki_name": "North Northamptonshire",
         "wiki_note": "Pass the UPRN. You can find it using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E06000061"
     },
@@ -1676,7 +1676,7 @@
         "skip_get_url": true,
         "uprn": "24051674",
         "url": "https://forms.n-somerset.gov.uk/Waste/CollectionSchedule",
-        "wiki_name": "North Somerset Council",
+        "wiki_name": "North Somerset",
         "wiki_note": "Pass the postcode and UPRN. You can find the UPRN using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E06000024"
     },
@@ -1685,7 +1685,7 @@
         "skip_get_url": true,
         "uprn": "47097627",
         "url": "https://my.northtyneside.gov.uk/category/81/bin-collection-dates",
-        "wiki_name": "North Tyneside Council",
+        "wiki_name": "North Tyneside",
         "wiki_note": "Pass the postcode and UPRN. You can find the UPRN using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E08000022"
     },
@@ -1695,7 +1695,7 @@
         "uprn": "100030572613",
         "url": "https://www.nwleics.gov.uk/pages/collection_information",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "North West Leicestershire Council",
+        "wiki_name": "North West Leicestershire",
         "wiki_note": "Pass the postcode and UPRN. This parser requires a Selenium webdriver.",
         "LAD24CD": "E07000134"
     },
@@ -1703,7 +1703,7 @@
         "skip_get_url": true,
         "uprn": "10093091235",
         "url": "https://www.northyorks.gov.uk/bin-calendar/lookup",
-        "wiki_name": "North Yorkshire Council",
+        "wiki_name": "North Yorkshire",
         "wiki_note": "Pass the UPRN. You can find it using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E06000065"
     },
@@ -1713,7 +1713,7 @@
         "skip_get_url": true,
         "url": "https://www.northumberland.gov.uk/Waste/Household-waste/Household-bin-collections/Bin-Calendars.aspx",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Northumberland Council",
+        "wiki_name": "Northumberland",
         "wiki_note": "Pass the house number and postcode in their respective parameters. This parser requires a Selenium webdriver.",
         "LAD24CD": "E06000057"
     },
@@ -1721,7 +1721,7 @@
         "uprn": "100090888980",
         "url": "https://www.norwich.gov.uk",
         "wiki_command_url_override": "https://www.norwich.gov.uk",
-        "wiki_name": "Norwich City Council",
+        "wiki_name": "Norwich",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "E07000148"
     },
@@ -1729,7 +1729,7 @@
         "skip_get_url": true,
         "uprn": "100031540180",
         "url": "https://geoserver.nottinghamcity.gov.uk/bincollections2/api/collection/100031540180",
-        "wiki_name": "Nottingham City Council",
+        "wiki_name": "Nottingham",
         "wiki_note": "Pass the UPRN. You can find it using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E06000018"
     },
@@ -1737,7 +1737,7 @@
         "house_number": "Newdigate Road",
         "skip_get_url": true,
         "url": "https://www.nuneatonandbedworth.gov.uk",
-        "wiki_name": "Nuneaton and Bedworth Borough Council",
+        "wiki_name": "Nuneaton and Bedworth",
         "wiki_note": "Pass the name of the street ONLY in the house number parameter, wrapped in double quotes. Street name must match exactly as it appears on the council's website.",
         "LAD24CD": "E07000219"
     },
@@ -1745,12 +1745,12 @@
         "LAD24CD": "E07000135",
         "uprn": "10010149102",
         "url": "https://my.oadby-wigston.gov.uk",
-        "wiki_name": "Oadby & Wigston Borough Council",
+        "wiki_name": "Oadby and Wigston",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN."
     },
     "OldhamCouncil": {
         "url": "https://portal.oldham.gov.uk/bincollectiondates/details?uprn=422000033556",
-        "wiki_name": "Oldham Council",
+        "wiki_name": "Oldham",
         "wiki_note": "Replace UPRN in URL with your own UPRN.",
         "LAD24CD": "E08000004"
     },
@@ -1759,7 +1759,7 @@
         "uprn": "100120820551",
         "url": "https://www.oxford.gov.uk",
         "wiki_command_url_override": "https://www.oxford.gov.uk",
-        "wiki_name": "Oxford City Council",
+        "wiki_name": "Oxford",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "E07000178"
     },
@@ -1769,7 +1769,7 @@
         "skip_get_url": true,
         "url": "https://report.peterborough.gov.uk/waste",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Peterborough City Council",
+        "wiki_name": "Peterborough",
         "wiki_note": "Pass the full address as it appears o nthe Peterborough website and postcode in their respective parameters. This parser requires a Selenium webdriver.",
         "LAD24CD": "E06000031"
     },
@@ -1777,7 +1777,7 @@
         "uprn": "124032322",
         "url": "https://www.pkc.gov.uk",
         "wiki_command_url_override": "https://www.pkc.gov.uk",
-        "wiki_name": "Perth and Kinross Council",
+        "wiki_name": "Perth and Kinross",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "S12000048"
     },
@@ -1785,7 +1785,7 @@
         "uprn": "100040420582",
         "url": "https://www.plymouth.gov.uk",
         "wiki_command_url_override": "https://www.plymouth.gov.uk",
-        "wiki_name": "Plymouth Council",
+        "wiki_name": "Plymouth",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "E06000026"
     },
@@ -1795,7 +1795,7 @@
         "uprn": "1775027504",
         "url": "https://my.portsmouth.gov.uk/en/AchieveForms/?form_uri=sandbox-publish://AF-Process-26e27e70-f771-47b1-a34d-af276075cede/AF-Stage-cd7cc291-2e59-42cc-8c3f-1f93e132a2c9/definition.json&redirectlink=%2F&cancelRedirectLink=%2F",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Portsmouth City Council",
+        "wiki_name": "Portsmouth",
         "wiki_note": "Pass the postcode and UPRN. This parser requires a Selenium webdriver.",
         "LAD24CD": "E06000044"
     },
@@ -1805,7 +1805,7 @@
         "skip_get_url": true,
         "url": "https://www.powys.gov.uk",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Powys Council",
+        "wiki_name": "Powys",
         "LAD24CD": "W06000023"
     },
     "PrestonCityCouncil": {
@@ -1814,14 +1814,14 @@
         "skip_get_url": true,
         "url": "https://selfservice.preston.gov.uk/service/Forms/FindMyNearest.aspx?Service=bins",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Preston City Council",
+        "wiki_name": "Preston",
         "wiki_note": "Pass the house number and postcode in their respective parameters. This parser requires a Selenium webdriver.",
         "LAD24CD": "E07000123"
     },
     "ReadingBoroughCouncil": {
         "url": "https://api.reading.gov.uk/api/collections/310056735",
         "wiki_command_url_override": "https://api.reading.gov.uk/api/collections/XXXXXXXX",
-        "wiki_name": "Reading Borough Council",
+        "wiki_name": "Reading",
         "wiki_note": "Replace XXXXXXXX with your property's UPRN.",
         "LAD24CD": "E06000038"
     },
@@ -1830,7 +1830,7 @@
         "postcode": "TS10 2RE",
         "skip_get_url": true,
         "url": "https://www.redcar-cleveland.gov.uk",
-        "wiki_name": "Redcar and Cleveland Council",
+        "wiki_name": "Redcar and Cleveland",
         "wiki_note": "Pass the house name/number and postcode in their respective parameters",
         "LAD24CD": "E06000003"
     },
@@ -1838,7 +1838,7 @@
         "uprn": "10094557691",
         "url": "https://redditchbc.gov.uk",
         "wiki_command_url_override": "https://redditchbc.gov.uk",
-        "wiki_name": "Redditch Borough Council",
+        "wiki_name": "Redditch",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "E07000236"
     },
@@ -1847,7 +1847,7 @@
         "uprn": "68134867",
         "url": "https://www.reigate-banstead.gov.uk/",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Reigate and Banstead Borough Council",
+        "wiki_name": "Reigate and Banstead",
         "wiki_note": "To get the UPRN, you can use [FindMyAddress](https://www.findmyaddress.co.uk/search). This parser requires a Selenium webdriver.",
         "LAD24CD": "E07000211"
     },
@@ -1858,7 +1858,7 @@
         "skip_get_url": true,
         "url": "https://www.renfrewshire.gov.uk/bin-day",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Renfrewshire Council",
+        "wiki_name": "Renfrewshire",
         "wiki_note": "Pass the full address as it appears on the website. This parser requires a Selenium webdriver.",
         "LAD24CD": "S12000038"
     },
@@ -1866,7 +1866,7 @@
         "skip_get_url": true,
         "uprn": "100100778320",
         "url": "https://www.rctcbc.gov.uk/EN/Resident/RecyclingandWaste/RecyclingandWasteCollectionDays.aspx",
-        "wiki_name": "Rhondda Cynon Taff Council",
+        "wiki_name": "Rhondda Cynon Taff",
         "wiki_note": "To get the UPRN, you can use [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "W06000016"
     },
@@ -1875,20 +1875,20 @@
         "skip_get_url": true,
         "uprn": "23049922",
         "url": "https://webforms.rochdale.gov.uk/BinCalendar",
-        "wiki_name": "Rochdale Council",
+        "wiki_name": "Rochdale",
         "wiki_note": "Provide your UPRN and postcode. You can find your UPRN using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E08000005"
     },
     "RochfordCouncil": {
         "url": "https://www.rochford.gov.uk/online-bin-collections-calendar",
-        "wiki_name": "Rochford Council",
+        "wiki_name": "Rochford",
         "wiki_note": "No extra parameters are required. Dates presented should be read as 'week commencing'.",
         "LAD24CD": "E07000075"
     },
     "RotherDistrictCouncil": {
         "uprn": "100061937338",
         "url": "https://www.rother.gov.uk",
-        "wiki_name": "Rother District Council",
+        "wiki_name": "Rother",
         "wiki_note": "Use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find your UPRN.",
         "LAD24CD": "E07000064"
     },
@@ -1896,7 +1896,7 @@
         "uprn": "100050866000",
         "url": "https://www.rotherham.gov.uk/bin-collections?address=100050866000&submit=Submit",
         "wiki_command_url_override": "https://www.rotherham.gov.uk/bin-collections?address=XXXXXXXXX&submit=Submit",
-        "wiki_name": "Rotherham Council",
+        "wiki_name": "Rotherham",
         "wiki_note": "Replace `XXXXXXXXX` with your UPRN in the URL. You can find your UPRN using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E08000018"
     },
@@ -1905,7 +1905,7 @@
         "postcode": "BR7 6DN",
         "skip_get_url": true,
         "url": "https://www.royalgreenwich.gov.uk",
-        "wiki_name": "Royal Borough of Greenwich",
+        "wiki_name": "Greenwich",
         "wiki_note": "Provide your house number in the `house_number` parameter and your postcode in the `postcode` parameter.",
         "LAD24CD": "E09000011"
     },
@@ -1914,7 +1914,7 @@
         "skip_get_url": true,
         "uprn": "100070182634",
         "url": "https://www.rugby.gov.uk/check-your-next-bin-day",
-        "wiki_name": "Rugby Borough Council",
+        "wiki_name": "Rugby",
         "wiki_note": "Provide your UPRN and postcode. You can find your UPRN using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E07000220"
     },
@@ -1922,7 +1922,7 @@
         "skip_get_url": true,
         "uprn": "100061483636",
         "url": "https://www.runnymede.gov.uk/",
-        "wiki_name": "Runnymede Borough Council",
+        "wiki_name": "Runnymede",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "E07000212"
     },
@@ -1932,14 +1932,14 @@
         "uprn": "3040040994",
         "url": "https://www.rushcliffe.gov.uk/",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Rushcliffe Borough Council",
+        "wiki_name": "Rushcliffe",
         "wiki_note": "Provide your UPRN and postcode. Use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find your UPRN.",
         "LAD24CD": "E07000176"
     },
     "RushmoorCouncil": {
         "url": "https://www.rushmoor.gov.uk/Umbraco/Api/BinLookUpWorkAround/Get?selectedAddress=100060545034",
         "wiki_command_url_override": "https://www.rushmoor.gov.uk/Umbraco/Api/BinLookUpWorkAround/Get?selectedAddress=XXXXXXXXXX",
-        "wiki_name": "Rushmoor Council",
+        "wiki_name": "Rushmoor",
         "wiki_note": "Replace `XXXXXXXXXX` with your UPRN, which you can find using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E07000092"
     },
@@ -1947,7 +1947,7 @@
         "skip_get_url": true,
         "uprn": "100011416709",
         "url": "https://www.salford.gov.uk/bins-and-recycling/bin-collection-days/your-bin-collections",
-        "wiki_name": "Salford City Council",
+        "wiki_name": "Salford",
         "wiki_note": "Provide your UPRN. You can find it using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E08000006"
     },
@@ -1955,7 +1955,7 @@
         "skip_get_url": true,
         "uprn": "32101971",
         "url": "https://www.sandwell.gov.uk",
-        "wiki_name": "Sandwell Borough Council",
+        "wiki_name": "Sandwell",
         "wiki_note": "Pass the UPRN. You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E08000028"
     },
@@ -1963,7 +1963,7 @@
         "house_number": "1",
         "postcode": "L20 6GG",
         "url": "https://www.sefton.gov.uk",
-        "wiki_name": "Sefton Council",
+        "wiki_name": "Sefton",
         "wiki_note": "Pass the postcode and house number in their respective arguments, both wrapped in quotes.",
         "LAD24CD": "E08000014"
     },
@@ -1973,28 +1973,28 @@
         "skip_get_url": true,
         "url": "https://sevenoaks-dc-host01.oncreate.app/w/webpage/waste-collection-day",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Sevenoaks District Council",
+        "wiki_name": "Sevenoaks",
         "wiki_note": "Pass the house name/number in the `house_number` parameter, wrapped in double quotes, and the postcode in the `postcode` parameter.",
         "LAD24CD": "E07000111"
     },
     "SheffieldCityCouncil": {
         "url": "https://wasteservices.sheffield.gov.uk/property/100050931898",
         "wiki_command_url_override": "https://wasteservices.sheffield.gov.uk/property/XXXXXXXXXXX",
-        "wiki_name": "Sheffield City Council",
+        "wiki_name": "Sheffield",
         "wiki_note": "Follow the instructions [here](https://wasteservices.sheffield.gov.uk/) until you get the 'Your bin collection dates and services' page, then copy the URL and replace the URL in the command.",
         "LAD24CD": "E08000019"
     },
     "ShropshireCouncil": {
         "url": "https://bins.shropshire.gov.uk/property/100070034731",
         "wiki_command_url_override": "https://bins.shropshire.gov.uk/property/XXXXXXXXXXX",
-        "wiki_name": "Shropshire Council",
+        "wiki_name": "Shropshire",
         "wiki_note": "Follow the instructions [here](https://bins.shropshire.gov.uk/) until you get the page showing your bin collection dates, then copy the URL and replace the URL in the command.",
         "LAD24CD": "E06000051"
     },
     "SolihullCouncil": {
         "url": "https://digital.solihull.gov.uk/BinCollectionCalendar/Calendar.aspx?UPRN=100071005444",
         "wiki_command_url_override": "https://digital.solihull.gov.uk/BinCollectionCalendar/Calendar.aspx?UPRN=XXXXXXXX",
-        "wiki_name": "Solihull Council",
+        "wiki_name": "Solihull",
         "wiki_note": "Replace `XXXXXXXX` with your UPRN. You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "E08000029"
     },
@@ -2003,7 +2003,7 @@
         "skip_get_url": true,
         "uprn": "10090857775",
         "url": "https://www.somerset.gov.uk/",
-        "wiki_name": "Somerset Council",
+        "wiki_name": "Somerset",
         "wiki_note": "Provide your UPRN and postcode. Find your UPRN using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E06000066"
     },
@@ -2012,7 +2012,7 @@
         "skip_get_url": true,
         "uprn": "141003134",
         "url": "https://www.south-ayrshire.gov.uk/",
-        "wiki_name": "South Ayrshire Council",
+        "wiki_name": "South Ayrshire",
         "wiki_note": "Provide your UPRN and postcode. Use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find your UPRN.",
         "LAD24CD": "S12000028"
     },
@@ -2021,7 +2021,7 @@
         "postcode": "CB23 6GZ",
         "skip_get_url": true,
         "url": "https://www.scambs.gov.uk/recycling-and-bins/find-your-household-bin-collection-day/",
-        "wiki_name": "South Cambridgeshire Council",
+        "wiki_name": "South Cambridgeshire",
         "wiki_note": "Provide your house number in the `house_number` parameter and postcode in the `postcode` parameter.",
         "LAD24CD": "E07000012"
     },
@@ -2029,7 +2029,7 @@
         "uprn": "10000820668",
         "url": "https://maps.southderbyshire.gov.uk/iShareLIVE.web//getdata.aspx?RequestType=LocalInfo&ms=mapsources/MyHouse&format=JSONP&group=Recycling%20Bins%20and%20Waste|Next%20Bin%20Collections&uid=",
         "wiki_command_url_override": "https://maps.southderbyshire.gov.uk/iShareLIVE.web//getdata.aspx?RequestType=LocalInfo&ms=mapsources/MyHouse&format=JSONP&group=Recycling%20Bins%20and%20Waste|Next%20Bin%20Collections&uid=XXXXXXXX",
-        "wiki_name": "South Derbyshire District Council",
+        "wiki_name": "South Derbyshire",
         "wiki_note": "Replace `XXXXXXXX` with your UPRN. You can find your UPRN using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E07000039"
     },
@@ -2037,14 +2037,14 @@
         "skip_get_url": true,
         "uprn": "566419",
         "url": "https://beta.southglos.gov.uk/waste-and-recycling-collection-date",
-        "wiki_name": "South Gloucestershire Council",
+        "wiki_name": "South Gloucestershire",
         "wiki_note": "Provide your UPRN. You can find it using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E06000025"
     },
     "SouthHamsDistrictCouncil": {
         "uprn": "10004742851",
         "url": "https://www.southhams.gov.uk",
-        "wiki_name": "South Hams District Council",
+        "wiki_name": "South Hams",
         "wiki_note": "Use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find your UPRN.",
         "LAD24CD": "E07000044"
     },
@@ -2055,7 +2055,7 @@
         "uprn": "100030872493",
         "url": "https://www.sholland.gov.uk/mycollections",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "South Holland District Council",
+        "wiki_name": "South Holland",
         "wiki_note": "Pass the UPRN and postcode in their respective parameters. This parser requires a Selenium webdriver.",
         "LAD24CD": "E07000140"
     },
@@ -2065,14 +2065,14 @@
         "skip_get_url": true,
         "url": "https://pre.southkesteven.gov.uk/BinSearch.aspx",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "South Kesteven District Council",
+        "wiki_name": "South Kesteven",
         "wiki_note": "Provide your full address in the `house_number` parameter and your postcode in the `postcode` parameter.",
         "LAD24CD": "E07000141"
     },
     "SouthLanarkshireCouncil": {
         "url": "https://www.southlanarkshire.gov.uk/directory_record/579973/abbeyhill_crescent_lesmahagow",
         "wiki_command_url_override": "https://www.southlanarkshire.gov.uk/directory_record/XXXXX/XXXXX",
-        "wiki_name": "South Lanarkshire Council",
+        "wiki_name": "South Lanarkshire",
         "wiki_note": "Follow the instructions [here](https://www.southlanarkshire.gov.uk/info/200156/bins_and_recycling/1670/bin_collections_and_calendar) until you get the page that shows the weekly collections for your street, then copy the URL and replace the URL in the command.",
         "LAD24CD": "S12000029"
     },
@@ -2080,7 +2080,7 @@
         "skip_get_url": true,
         "uprn": "2630102526",
         "url": "https://www.southnorfolkandbroadland.gov.uk/rubbish-recycling/south-norfolk-bin-collection-day-finder",
-        "wiki_name": "South Norfolk Council",
+        "wiki_name": "South Norfolk",
         "wiki_note": "Provide your UPRN. Find it using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E07000149"
     },
@@ -2088,7 +2088,7 @@
         "skip_get_url": true,
         "uprn": "10033002851",
         "url": "https://www.southoxon.gov.uk/south-oxfordshire-district-council/recycling-rubbish-and-waste/when-is-your-collection-day/",
-        "wiki_name": "South Oxfordshire Council",
+        "wiki_name": "South Oxfordshire",
         "wiki_note": "Provide your UPRN. Use [FindMyAddress](https://www.findmyaddress.co.uk/search) to locate it.",
         "LAD24CD": "E07000179"
     },
@@ -2096,14 +2096,14 @@
         "uprn": "010013246384",
         "url": "https://www.southribble.gov.uk",
         "wiki_command_url_override": "https://www.southribble.gov.uk",
-        "wiki_name": "South Ribble Council",
+        "wiki_name": "South Ribble",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find your UPRN.",
         "LAD24CD": "E07000126"
     },
     "SouthStaffordshireDistrictCouncil": {
         "uprn": "200004523954",
         "url": "https://www.sstaffs.gov.uk/where-i-live?uprn=200004523954",
-        "wiki_name": "South Staffordshire District Council",
+        "wiki_name": "South Staffordshire",
         "wiki_note": "The URL needs to be `https://www.sstaffs.gov.uk/where-i-live?uprn=<Your_UPRN>`. Replace `<Your_UPRN>` with your UPRN.",
         "LAD24CD": "E07000196"
     },
@@ -2112,7 +2112,7 @@
         "postcode": "NE33 3JW",
         "skip_get_url": true,
         "url": "https://www.southtyneside.gov.uk/article/33352/Bin-collection-dates",
-        "wiki_name": "South Tyneside Council",
+        "wiki_name": "South Tyneside",
         "wiki_note": "Provide your house number in the `house_number` parameter and postcode in the `postcode` parameter.",
         "LAD24CD": "E08000023"
     },
@@ -2120,7 +2120,7 @@
         "skip_get_url": true,
         "uprn": "100060731893",
         "url": "https://www.southampton.gov.uk",
-        "wiki_name": "Southampton City Council",
+        "wiki_name": "Southampton",
         "wiki_note": "Pass the UPRN. You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E06000045"
     },
@@ -2128,7 +2128,7 @@
         "uprn": "200003469271",
         "url": "https://services.southwark.gov.uk/bins/lookup/",
         "wiki_command_url_override": "https://services.southwark.gov.uk/bins/lookup/XXXXXXXX",
-        "wiki_name": "Southwark Council",
+        "wiki_name": "Southwark",
         "wiki_note": "Replace `XXXXXXXX` with your UPRN. Use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find your UPRN.",
         "LAD24CD": "E09000028"
     },
@@ -2137,14 +2137,14 @@
         "postcode": "TW18 2PR",
         "skip_get_url": true,
         "url": "https://www.spelthorne.gov.uk",
-        "wiki_name": "Spelthorne Borough Council",
+        "wiki_name": "Spelthorne",
         "LAD24CD": "E07000213"
     },
     "StAlbansCityAndDistrictCouncil": {
         "skip_get_url": true,
         "uprn": "100081153583",
         "url": "https://gis.stalbans.gov.uk/NoticeBoard9/VeoliaProxy.NoticeBoard.asmx/GetServicesByUprnAndNoticeBoard",
-        "wiki_name": "St Albans City and District Council",
+        "wiki_name": "St Albans",
         "wiki_note": "Provide your UPRN. You can find it using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E07000240"
     },
@@ -2154,14 +2154,14 @@
         "skip_get_url": true,
         "url": "https://www.sthelens.gov.uk/",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "St Helens Borough Council",
+        "wiki_name": "St. Helens",
         "wiki_note": "Pass the house name/number in the house number parameter, wrapped in double quotes",
         "LAD24CD": "E08000013"
     },
     "StaffordBoroughCouncil": {
         "uprn": "100032203010",
         "url": "https://www.staffordbc.gov.uk/address/100032203010",
-        "wiki_name": "Stafford Borough Council",
+        "wiki_name": "Stafford",
         "wiki_note": "The URL needs to be `https://www.staffordbc.gov.uk/address/<Your_UPRN>`. Replace `<Your_UPRN>` with your UPRN.",
         "LAD24CD": "E07000197"
     },
@@ -2171,14 +2171,14 @@
         "uprn": "100031863037",
         "url": "https://www.staffsmoorlands.gov.uk/",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Staffordshire Moorlands District Council",
+        "wiki_name": "Staffordshire Moorlands",
         "wiki_note": "Provide your UPRN and postcode. Use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find your UPRN.",
         "LAD24CD": "E07000198"
     },
     "StevenageBoroughCouncil": {
         "uprn": "100080878852",
         "url": "https://www.stevenage.gov.uk",
-        "wiki_name": "Stevenage Borough Council",
+        "wiki_name": "Stevenage",
         "wiki_note": "Use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find your UPRN.",
         "LAD24CD": "E07000243"
     },
@@ -2188,14 +2188,14 @@
         "skip_get_url": true,
         "url": "https://www.stirling.gov.uk/bins-and-recycling/bin-collection-dates-search/",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Stirling Council",
+        "wiki_name": "Stirling",
         "wiki_note": "Use the full address as it appears on the drop-down on the site when you search by postcode.",
         "LAD24CD": "S12000030"
     },
     "StockportBoroughCouncil": {
         "url": "https://myaccount.stockport.gov.uk/bin-collections/show/100011434401",
         "wiki_command_url_override": "https://myaccount.stockport.gov.uk/bin-collections/show/XXXXXXXX",
-        "wiki_name": "Stockport Borough Council",
+        "wiki_name": "Stockport",
         "wiki_note": "Replace `XXXXXXXX` with your UPRN.",
         "LAD24CD": "E08000007"
     },
@@ -2205,13 +2205,13 @@
         "skip_get_url": true,
         "url": "https://www.stockton.gov.uk",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Stockton On Tees Council",
+        "wiki_name": "Stockton-on-Tees",
         "LAD24CD": "E06000004"
     },
     "StokeOnTrentCityCouncil": {
         "url": "https://www.stoke.gov.uk/jadu/custom/webserviceLookUps/BarTecWebServices_missed_bin_calendar.php?UPRN=3455121482",
         "wiki_command_url_override": "https://www.stoke.gov.uk/jadu/custom/webserviceLookUps/BarTecWebServices_missed_bin_calendar.php?UPRN=XXXXXXXXXX",
-        "wiki_name": "Stoke-on-Trent City Council",
+        "wiki_name": "Stoke-on-Trent",
         "wiki_note": "Replace `XXXXXXXXXX` with your property's UPRN.",
         "LAD24CD": "E06000021"
     },
@@ -2220,14 +2220,14 @@
         "skip_get_url": true,
         "uprn": "100070212698",
         "url": "https://www.stratford.gov.uk/waste-recycling/when-we-collect.cfm/part/calendar",
-        "wiki_name": "Stratford Upon Avon Council",
+        "wiki_name": "Stratford-on-Avon",
         "wiki_note": "Provide your UPRN. Use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find it."
     },
     "StroudDistrictCouncil": {
         "postcode": "GL10 3BH",
         "uprn": "100120512183",
         "url": "https://www.stroud.gov.uk/my-house?uprn=100120512183&postcode=GL10+3BH",
-        "wiki_name": "Stroud District Council",
+        "wiki_name": "Stroud",
         "wiki_note": "Provide your UPRN and postcode. Replace the UPRN and postcode in the URL with your own.",
         "LAD24CD": "E07000082"
     },
@@ -2237,7 +2237,7 @@
         "skip_get_url": true,
         "url": "https://webapps.sunderland.gov.uk/WEBAPPS/WSS/Sunderland_Portal/Forms/bindaychecker.aspx",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Sunderland City Council",
+        "wiki_name": "Sunderland",
         "wiki_note": "Provide your house number (without quotes) and postcode (wrapped in double quotes with a space).",
         "LAD24CD": "E08000024"
     },
@@ -2246,7 +2246,7 @@
         "postcode": "GU20 6PN",
         "skip_get_url": true,
         "url": "https://asjwsw-wrpsurreyheathmunicipal-live.whitespacews.com/",
-        "wiki_name": "Surrey Heath Borough Council / Joint Waste Solutions",
+        "wiki_name": "Surrey Heath",
         "wiki_note": "Provide your house number in the `house_number` parameter and postcode in the `postcode` parameter.",
         "LAD24CD": "E07000214"
     },
@@ -2256,7 +2256,7 @@
         "skip_get_url": true,
         "url": "https://swale.gov.uk/bins-littering-and-the-environment/bins/collection-days",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Swale Borough Council",
+        "wiki_name": "Swale",
         "wiki_note": "Provide your house number in the `house_number` parameter and postcode in the `postcode` parameter.",
         "LAD24CD": "E07000113"
     },
@@ -2265,7 +2265,7 @@
         "skip_get_url": true,
         "uprn": "100100324821",
         "url": "https://www1.swansea.gov.uk/recyclingsearch/",
-        "wiki_name": "Swansea Council",
+        "wiki_name": "Swansea",
         "wiki_note": "Provide your UPRN and postcode. Find your UPRN using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "W06000011"
     },
@@ -2273,7 +2273,7 @@
         "uprn": "10022793351",
         "url": "https://www.swindon.gov.uk",
         "wiki_command_url_override": "https://www.swindon.gov.uk",
-        "wiki_name": "Swindon Borough Council",
+        "wiki_name": "Swindon",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find your UPRN.",
         "LAD24CD": "E06000030"
     },
@@ -2281,7 +2281,7 @@
         "skip_get_url": true,
         "uprn": "100012835362",
         "url": "http://lite.tameside.gov.uk/BinCollections/CollectionService.svc/GetBinCollection",
-        "wiki_name": "Tameside Metropolitan Borough Council",
+        "wiki_name": "Tameside",
         "wiki_note": "Provide your UPRN. You can find it using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E08000008"
     },
@@ -2289,7 +2289,7 @@
         "skip_get_url": true,
         "uprn": "100062160432",
         "url": "https://tdcws01.tandridge.gov.uk/TDCWebAppsPublic/tfaBranded/408?utm_source=pressrelease&utm_medium=smposts&utm_campaign=check_my_bin_day",
-        "wiki_name": "Tandridge District Council",
+        "wiki_name": "Tandridge",
         "wiki_note": "Provide your UPRN. Use [FindMyAddress](https://www.findmyaddress.co.uk/search) to locate it.",
         "LAD24CD": "E07000215"
     },
@@ -2298,7 +2298,7 @@
         "url": "https://www.google.co.uk",
         "web_driver": "http://selenium:4444",
         "wiki_command_url_override": "https://www.google.co.uk",
-        "wiki_name": "Teignbridge Council",
+        "wiki_name": "Teignbridge",
         "wiki_note": "Provide Google as the URL as the real URL breaks the integration. You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "E07000045"
     },
@@ -2306,7 +2306,7 @@
         "skip_get_url": true,
         "uprn": "000452015013",
         "url": "https://dac.telford.gov.uk/bindayfinder/",
-        "wiki_name": "Telford and Wrekin Council",
+        "wiki_name": "Telford and Wrekin",
         "wiki_note": "Provide your UPRN. Find it using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E06000020"
     },
@@ -2316,7 +2316,7 @@
         "uprn": "100090604247",
         "url": "https://tendring-self.achieveservice.com/en/service/Rubbish_and_recycling_collection_days",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Tendring District Council",
+        "wiki_name": "Tendring",
         "wiki_note": "Provide your UPRN and postcode. Find your UPRN using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E07000076"
     },
@@ -2325,14 +2325,14 @@
         "skip_get_url": true,
         "uprn": "200010012019",
         "url": "https://testvalley.gov.uk/wasteandrecycling/when-are-my-bins-collected",
-        "wiki_name": "Test Valley Borough Council",
+        "wiki_name": "Test Valley",
         "wiki_note": "Provide your UPRN and postcode. Use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find your UPRN.",
         "LAD24CD": "E07000093"
     },
     "ThanetDistrictCouncil": {
         "uprn": "100061111858",
         "url": "https://www.thanet.gov.uk",
-        "wiki_name": "Thanet District Council",
+        "wiki_name": "Thanet",
         "wiki_note": "Use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find your UPRN.",
         "LAD24CD": "E07000114"
     },
@@ -2342,7 +2342,7 @@
         "uprn": "100080913662",
         "url": "https://my.threerivers.gov.uk/en/AchieveForms/?mode=fill&consentMessage=yes&form_uri=sandbox-publish://AF-Process-52df96e3-992a-4b39-bba3-06cfaabcb42b/AF-Stage-01ee28aa-1584-442c-8d1f-119b6e27114a/definition.json&process=1&process_uri=sandbox-processes://AF-Process-52df96e3-992a-4b39-bba3-06cfaabcb42b&process_id=AF-Process-52df96e3-992a-4b39-bba3-06cfaabcb42b&noLoginPrompt=1",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Three Rivers District Council",
+        "wiki_name": "Three Rivers",
         "wiki_note": "Provide your UPRN and postcode. Find your UPRN using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E07000102"
     },
@@ -2351,7 +2351,7 @@
         "postcode": "Round A",
         "skip_get_url": true,
         "url": "https://www.thurrock.gov.uk",
-        "wiki_name": "Thurrock Council",
+        "wiki_name": "Thurrock",
         "wiki_note": "Use the House Number field to pass the DAY of the week for your collections. [Monday/Tuesday/Wednesday/Thursday/Friday]. Use the 'postcode' field to pass the ROUND (wrapped in quotes) for your collections. [Round A/Round B].",
         "LAD24CD": "E06000034"
     },
@@ -2360,7 +2360,7 @@
         "skip_get_url": true,
         "uprn": "10002914589",
         "url": "https://www.tmbc.gov.uk/",
-        "wiki_name": "Tonbridge and Malling Borough Council",
+        "wiki_name": "Tonbridge and Malling",
         "wiki_note": "Provide your UPRN and postcode.",
         "LAD24CD": "E07000115"
     },
@@ -2368,7 +2368,7 @@
         "skip_get_url": true,
         "uprn": "10024000295",
         "url": "https://www.torbay.gov.uk/recycling/bin-collections/",
-        "wiki_name": "Torbay Council",
+        "wiki_name": "Torbay",
         "wiki_note": "Provide your UPRN. Use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find it.",
         "LAD24CD": "E06000027"
     },
@@ -2376,7 +2376,7 @@
         "skip_get_url": true,
         "uprn": "10091078762",
         "url": "https://collections-torridge.azurewebsites.net/WebService2.asmx",
-        "wiki_name": "Torridge District Council",
+        "wiki_name": "Torridge",
         "wiki_note": "Provide your UPRN.",
         "LAD24CD": "E07000046"
     },
@@ -2384,7 +2384,7 @@
         "uprn": "10090058289",
         "url": "https://tunbridgewells.gov.uk",
         "wiki_command_url_override": "https://tunbridgewells.gov.uk",
-        "wiki_name": "Tunbridge Wells Council",
+        "wiki_name": "Tunbridge Wells",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find your UPRN.",
         "LAD24CD": "E07000116"
     },
@@ -2395,7 +2395,7 @@
         "uprn": "100090643434",
         "url": "https://bins.uttlesford.gov.uk/",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Uttlesford District Council",
+        "wiki_name": "Uttlesford",
         "wiki_note": "Provide your full address in the `house_number` parameter and your postcode in the `postcode` parameter.",
         "LAD24CD": "E07000077"
     },
@@ -2403,7 +2403,7 @@
         "skip_get_url": true,
         "uprn": "64029020",
         "url": "https://www.valeofglamorgan.gov.uk/en/living/Recycling-and-Waste/",
-        "wiki_name": "Vale of Glamorgan Council",
+        "wiki_name": "The Vale of Glamorgan",
         "wiki_note": "Provide your UPRN. Find it using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "W06000014"
     },
@@ -2412,7 +2412,7 @@
         "skip_get_url": true,
         "uprn": "100121391443",
         "url": "https://eform.whitehorsedc.gov.uk/ebase/BINZONE_DESKTOP.eb",
-        "wiki_name": "Vale of White Horse Council",
+        "wiki_name": "Vale of White Horse",
         "wiki_note": "Provide your UPRN.",
         "LAD24CD": "E07000180"
     },
@@ -2422,7 +2422,7 @@
         "url": "https://www.wakefield.gov.uk/where-i-live/?uprn=63035490&a=115%20Elizabeth%20Drive%20Castleford%20WF10%203RR&usrn=41801243&e=445418&n=426091&p=WF10%203RR",
         "web_driver": "http://selenium:4444",
         "wiki_command_url_override": "https://www.wakefield.gov.uk/where-i-live/?uprn=XXXXXXXXXXX&a=XXXXXXXXXXX&usrn=XXXXXXXXXXX&e=XXXXXXXXXXX&n=XXXXXXXXXXX&p=XXXXXXXXXXX",
-        "wiki_name": "Wakefield City Council",
+        "wiki_name": "Wakefield",
         "wiki_note": "Follow the instructions [here](https://www.wakefield.gov.uk/where-i-live/) until you get the page that includes a 'Bin Collections' section, then copy the URL and replace the URL in the command.",
         "LAD24CD": "E08000036"
     },
@@ -2430,7 +2430,7 @@
         "uprn": "100071080513",
         "url": "https://cag.walsall.gov.uk/",
         "wiki_command_url_override": "https://cag.walsall.gov.uk/",
-        "wiki_name": "Walsall Council",
+        "wiki_name": "Walsall",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find your UPRN.",
         "LAD24CD": "E08000030"
     },
@@ -2449,7 +2449,7 @@
         "uprn": "100022684035",
         "url": "https://www.wandsworth.gov.uk",
         "wiki_command_url_override": "https://www.wandsworth.gov.uk",
-        "wiki_name": "Wandsworth Council",
+        "wiki_name": "Wandsworth",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "E09000032"
     },
@@ -2457,14 +2457,14 @@
         "uprn": "10094964379",
         "url": "https://www.warrington.gov.uk",
         "wiki_command_url_override": "https://www.warrington.gov.uk",
-        "wiki_name": "Warrington Borough Council",
+        "wiki_name": "Warrington",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "E06000007"
     },
     "WarwickDistrictCouncil": {
         "url": "https://estates7.warwickdc.gov.uk/PropertyPortal/Property/Recycling/100070263793",
         "wiki_command_url_override": "https://estates7.warwickdc.gov.uk/PropertyPortal/Property/Recycling/XXXXXXXX",
-        "wiki_name": "Warwick District Council",
+        "wiki_name": "Warwick",
         "wiki_note": "Replace `XXXXXXXX` with your UPRN.",
         "LAD24CD": "E07000222"
     },
@@ -2472,7 +2472,7 @@
         "uprn": "100080942183",
         "url": "https://www.watford.gov.uk",
         "wiki_command_url_override": "https://www.watford.gov.uk",
-        "wiki_name": "Watford Borough Council",
+        "wiki_name": "Watford",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "E07000103"
     },
@@ -2481,7 +2481,7 @@
         "postcode": "GU9 9QG",
         "skip_get_url": true,
         "url": "https://wav-wrp.whitespacews.com/",
-        "wiki_name": "Waverley Borough Council",
+        "wiki_name": "Waverley",
         "wiki_note": "Follow the instructions [here](https://wav-wrp.whitespacews.com/#!) until you get the page that shows your next scheduled collections. Then take the number from `pIndex=NUMBER` in the URL and pass it as the `-n` parameter along with your postcode in `-p`.",
         "LAD24CD": "E07000216"
     },
@@ -2489,7 +2489,7 @@
         "skip_get_url": true,
         "uprn": "10033413624",
         "url": "https://www.wealden.gov.uk/recycling-and-waste/bin-search/",
-        "wiki_name": "Wealden District Council",
+        "wiki_name": "Wealden",
         "wiki_note": "Provide your UPRN. Use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find it.",
         "LAD24CD": "E07000065"
     },
@@ -2498,7 +2498,7 @@
         "postcode": "AL8 6HQ",
         "uprn": "100080982825",
         "url": "https://www.welhat.gov.uk/xfp/form/214",
-        "wiki_name": "Welhat Council",
+        "wiki_name": "Welwyn Hatfield",
         "wiki_note": "Provide your UPRN and postcode."
     },
     "WestBerkshireCouncil": {
@@ -2507,14 +2507,14 @@
         "skip_get_url": true,
         "url": "https://www.westberks.gov.uk/binday",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "West Berkshire Council",
+        "wiki_name": "West Berkshire",
         "wiki_note": "Provide your house number in the `house_number` parameter and postcode in the `postcode` parameter.",
         "LAD24CD": "E06000037"
     },
     "WestDunbartonshireCouncil": {
         "uprn": "129001383",
         "url": "https://www.west-dunbarton.gov.uk/",
-        "wiki_name": "West Dunbartonshire Council",
+        "wiki_name": "West Dunbartonshire",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "S12000039"
     },
@@ -2522,7 +2522,7 @@
         "postcode": "WN8 0HR",
         "uprn": "10012343339",
         "url": "https://www.westlancs.gov.uk",
-        "wiki_name": "West Lancashire Borough Council",
+        "wiki_name": "West Lancashire",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "E07000127"
     },
@@ -2531,7 +2531,7 @@
         "postcode": "LN8 3AX",
         "skip_get_url": true,
         "url": "https://www.west-lindsey.gov.uk/",
-        "wiki_name": "West Lindsey District Council",
+        "wiki_name": "West Lindsey",
         "wiki_note": "Provide your house name/number in the `house_number` parameter, and postcode in the `postcode` parameter, both wrapped in double quotes. If multiple results are returned, the first will be used.",
         "LAD24CD": "E07000142"
     },
@@ -2541,7 +2541,7 @@
         "skip_get_url": true,
         "url": "https://www.westlothian.gov.uk/",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "West Lothian Council",
+        "wiki_name": "West Lothian",
         "wiki_note": "Provide your house name/number in the `house_number` parameter (wrapped in double quotes) and your postcode in the `postcode` parameter.",
         "LAD24CD": "S12000040"
     },
@@ -2549,7 +2549,7 @@
         "uprn": "100110353478",
         "url": "https://www.westmorlandandfurness.gov.uk/",
         "wiki_command_url_override": "https://www.westmorlandandfurness.gov.uk/",
-        "wiki_name": "West Morland and Furness Council",
+        "wiki_name": "Westmorland and Furness",
         "wiki_note": "Provide your UPRN. You can find your UPRN using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E06000064"
     },
@@ -2557,7 +2557,7 @@
         "skip_get_url": true,
         "uprn": "28056796",
         "url": "https://www.westnorthants.gov.uk",
-        "wiki_name": "West Northamptonshire Council",
+        "wiki_name": "West Northamptonshire",
         "wiki_note": "Provide your UPRN. You can find your UPRN using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E06000062"
     },
@@ -2567,7 +2567,7 @@
         "skip_get_url": true,
         "url": "https://community.westoxon.gov.uk/s/waste-collection-enquiry",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "West Oxfordshire District Council",
+        "wiki_name": "West Oxfordshire",
         "wiki_note": "Provide your house number in the `house_number` parameter and your postcode in the `postcode` parameter.",
         "LAD24CD": "E07000181"
     },
@@ -2576,7 +2576,7 @@
         "skip_get_url": true,
         "uprn": "10009739960",
         "url": "https://maps.westsuffolk.gov.uk/MyWestSuffolk.aspx",
-        "wiki_name": "West Suffolk Council",
+        "wiki_name": "West Suffolk",
         "wiki_note": "Provide your UPRN and postcode. You can find your UPRN using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E07000245"
     },
@@ -2585,7 +2585,7 @@
         "skip_get_url": true,
         "uprn": "010093942934",
         "url": "https://apps.wigan.gov.uk/MyNeighbourhood/",
-        "wiki_name": "Wigan Borough Council",
+        "wiki_name": "Wigan",
         "wiki_note": "Provide your UPRN and postcode. Find your UPRN using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E08000010"
     },
@@ -2594,7 +2594,7 @@
         "skip_get_url": true,
         "uprn": "100120982570",
         "url": "https://ilambassadorformsprod.azurewebsites.net/wastecollectiondays/index",
-        "wiki_name": "Wiltshire Council",
+        "wiki_name": "Wiltshire",
         "wiki_note": "Provide your UPRN and postcode. Use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find your UPRN.",
         "LAD24CD": "E06000054"
     },
@@ -2605,7 +2605,7 @@
         "skip_get_url": false,
         "url": "https://iportal.itouchvision.com/icollectionday/collection-day",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Winchester City Council",
+        "wiki_name": "Winchester",
         "wiki_note": "Provide your house name/number in the `house_number` parameter (wrapped in double quotes) and your postcode in the `postcode` parameter.",
         "LAD24CD": "E07000094"
     },
@@ -2614,7 +2614,7 @@
         "uprn": "100080371082",
         "url": "https://forms.rbwm.gov.uk/bincollections?uprn=",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Windsor and Maidenhead Council",
+        "wiki_name": "Windsor and Maidenhead",
         "wiki_note": "Provide your UPRN. You can find it using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E06000040"
     },
@@ -2622,7 +2622,7 @@
         "uprn": "Vernon Avenue,Seacombe",
         "url": "https://www.wirral.gov.uk",
         "wiki_command_url_override": "https://www.wirral.gov.uk",
-        "wiki_name": "Wirral Council",
+        "wiki_name": "Wirral",
         "wiki_note": "In the `uprn` field, enter your street name and suburb separated by a comma (e.g., 'Vernon Avenue,Seacombe').",
         "LAD24CD": "E08000015"
     },
@@ -2631,7 +2631,7 @@
         "postcode": "GU21 4JY",
         "skip_get_url": true,
         "url": "https://asjwsw-wrpwokingmunicipal-live.whitespacews.com/",
-        "wiki_name": "Woking Borough Council / Joint Waste Solutions",
+        "wiki_name": "Woking",
         "wiki_note": "Provide your house number in the `house_number` parameter and postcode in the `postcode` parameter. This works with all collection areas that use Joint Waste Solutions.",
         "LAD24CD": "E07000217"
     },
@@ -2641,7 +2641,7 @@
         "skip_get_url": true,
         "url": "https://www.wokingham.gov.uk/rubbish-and-recycling/waste-collection/find-your-bin-collection-day",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Wokingham Borough Council",
+        "wiki_name": "Wokingham",
         "wiki_note": "Provide your house number in the `house_number` parameter and postcode in the `postcode` parameter.",
         "LAD24CD": "E06000041"
     },
@@ -2649,7 +2649,7 @@
         "postcode": "WV3 9NZ",
         "uprn": "100071205205",
         "url": "https://www.wolverhampton.gov.uk",
-        "wiki_name": "Wolverhampton City Council",
+        "wiki_name": "Wolverhampton",
         "wiki_note": "Use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find your UPRN.",
         "LAD24CD": "E08000031"
     },
@@ -2657,7 +2657,7 @@
         "uprn": "100120650345",
         "url": "https://www.Worcester.gov.uk",
         "wiki_command_url_override": "https://www.Worcester.gov.uk",
-        "wiki_name": "Worcester City Council",
+        "wiki_name": "Worcester",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "E07000237"
     },
@@ -2668,7 +2668,7 @@
         "skip_get_url": true,
         "url": "https://www.wrexham.gov.uk/service/when-are-my-bins-collected",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Wrexham County Borough Council",
+        "wiki_name": "Wrexham",
         "wiki_note": "Provide your house number in the `house_number` parameter and postcode in the `postcode` parameter.",
         "LAD24CD": "W06000006"
     },
@@ -2678,7 +2678,7 @@
         "uprn": "100120716273",
         "url": "https://selfservice.wychavon.gov.uk/wdcroundlookup/wdc_search.jsp",
         "web_driver": "http://selenium:4444",
-        "wiki_name": "Wychavon District Council",
+        "wiki_name": "Wychavon",
         "wiki_note": "Provide your UPRN and postcode. Find your UPRN using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E07000238"
     },
@@ -2686,7 +2686,7 @@
         "skip_get_url": true,
         "uprn": "10003519994",
         "url": "https://www.wyre.gov.uk/bins-rubbish-recycling",
-        "wiki_name": "Wyre Council",
+        "wiki_name": "Wyre",
         "wiki_note": "Provide your UPRN. Find your UPRN using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E07000128"
     },
@@ -2694,7 +2694,7 @@
         "house_number": "Monday",
         "skip_get_url": true,
         "url": "https://www.wyreforestdc.gov.uk",
-        "wiki_name": "Wyre Forest District Council",
+        "wiki_name": "Wyre Forest",
         "wiki_note": "Use the House Number field to pass the DAY of the week for your collections. [Monday/Tuesday/Wednesday/Thursday/Friday/Saturday/Sunday].",
         "LAD24CD": "E07000239"
     },
@@ -2702,7 +2702,7 @@
         "skip_get_url": true,
         "uprn": "100050535540",
         "url": "https://waste-api.york.gov.uk/api/Collections/GetBinCollectionDataForUprn/",
-        "wiki_name": "York Council",
+        "wiki_name": "York",
         "wiki_note": "Provide your UPRN.",
         "LAD24CD": "E06000014"
     }


### PR DESCRIPTION
As mentioned [here](https://github.com/robbrad/UKBinCollectionData/discussions/1364). Taken from [here](https://pages.mysociety.org/uk_local_authority_names_and_codes/downloads/uk_la_past_current_json/latest). 

Also removed Brighton's UPRN since it doesn't use it.

[uk_la_past_current.json](https://github.com/user-attachments/files/19865380/uk_la_past_current.json)
