### PR TITLE
Fix WestOxfordshireDistrictCouncil

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/WestOxfordshireDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/WestOxfordshireDistrictCouncil.py
@@ -56,7 +56,7 @@ class CouncilClass(AbstractGetBinDataClass):
 
             first_found_address = wait.until(
                 EC.element_to_be_clickable(
-                    (By.XPATH, '//*[@id="dropdown-element-23"]/ul')
+                    (By.XPATH, '//*[@id="combobox-input-23-1-23"]/ul')
                 )
             )
 


### PR DESCRIPTION
combo box dropdown behavior appears to have changed

Clicking the dropdown in selenium seems to cause it to disappear but clicking combo-input-23-1-23 seems to correctly select the first item in the list 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed address lookup functionality for West Oxfordshire District Council bin collection queries to ensure proper selection and processing of entered addresses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->