### PR TITLE
Enhance HTTP requests with retry logic and headers

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/LondonBoroughSutton.py
+++ b/uk_bin_collection/uk_bin_collection/councils/LondonBoroughSutton.py
@@ -1,8 +1,10 @@
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 from bs4 import BeautifulSoup
 from datetime import datetime
 import re
-from time import sleep
+import time
 
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
@@ -11,80 +13,104 @@ def remove_ordinal_indicator_from_date_string(date_str):
     return re.sub(r'(\d+)(st|nd|rd|th)', r'\1', date_str)
 
 class CouncilClass(AbstractGetBinDataClass):
-
     def parse_data(self, page: str, **kwargs) -> dict:
         user_uprn = kwargs.get("uprn")
         bindata = {"bins": []}
 
         URI = f"https://waste-services.sutton.gov.uk/waste/{user_uprn}"
 
+        # --- Session with polite retry policy
         s = requests.Session()
-        r = s.get(URI)
-        while "Loading your bin days..." in r.text:
-            sleep(2)
-            r = s.get(URI)
+        s.headers.update({
+            "User-Agent": "uk-bin-collection/1.0 (+https://github.com/robbrad/UKBinCollectionData)",
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            "Connection": "close",
+        })
+        retry = Retry(
+            total=5,
+            backoff_factor=1.5,             # 0, 1.5s, 3s, 4.5s, 6s...
+            status_forcelist=(429, 500, 502, 503, 504),
+            allowed_methods=("GET",),
+            respect_retry_after_header=True
+        )
+        s.mount("https://", HTTPAdapter(max_retries=retry))
+        s.mount("http://", HTTPAdapter(max_retries=retry))
+
+        # --- Initial fetch with timeout
+        r = s.get(URI, timeout=20)
+        # If 429 and Retry-After present, requests+urllib3 will already honor it.
         r.raise_for_status()
+
+        # --- Poll only if the page explicitly says it's still loading
+        # Use exponential backoff and a hard cap to avoid rate limits
+        max_polls = 5           # don't keep hammering
+        delay = 2.0
+        poll = 0
+        while "Loading your bin days..." in r.text and poll < max_polls:
+            time.sleep(delay)
+            delay = min(delay * 2, 30)  # grow delay but cap it
+            r = s.get(URI, timeout=20)
+            if r.status_code == 429:
+                # manual respect if upstream Retry didn’t catch (e.g., no header)
+                retry_after = int(r.headers.get("Retry-After", "10"))
+                time.sleep(min(retry_after, 60))
+            r.raise_for_status()
+            poll += 1
+
+        if "Loading your bin days..." in r.text:
+            # fail fast with a clear message so callers can back off scheduling
+            raise RuntimeError(
+                "Sutton page still loading after polite retries; back off and try later."
+            )
 
         soup = BeautifulSoup(r.content, "html.parser")
         current_year = datetime.now().year
         next_year = current_year + 1
 
-        # Find all h3 headers (bin types)
         services = soup.find_all("h3")
         for service in services:
             bin_type = service.get_text(strip=True)
             if "Bulky Waste" in bin_type:
                 continue
 
-            # Find the next element (next sibling) which is likely a paragraph with date info
-            next_sib = service.find_next_sibling()
-            while next_sib and getattr(next_sib, 'name', None) not in [None, 'p']:
-                next_sib = next_sib.find_next_sibling()
-
+            # Walk a few siblings to find 'Next collection'
             next_coll = None
