### PR TITLE
Fix Wigan Council parsing

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/WiganBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/WiganBoroughCouncil.py
@@ -82,7 +82,7 @@ class CouncilClass(AbstractGetBinDataClass):
         # Get the dates.
         for bins in soup.find_all("div", {"class": "BinsRecycling"}):
             bin_type = bins.find("h2").text
-            binCollection = bins.find("div", {"class": "dateWrapper-next"}).get_text(
+            binCollection = bins.find("div", {"class": "dateWrap-next"}).get_text(
                 strip=True
             )
             binData = datetime.strptime(


### PR DESCRIPTION
The HTML source code of the page on Wigan Council's website shows the bin collection dates class has changed from dateWrapper-next to dateWrap-next - updating this value in the `find()` function should fix the parsing of data for this council (and hopefully fix #1485)