### PR TITLE
Fix: #1498 Rotherham Council

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/RotherhamCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/RotherhamCouncil.py
@@ -1,57 +1,89 @@
-from bs4 import BeautifulSoup
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
+import requests
+from datetime import datetime
 
 
-# import the wonderful Beautiful Soup and the URL grabber
 class CouncilClass(AbstractGetBinDataClass):
     """
-    Concrete classes have to implement all abstract operations of the
-    base class. They can also override some operations with a default
-    implementation.
+    Rotherham collections via the public JSON API.
+    Returns the same shape as before:
+      {"bins": [{"type": "Black Bin", "collectionDate": "Tuesday, 29 September 2025"}, ...]}
+    Accepts kwargs['premisesid'] (recommended) or a numeric kwargs['uprn'].
     """
 
     def parse_data(self, page: str, **kwargs) -> dict:
-        user_uprn = kwargs.get("uprn")
+        # prefer explicit premisesid, fallback to uprn (if numeric)
+        premises = kwargs.get("premisesid")
+        uprn = kwargs.get("uprn")
 
-        check_uprn(user_uprn)
-        headers = {
-            "Content-Type": "application/x-www-form-urlencoded",
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36",
+        if uprn:
+            # preserve original behaviour where check_uprn exists for validation,
+            # but don't fail if uprn is intended as a simple premises id number.
+            try:
+                check_uprn(uprn)
+            except Exception:
+                # silently continue — user may have passed a numeric premises id as uprn
+                pass
+
+            if not premises and str(uprn).strip().isdigit():
+                premises = str(uprn).strip()
+
+        if not premises:
+            raise ValueError("No premises ID supplied. Pass 'premisesid' in kwargs or a numeric 'uprn'.")
+
+        api_url = "https://bins.azurewebsites.net/api/getcollections"
+        params = {
+            "premisesid": str(premises),
+            "localauthority": kwargs.get("localauthority", "Rotherham"),
         }
-        response = requests.post(
-            "https://www.rotherham.gov.uk/bin-collections?address={}&submit=Submit".format(
-                user_uprn
-            ), 
-            headers=headers
-        )
-        # Make a BS4 object
-        soup = BeautifulSoup(response.text, features="html.parser")
-        soup.prettify()
+        headers = {
+            "User-Agent": "UKBinCollectionData/1.0 (+https://github.com/robbrad/UKBinCollectionData)"
+        }
+
+        try:
+            resp = requests.get(api_url, params=params, headers=headers, timeout=10)
+        except Exception as exc:
+            print(f"Error contacting Rotherham API: {exc}")
+            return {"bins": []}
+
+        if resp.status_code != 200:
+            print(f"Rotherham API request failed ({resp.status_code}). URL: {resp.url}")
+            return {"bins": []}
+
+        try:
+            collections = resp.json()
+        except ValueError:
+            print("Rotherham API returned non-JSON response.")
+            return {"bins": []}
 
         data = {"bins": []}
+        seen = set()  # dedupe identical (type, date) pairs
+        for item in collections:
+            bin_type = item.get("BinType") or item.get("bintype") or "Unknown"
+            date_str = item.get("CollectionDate") or item.get("collectionDate")
+            if not date_str:
+                continue
 
-        table = soup.select("table")[0]
+            # API gives ISO date like '2025-09-29' (or possibly '2025-09-29T00:00:00').
+            try:
+                iso_date = date_str.split("T")[0]
+                parsed = datetime.strptime(iso_date, "%Y-%m-%d")
+                formatted = parsed.strftime(date_format)
+            except Exception:
+                # skip malformed dates
+                continue
 
-        if table:
-            rows = table.select("tr")
+            key = (bin_type.strip().lower(), formatted)
+            if key in seen:
+                continue
+            seen.add(key)
 
-            for index, row in enumerate(rows):
-                bin_info_cell = row.select("td")
-                if bin_info_cell:
-                    bin_type = bin_info_cell[0].get_text(separator=" ", strip=True)
-                    bin_collection = bin_info_cell[1]
+            dict_data = {"type": bin_type.title(), "collectionDate": formatted}
+            data["bins"].append(dict_data)
 
-                    if bin_collection:
-                        dict_data = {
-                            "type": bin_type.title(),
-                            "collectionDate": datetime.strptime(
-                                bin_collection.get_text(strip=True), "%A, %d %B %Y"
-                            ).strftime(date_format),
-                        }
-
-                    data["bins"].append(dict_data)
-        else:
-            print("Something went wrong. Please open a GitHub issue.")
+        if not data["bins"]:
+            # helpful debugging note
+            print(f"Rotherham API returned no collection entries for premisesid={premises}")
 
         return data


### PR DESCRIPTION
update `RotherhamCouncil.py` to use new api since Rotherham Council website has removed bins.

This fixes issue #1498 

The only change on the user end is the `UPRN` number would be a `premisesid` which can be found by entering your postcode at the end of this link: https://bins.azurewebsites.net/api/getaddress?postcode=S636RL and entering it into the UPRN field in the config.