### PR TITLE
Simplify and fix wait for content, fixes Croydon council

### DIFF
--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -614,8 +614,9 @@
         "postcode": "SE25 5DW",
         "skip_get_url": true,
         "url": "https://service.croydon.gov.uk/wasteservices/w/webpage/bin-day-enter-address",
+        "web_driver": "http://selenium:4444",
         "wiki_name": "Croydon",
-        "wiki_note": "Pass the house number and postcode in their respective parameters.",
+        "wiki_note": "Pass the house number and postcode in their respective parameters. This parser requires a Selenium webdriver.",
         "LAD24CD": "E09000008"
     },
     "CumberlandAllerdaleCouncil": {
@@ -745,7 +746,7 @@
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "E07000061"
     },
-    "EastCambridgeshireCouncil": { 
+    "EastCambridgeshireCouncil": {
         "skip_get_url": true,
         "uprn": "10002597178",
         "url": "https://www.eastcambs.gov.uk/",

--- a/uk_bin_collection/uk_bin_collection/councils/CroydonCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/CroydonCouncil.py
@@ -79,12 +79,9 @@ class CouncilClass(AbstractGetBinDataClass):
             next_button.click()
 
             # Wait for the bin collection content to load
-            collection_content = WebDriverWait(driver, 10).until(
-                EC.presence_of_element_located(
-                    (
-                        By.XPATH,
-                        '//*[@id="mats_content_wrapper"]/div[2]/div[2]/div[2]/div/div[1]/div/div[3]/div/div/div/div',
-                    )
+            listing_records = WebDriverWait(driver, 10).until(
+                EC.presence_of_all_elements_located(
+                    (By.CSS_SELECTOR, "#mats_content_wrapper .listing_template_record")
                 )
             )
 


### PR DESCRIPTION
This should fix the Croydon issues I was having. 
While debugging I noticed that bin_sections were coming back empty. After updating the wait-for-content function (as shown in this PR), the tests started passing consistently.

Also added the missing web_driver entry in input.json.