### PR TITLE
fix: RochfordCouncil date parsing

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/RochfordCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/RochfordCouncil.py
@@ -33,11 +33,9 @@ class CouncilClass(AbstractGetBinDataClass):
                     "tr", {"class": "govuk-table__row"}
                 ):
                     week_text = week.get_text().strip().split("\n")
+                    date_str = week_text[0].split(" - ")[0].split("–")[0].strip()
                     collection_date = datetime.strptime(
-                        remove_ordinal_indicator_from_date_string(
-                            week_text[0].split(" - ")[0]
-                        )
-                        .strip(),
+                        remove_ordinal_indicator_from_date_string(date_str),
                         "%A %d %B",
                     )
                     next_collection = collection_date.replace(year=datetime.now().year)


### PR DESCRIPTION
Before:
```
% python3 -m uk_bin_collection.uk_bin_collection.collect_data RochfordCouncil https://www.rochford.gov.uk/online-bin-collections-calendar
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/Shared/GitHub/UKBinCollectionData/uk_bin_collection/uk_bin_collection/collect_data.py", line 135, in <module>
    run()
    ~~~^^
  File "/Users/Shared/GitHub/UKBinCollectionData/uk_bin_collection/uk_bin_collection/collect_data.py", line 131, in run
    print(app.run())
          ~~~~~~~^^
  File "/Users/Shared/GitHub/UKBinCollectionData/uk_bin_collection/uk_bin_collection/collect_data.py", line 102, in run
    return self.client_code(
           ~~~~~~~~~~~~~~~~^
        council_module.CouncilClass(),
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<9 lines>...
        council_module_str=self.parsed_args.module,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/Users/Shared/GitHub/UKBinCollectionData/uk_bin_collection/uk_bin_collection/collect_data.py", line 122, in client_code
    return get_bin_data_class.template_method(address_url, **kwargs)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/Shared/GitHub/UKBinCollectionData/uk_bin_collection/uk_bin_collection/get_bin_data.py", line 61, in template_method
    bin_data_dict = self.get_and_parse_data(this_url, **kwargs)
  File "/Users/Shared/GitHub/UKBinCollectionData/uk_bin_collection/uk_bin_collection/get_bin_data.py", line 82, in get_and_parse_data
    bin_data_dict = self.parse_data(page, url=address_url, **kwargs)
  File "/Users/Shared/GitHub/UKBinCollectionData/uk_bin_collection/uk_bin_collection/councils/RochfordCouncil.py", line 36, in parse_data
    collection_date = datetime.strptime(
        remove_ordinal_indicator_from_date_string(
    ...<2 lines>...
        "%A %d %B",
    )
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/_strptime.py", line 673, in _strptime_datetime
    tt, fraction, gmtoff_fraction = _strptime(data_string, format)
                                    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.13/lib/python3.13/_strptime.py", line 455, in _strptime
    raise ValueError("unconverted data remains: %s" %
                      data_string[found.end():])
ValueError: unconverted data remains:  – Friday 29 August
```

After:

```
% python3 -m uk_bin_collection.uk_bin_collection.collect_data RochfordCouncil https://www.rochford.gov.uk/online-bin-collections-calendar
{
    "bins": [
        {
            "type": "Recycling bin",
            "collectionDate": "18/08/2025"
        },
        {
            "type": "Non-recycling bin",
            "collectionDate": "25/08/2025"
        },
        {
            "type": "Recycling bin",
            "collectionDate": "01/09/2025"
        },
        {
            "type": "Non-recycling bin",
            "collectionDate": "08/09/2025"
        },
        {
            "type": "Recycling bin",
            "collectionDate": "15/09/2025"
        },
        {
            "type": "Non-recycling bin",
            "collectionDate": "22/09/2025"
        },
        {
            "type": "Recycling bin",
            "collectionDate": "29/09/2025"
        }
    ]
}
```