### PR TITLE
fix: Herefordshire Council

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/HerefordshireCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/HerefordshireCouncil.py
@@ -31,7 +31,7 @@ class CouncilClass(AbstractGetBinDataClass):
         soup.prettify
 
         checkValid = any("Your next collection days" in h2.get_text() for h2 in soup.find_all("h2"))
-        if checkValid is None:
+        if not checkValid:
             raise ValueError("Address/UPRN not found")
 
         data = {"bins": []}
@@ -49,7 +49,10 @@ class CouncilClass(AbstractGetBinDataClass):
                 continue
 
             # Get the first <li>, which is the 'next collection' entry
-            next_date = ul.find("li").get_text(strip=True).replace(" (next collection)", "")
+            li = ul.find("li")
+            if not li:
+                continue
+            next_date = li.get_text(strip=True).replace(" (next collection)", "")
 
             logging.info(f"Bin type: {bin_type} - Collection date: {next_date}")
 


### PR DESCRIPTION
Fixes https://github.com/robbrad/UKBinCollectionData/issues/1682.

The council changed their page somewhat significantly so the old method isn't working, and the tests failed. This passes the tests, as well as running it locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable Herefordshire bin collection parsing: better detection of collection sections, ignores non-bin items, and robustly finds the next collection date.
  * Improved handling when page content is unexpected to reduce wrong or missing dates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->