-            if next_sib:
-                text = next_sib.get_text() if hasattr(next_sib, 'get_text') else str(next_sib)
-                match = re.search(r"Next collection\s*([A-Za-z]+,? \d{1,2}(?:st|nd|rd|th)? [A-Za-z]+)", text)
-                if match:
-                    next_coll = match.group(1)
-                else:
-                    # Sometimes the text may be attached without a space after 'Next collection'
-                    match = re.search(r"Next collection([A-Za-z]+,? \d{1,2}(?:st|nd|rd|th)? [A-Za-z]+)", text)
-                    if match:
-                        next_coll = match.group(1)
+            sib = service
+            for _ in range(4):
+                sib = sib.find_next_sibling() if sib else None
+                if not sib:
+                    break
+                text = sib.get_text(" ", strip=True) if hasattr(sib, "get_text") else str(sib)
+                m = re.search(r"Next collection\s*([A-Za-z]+,?\s+\d{1,2}(?:st|nd|rd|th)?\s+[A-Za-z]+)", text)
+                if not m:
+                    m = re.search(r"Next collection([A-Za-z]+,?\s+\d{1,2}(?:st|nd|rd|th)?\s+[A-Za-z]+)", text)
+                if m:
+                    next_coll = m.group(1)
+                    break
 
-            # Try several siblings forward if not found
             if not next_coll:
-                sib_try = service
-                for _ in range(3):
-                    if sib_try:
-                        sib_try = sib_try.find_next_sibling()
-                    else:
-                        break
-                    if sib_try:
-                        text = sib_try.get_text() if hasattr(sib_try, 'get_text') else str(sib_try)
-                        match = re.search(r"Next collection\s*([A-Za-z]+,? \d{1,2}(?:st|nd|rd|th)? [A-Za-z]+)", text)
-                        if match:
-                            next_coll = match.group(1)
-                            break
+                continue
 
-            if next_coll:
-                next_coll = remove_ordinal_indicator_from_date_string(next_coll)
+            next_coll = remove_ordinal_indicator_from_date_string(next_coll)
+            try:
+                next_dt = datetime.strptime(next_coll, "%A, %d %B")
+            except ValueError:
+                # Try a looser pattern if the comma is missing
                 try:
-                    next_collection = datetime.strptime(next_coll, "%A, %d %B")
+                    next_dt = datetime.strptime(next_coll, "%A %d %B")
                 except ValueError:
                     continue
 
-                if (datetime.now().month == 12 and next_collection.month == 1):
-                    next_collection = next_collection.replace(year=next_year)
-                else:
-                    next_collection = next_collection.replace(year=current_year)
+            # Year roll-over handling
+            if datetime.now().month == 12 and next_dt.month == 1:
+                next_dt = next_dt.replace(year=next_year)
+            else:
+                next_dt = next_dt.replace(year=current_year)
 
-                dict_data = {
-                    "type": bin_type,
-                    "collectionDate": next_collection.strftime("%d/%m/%Y"),
-                }
-                bindata["bins"].append(dict_data)
+            bindata["bins"].append({
+                "type": bin_type,
+                "collectionDate": next_dt.strftime("%d/%m/%Y"),
+            })
 
-        bindata["bins"].sort(key=lambda x: datetime.strptime(x.get("collectionDate"), "%d/%m/%Y"))
+        bindata["bins"].sort(key=lambda x: datetime.strptime(x["collectionDate"], "%d/%m/%Y"))
         return bindata


### PR DESCRIPTION
This update improves reliability and politeness of the Sutton Council data fetcher. It introduces retry logic, request headers, timeouts, and capped exponential backoff when polling for bin data. These changes reduce the chance of rate limits (HTTP 429), transient 5xx errors, and infinite loops during slow server responses.

Key changes:

Added a requests.Session with custom headers and polite retry policy (Retry + HTTPAdapter).

Implemented timeouts and exponential backoff for polling while the page loads.

Respects Retry-After headers when rate-limited.

Raises a clear error if the page remains in “Loading your bin days...” state after max retries.

Improved parsing logic to handle minor format variations (missing commas, extra siblings).

Impact:
No breaking changes — same function signature and output schema. Improves resilience, reduces unnecessary requests, and handles network throttling gracefully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved reliability of bin collection date retrieval for this council
  * Enhanced handling of date format variations and year transitions (December to January)
  * Better resilience against temporarily unavailable or slow-loading pages with automatic retry logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->