### PR TITLE
fix(OxfordCityCouncil): Fixed Oxford City Council parsing Changes

### DIFF
--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -1828,8 +1828,8 @@
     "OxfordCityCouncil": {
         "postcode": "OX3 7QF",
         "uprn": "100120820551",
-        "url": "https://www.oxford.gov.uk",
-        "wiki_command_url_override": "https://www.oxford.gov.uk",
+        "url": "https://www.oxford.gov.uk/xfp/form/142",
+        "wiki_command_url_override": "https://www.oxford.gov.uk/xfp/form/142",
         "wiki_name": "Oxford",
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "E07000178"

--- a/uk_bin_collection/uk_bin_collection/councils/OxfordCityCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/OxfordCityCouncil.py
@@ -21,8 +21,8 @@ class CouncilClass(AbstractGetBinDataClass):
         check_postcode(user_postcode)
         bindata = {"bins": []}
 
-        session_uri = "https://www.oxford.gov.uk/mybinday"
-        URI = "https://www.oxford.gov.uk/xfp/form/142"
+        session_uri = "https://www.oxford.gov.uk/xfp/form/142"
+        URI = "https://www.oxford.gov.uk/xfp/form/142#q6ad4e3bf432c83230a0347a6eea6c805c672efeb_0"
 
         session = requests.Session()
         token_response = session.get(session_uri)
@@ -40,15 +40,18 @@ class CouncilClass(AbstractGetBinDataClass):
 
         collection_response = session.post(URI, data=form_data)
 
-        collection_soup = BeautifulSoup(collection_response.text, "html.parser")
-        for paragraph in collection_soup.find("div", class_="editor").find_all("p"):
-            matches = re.match(r"^(\w+) Next Collection: (.*)", paragraph.text)
+        soup = BeautifulSoup(collection_response.text, "html.parser")
+        #print(soup)
+
+        for paragraph in soup.find("div", class_="editor").find_all("p"):
+            matches = re.match(r"^Your next (\w+) collections: (.*)", paragraph.text)
             if matches:
                 collection_type, date_string = matches.groups()
+                parts = date_string.split(', ', 1)
                 try:
-                    date = datetime.strptime(date_string, "%A %d %B %Y").date()
+                    date = datetime.strptime(parts[0], "%A %d %B %Y").date()
                 except ValueError:
-                    date = datetime.strptime(date_string, "%A %d %b %Y").date()
+                    date = datetime.strptime(parts[0], "%A %d %b %Y").date()
 
                 dict_data = {
                     "type": collection_type,
@@ -61,3 +64,5 @@ class CouncilClass(AbstractGetBinDataClass):
         )
 
         return bindata
+
+

--- a/wiki/Councils.md
+++ b/wiki/Councils.md
@@ -2682,7 +2682,7 @@ Note: Replace UPRN in URL with your own UPRN.
 
 ### Oxford City Council
 ```commandline
-python collect_data.py OxfordCityCouncil https://www.oxford.gov.uk -u XXXXXXXX -p "XXXX XXX"
+python collect_data.py OxfordCityCouncil https://www.oxford.gov.uk/xfp/form/142 -u XXXXXXXX -p "XXXX XXX"
 ```
 Additional parameters:
 - `-u` - UPRN


### PR DESCRIPTION
Fixed Oxford City Council parsing Changes in output from the website, now correctly gets the bin types, tested using sample Postcode and UPRN from the Wiki and also the Postcode and UPRN listed in the bug, all works succesfully

![image](https://github.com/user-attachments/assets/9ab77523-b1c7-4d3e-a5a0-81948d435ae9)

this should resolve [this bug](https://github.com/robbrad/UKBinCollectionData/issues/1393)