### PR TITLE
Fix up North Herts Council CSS Selector so it only matches on the correct title

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/NorthHertfordshireDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/NorthHertfordshireDistrictCouncil.py
@@ -151,7 +151,7 @@ class CouncilClass(AbstractGetBinDataClass):
 
             # Looking for bin types in the exact HTML structure
             bin_type_elements = soup.select(
-                "div.formatting_bold.formatting_size_bigger.formatting span.value-as-text"
+                "div.page_cell.contains_widget:first-of-type div.formatting_bold.formatting_size_bigger.formatting span.value-as-text"
             )
             # print(f"Found {len(bin_type_elements)} bin type elements")
 


### PR DESCRIPTION
I noticed an issue with the existing North Herts Council website, which may have changed recently.

Without this change, the existing script will select all the elements highlighted in Red:

![image](https://github.com/user-attachments/assets/f165e02b-2563-4940-99a3-650f52f58761)

And will Generate the following JSON:

```
{
    "bins": [
        {
            "type": "Food waste",
            "collectionDate": "10/06/2025"
        },
        {
            "type": "Brown caddy",
            "collectionDate": "10/06/2025"
        },
        {
            "type": "Paper & magazines",
            "collectionDate": "10/06/2025"
        },
        {
            "type": "Mixed recycling",
            "collectionDate": "10/06/2025"
        },
        {
            "type": "Blue box",
            "collectionDate": "17/06/2025"
        }
    ]
}
```

This is incorrect, as my 'Food Waste' and 'Brown Caddy' are the same bin.

I've modified the CSS Selector to take into account the fact that each bin has two elements that could contain the bin name, and to only select the first.

With this change, the list of bins is correctly scraped.

```
{
    "bins": [
        {
            "type": "Food waste",
            "collectionDate": "10/06/2025"
        },
        {
            "type": "Paper & magazines",
            "collectionDate": "10/06/2025"
        },
        {
            "type": "Mixed recycling",
            "collectionDate": "10/06/2025"
        },
        {
            "type": "Garden waste",
            "collectionDate": "10/06/2025"
        },
        {
            "type": "Non-recyclable refuse",
            "collectionDate": "17/06/2025"
        }
    ]
}
```

There may be a more elegant way of achieving this, but I've not worked with HTML/CSS seriously in the best part of a decade. 