### PR TITLE
Update RotherhamCouncil.py

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/RotherhamCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/RotherhamCouncil.py
@@ -15,11 +15,15 @@ class CouncilClass(AbstractGetBinDataClass):
         user_uprn = kwargs.get("uprn")
 
         check_uprn(user_uprn)
-
+        headers = {
+            "Content-Type": "application/x-www-form-urlencoded",
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36",
+        }
         response = requests.post(
             "https://www.rotherham.gov.uk/bin-collections?address={}&submit=Submit".format(
                 user_uprn
-            )
+            ), 
+            headers=headers
         )
         # Make a BS4 object
         soup = BeautifulSoup(response.text, features="html.parser")


### PR DESCRIPTION
Added headers to request, emulating browser, to resolve 403 error that is the cause of #1498.

Before headers, page would return (via _print_ing the soup output)

```
<html>
<head><title>403 Forbidden</title></head>
<body>
<center><h1>403 Forbidden</h1></center>
</body>
</html>
```

After adding headers, page returns full results and JSON data is retrieved as
```
{
    "bins": [
        {
            "type": "Pink Lid Bin",
            "collectionDate": "27/06/2025"
        },
        {
            "type": "Brown Bin",
            "collectionDate": "04/07/2025"
        },
        {
            "type": "Green Bin",
            "collectionDate": "04/07/2025"
        },
        {
            "type": "Pink Lid Bin",
            "collectionDate": "11/07/2025"
        },
        {
            "type": "Brown Bin",
            "collectionDate": "18/07/2025"
        },
        {
            "type": "Black Bin",
            "collectionDate": "18/07/2025"
        },
        {
            "type": "Pink Lid Bin",
            "collectionDate": "25/07/2025"
        }
    ]
}
```