### PR TITLE
Fix Newcastle-under-Lyme Council - Add request headers to resolve 403 Forbidden

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/NewcastleUnderLymeCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/NewcastleUnderLymeCouncil.py
@@ -23,7 +23,8 @@ class CouncilClass(AbstractGetBinDataClass):
         URI = f"https://www.newcastle-staffs.gov.uk/homepage/97/check-your-bin-day?uprn={user_uprn}"
 
         # Make the GET request
-        response = requests.get(URI)
+        request_headers = {'user-agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'}
+        response = requests.get(URI, headers=request_headers) 
         response.raise_for_status()
         soup = BeautifulSoup(response.text, features="html.parser")
         soup.prettify()


### PR DESCRIPTION
Add request headers to fix the following issue:

Newcastle-under-Lyme Council - 403 error #1501