### PR TITLE
fix: Update NorthTynesideCouncil to reflect changes to collection schedule pages

### DIFF
--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -1760,8 +1760,9 @@
         "skip_get_url": true,
         "uprn": "47097627",
         "url": "https://www.northtyneside.gov.uk/waste-collection-schedule",
-        "wiki_name": "North Tyneside",
-        "wiki_note": "Pass the UPRN. You can find the UPRN using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
+        "wiki_command_url_override": "https://www.northtyneside.gov.uk/waste-collection-schedule/view/XXXXXXXX",
+      "wiki_name": "North Tyneside",
+        "wiki_note": "Pass only the UPRN (no postcode). You can find the UPRN using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E08000022"
     },
     "NorthWestLeicestershire": {

--- a/uk_bin_collection/uk_bin_collection/councils/NorthTynesideCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/NorthTynesideCouncil.py
@@ -2,27 +2,58 @@ import logging
 from datetime import datetime
 from bs4 import BeautifulSoup
 
-from uk_bin_collection.uk_bin_collection.common import *
+from uk_bin_collection.uk_bin_collection.common import check_uprn, date_format
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
 logger = logging.getLogger(__name__)
 
 
 class CouncilClass(AbstractGetBinDataClass):
+    """
+    North Tyneside Council bin collection schedule parser
+    """
 
     def parse_data(self, page: str, **kwargs) -> dict:
+        """
+        Parse waste collection schedule data for a given UPRN.
+
+        Args:
+            page (str): Unused parameter (required by parent class interface).
+            **kwargs: Keyword arguments containing:
+                - uprn (str): The Unique Property Reference Number for the property.
+
+        Returns:
+            dict: A dictionary containing:
+                - bins (list): A list of dictionaries, each containing:
+                    - type (str): Bin type and colour in format "Type (Colour)"
+                                 (e.g., "Recycling (Grey)")
+                    - collectionDate (str): Collection date in the format specified
+                                           by date_format
+
+        Raises:
+            ValueError: If no waste collection schedule is found on the page, indicating
+                       the page structure may have changed.
+            requests.HTTPError: If the HTTP request to fetch the schedule fails.
+
+        Notes:
+            - The method handles bank holiday notifications that may appear in the
+              collection type field, extracting only the direct text content.
+            - Invalid or unparsable collection entries are logged and skipped.
+            - Results are sorted by collection date in ascending order.
+        """
+        # `page` is unused because we construct the view URL directly.
+        del page
 
         user_uprn = kwargs.get("uprn")
         check_uprn(user_uprn)
 
-        # diable warnings so that we can ignore cert verification
-        requests.packages.urllib3.disable_warnings()
+        # Fetch the schedule page (includes UA, verify=False, timeout)
+        view_url = f"https://www.northtyneside.gov.uk/waste-collection-schedule/view/{user_uprn}"
+        response = self.get_data(view_url)
 
-        # Fetch the schedule page
-        response = requests.get(
-            f"https://www.northtyneside.gov.uk/waste-collection-schedule/view/{user_uprn}",
-            verify=False,
-        )
+        # Fail fast on HTTP errors
+        if getattr(response, "raise_for_status", None):
+            response.raise_for_status()
 
 
         # Parse form page and get the day of week and week offsets
@@ -30,7 +61,7 @@ class CouncilClass(AbstractGetBinDataClass):
         schedule = soup.find("div", {"class": "waste-collection__schedule"})
 
         if schedule is None:
-            raise Exception("No waste-collection schedule info found - has the page changed?")
+            raise ValueError("No waste-collection schedule found. The page structure may have changed.")
 
 
         # Find days of form:
@@ -55,23 +86,30 @@ class CouncilClass(AbstractGetBinDataClass):
 
         for day in schedule.find_all("li", {"class": "waste-collection__day"}):
             try:
-                # extract the date, bin type and colour
-                collection_date = datetime.strptime(day.find("time")["datetime"], "%Y-%m-%d")
-
-                # for the collection type we only want the text before any nested span
-                type_span = day.find("span", {"class": "waste-collection__day--type"})
-                bin_type = next(type_span.strings).strip()
-
-                bin_colour = day.find("span", {"class": "waste-collection__day--colour"}).text.strip()
-
-                collections.append((f'{bin_type} ({bin_colour})', collection_date))
-
-            except Exception as e:
-                # here NoneType typically suggests parsing errors so report them and continue
-                if "NoneType" in str(e):
-                    logger.warning(f'Error while processing {day}: {e}')
+                time_el = day.find("time")
+                if not time_el or not time_el.get("datetime"):
+                    logger.warning("Skipping day: missing time/datetime")
                     continue
-                raise
+                collection_date = datetime.strptime(time_el["datetime"], "%Y-%m-%d")
+
+                type_span = day.find("span", {"class": "waste-collection__day--type"})
+                # Direct text only (exclude nested spans, e.g., bank-holiday note)
+                bin_type_text = type_span.find(text=True, recursive=False) if type_span else None
+                if not bin_type_text:
+                    logger.warning("Skipping day: missing type")
+                    continue
+                bin_type = bin_type_text.strip()
+
+                colour_span = day.find("span", {"class": "waste-collection__day--colour"})
+                if not colour_span:
+                    logger.warning("Skipping day: missing colour")
+                    continue
+                bin_colour = colour_span.get_text(strip=True)
+
+                collections.append((f"{bin_type} ({bin_colour})", collection_date))
+            except (AttributeError, KeyError, TypeError, ValueError) as e:
+                logger.warning(f"Skipping unparsable day node: {e}")
+                continue
 
         return {
             "bins": [


### PR DESCRIPTION
Summary:
- Fix North Tyneside council integration following changes to collection schedule pages

Changes:
- Updated URL from `https://my.northtyneside.gov.uk/category/81/bin-collection-dates` to `https://www.northtyneside.gov.uk/waste-collection-schedule`
- Adjusted parsing to match the new page structure.
- Updated input.json to update URL and remove unneeded postcode parameter

Fixes: #1654

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * North Tyneside waste lookup now works with UPRN only (postcode removed); schedule is fetched from the updated service and parsed directly, improving reliability of dates, bin types and colours with better error handling.
* **Documentation**
  * Help/wiki text and lookup URL updated; guidance now points to FindMyAddress for UPRN lookup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->