### PR TITLE
Fix Bedfordshire Council (AWS) blocking python-requests user agent

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/BedfordshireCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/BedfordshireCouncil.py
@@ -28,6 +28,7 @@ class CouncilClass(AbstractGetBinDataClass):
         headers = {
             "Origin": "https://www.centralbedfordshire.gov.uk",
             "Referer": "https://www.centralbedfordshire.gov.uk/info/163/bins_and_waste_collections_-_check_bin_collection_day",
+            "User-Agent": "Mozilla/5.0 (Linux; Android 8.0; Pixel 2 Build/OPD3.170816.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.7968.1811 Mobile Safari/537.36",
         }
 
         files = {


### PR DESCRIPTION
**Issue**
Bedfordshire Council website has been returning 403 responses which is resulting in the error `Unexpected error: 'NoneType' object has no attribute 'find_all'`

**Cause**
Bedfordshire Council is fronted by AWS. From simple tests it appears they are blocking the python-requests user agent as altering the user agent to something else allowed the request through. The issue was initially repro'd with a raw HTTP request and passing the python-requests user agent.

**Fix**
Pass a custom user agent value in the header when making the request to the Bedfordshire Council website.