### PR TITLE
Fix headless argument handling HACS Integration

### DIFF
--- a/custom_components/uk_bin_collection/__init__.py
+++ b/custom_components/uk_bin_collection/__init__.py
@@ -291,7 +291,15 @@ def build_ukbcd_args(config_data: dict) -> list:
             continue
         if key == "web_driver" and value is not None:
             value = value.rstrip("/")
-        args.append(f"--{key}={value}")
+            args.append(f"--{key}={value}")
+        elif key == "headless":
+            # Handle boolean headless argument correctly
+            if value:
+                args.append("--headless")
+            else:
+                args.append("--not-headless")
+        else:
+            args.append(f"--{key}={value}")
 
     return args
 

--- a/custom_components/uk_bin_collection/const.py
+++ b/custom_components/uk_bin_collection/const.py
@@ -31,7 +31,6 @@ EXCLUDED_ARG_KEYS = {
     "council",
     "url",
     "skip_get_url",
-    "headless",
     "local_browser",
     "timeout",
     "icon_color_mapping",


### PR DESCRIPTION
Fixed the handling of the headless argument in the build_ukbcd_args function to correctly pass boolean values as command-line flags.