### PR TITLE
fix: fix UPRN param encoding for SouthamptonCityCouncil

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/SouthamptonCityCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/SouthamptonCityCouncil.py
@@ -65,9 +65,14 @@ class CouncilClass(AbstractGetBinDataClass):
         r.raise_for_status()
 
         # Limit search scope to avoid duplicates
-        calendar_view_only = re.search(
+        calendar_match = re.search(
             r"#calendar1.*?listView", r.text, flags=re.DOTALL
-        )[0]
+        )
+        if not calendar_match:
+            raise ValueError(
+                "Unable to find calendar view in response. The council website structure may have changed."
+            )
+        calendar_view_only = calendar_match.group(0)
 
         results = re.findall(REGEX, calendar_view_only)
 


### PR DESCRIPTION
I'm hoping this will fix #1719 

I have been unable to test locally due to Captcha issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored reliable Southampton City Council bin collection lookup so collection dates are retrieved consistently.
  * Improved validation to surface a clear error when a council's waste calendar is missing or unreachable.
  * No changes to how collection dates are displayed or sorted for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->