### PR TITLE
Fix requirement name in manifest

### DIFF
--- a/custom_components/uk_bin_collection/manifest.json
+++ b/custom_components/uk_bin_collection/manifest.json
@@ -9,7 +9,7 @@
     "integration_type": "service",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/robbrad/UKBinCollectionData/issues",
-    "requirements": ["uk-bin-collection>=0.159.1"],
+    "requirements": ["uk_bin_collection>=0.159.1"],
     "version": "0.159.1",
     "zeroconf": []
 }


### PR DESCRIPTION
It's using underscores on pypi
https://pypi.org/project/uk_bin_collection/#history

I can only imagine that an update to pip is not normalising them anymore

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected package dependency reference to resolve potential installation and compatibility issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->