### PR TITLE
fix #1455: remove ordinal indicators from bin collection date parsing

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/NorthLincolnshireCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/NorthLincolnshireCouncil.py
@@ -46,7 +46,8 @@ class CouncilClass(AbstractGetBinDataClass):
                     "type": bin_type,
                     "collectionDate": get_next_occurrence_from_day_month(
                         datetime.strptime(
-                            c["BinCollectionDate"].replace(" (*)", "").strip()
+                            remove_ordinal_indicator_from_date_string(
+                                c["BinCollectionDate"].replace(" (*)", "").strip())
                             + " "
                             + datetime.now().strftime("%Y"),
                             "%A %d %B %Y",


### PR DESCRIPTION
RE: issue #1455 - update to use the common ordinal_remover.