### PR TITLE
fix(SouthGloucestershireCouncil): Check None instead of empty string

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/SouthGloucestershireCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/SouthGloucestershireCouncil.py
@@ -48,7 +48,7 @@ class CouncilClass(AbstractGetBinDataClass):
             print(collection)
             item = collection.get('hso_nextcollection')
 
-            if item == "":
+            if not item:
                 continue
 
             collection_date = datetime.fromisoformat(item)


### PR DESCRIPTION
To resolve `Failed setup, will retry: Unexpected error: fromisoformat: argument must be str ` when no data for certain bin types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened validation to skip empty or missing collection entries (e.g., blank or null) before parsing dates, preventing parsing errors and avoiding incorrect or incomplete schedule entries. This improves reliability of displayed bin collection schedules and reduces unexpected failures when source data contains falsy values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->