### PR TITLE
fix(tendring): read 'Next collection' column; harden cookie/iframe handling; normalise dd/MM/YYYY

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/TendringDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/TendringDistrictCouncil.py
@@ -145,7 +145,7 @@ class CouncilClass(AbstractGetBinDataClass):
                     parsed = datetime.strptime(date_str, "%d/%m/%Y")
                 except ValueError:
                     continue
-                if parsed.date() < today:
+                if parsed.date() <= today:
                     continue
 
                 bin_data["bins"].append(


### PR DESCRIPTION
Tendring District Council’s bin collection page lists both “Previous” and “Next collection” dates.
The scraper was previously capturing the “Previous” column, resulting in outdated data.

This update:
- Dynamically detects the “Next collection” header.
- Extracts only future dates in dd/mm/YYYY format.
- Verified working via Home Assistant integration for UPRN 100091265417 (CO16 9EE).

Tested with uk_bin_collection v0.160.1.

Closes #1673


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tendring District Council bin lookup: improved postcode/UPRN validation, robust cookie-banner handling with fallback, supports "continue without an account" iframe flow, avoids crashes when elements are missing, ensures cleanup on exit, extracts and normalizes upcoming collection dates, filters out past/incomplete entries, and reliably detects/parses next-collection and waste-type columns.

* **Documentation**
  * Updated docs to reflect iframe-driven flow, input validation, and improved next-collection parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->