### PR TITLE
fix: Fareham Borough Council parameter for 2025

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/FarehamBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/FarehamBoroughCouncil.py
@@ -21,7 +21,7 @@ class CouncilClass(AbstractGetBinDataClass):
         }
         params = {
             "type": "JSON",
-            "list": "DomesticBinCollections",
+            "list": "DomesticBinCollections2025on",
             "Road": "",
             "Postcode": user_postcode,
         }


### PR DESCRIPTION
Bin dates have changed so this needs to be updated to pull the new data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated bin collection data source for Fareham Borough Council to ensure accurate and current collection schedules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->