### PR TITLE
fix: Oxford now rejects the "Requests" default user agent

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/OxfordCityCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/OxfordCityCouncil.py
@@ -25,6 +25,7 @@ class CouncilClass(AbstractGetBinDataClass):
         URI = "https://www.oxford.gov.uk/xfp/form/142#q6ad4e3bf432c83230a0347a6eea6c805c672efeb_0"
 
         session = requests.Session()
+        session.headers.update({'User-Agent': 'HomeAssistant UK Bin Collection integration'})
         token_response = session.get(session_uri)
         soup = BeautifulSoup(token_response.text, "html.parser")
         token = soup.find("input", {"name": "__token"}).attrs["value"]


### PR DESCRIPTION
Fixes #1518

Without this, you get a 403 from the City Council pages.