### PR TITLE
Updated EdinburghCityCouncil.py with new 2025 start dates

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/EdinburghCityCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/EdinburghCityCouncil.py
@@ -42,13 +42,13 @@ class CouncilClass(AbstractGetBinDataClass):
         offset_days = days_of_week.index(collection_day)
 
         if collection_week == 0:
-            recyclingstartDate = datetime(2024, 11, 4)
-            glassstartDate = datetime(2024, 11, 4)
-            refusestartDate = datetime(2024, 11, 11)
+            recyclingstartDate = datetime(2025, 11, 3)
+            glassstartDate = datetime(2025, 11, 3)
+            refusestartDate = datetime(2025, 11, 10)
         elif collection_week == 1:
-            recyclingstartDate = datetime(2024, 11, 11)
-            glassstartDate = datetime(2024, 11, 11)
-            refusestartDate = datetime(2024, 11, 4)
+            recyclingstartDate = datetime(2025, 11, 10)
+            glassstartDate = datetime(2025, 11, 10)
+            refusestartDate = datetime(2025, 11, 3)
 
         refuse_dates = get_dates_every_x_days(refusestartDate, 14, 28)
         glass_dates = get_dates_every_x_days(glassstartDate, 14, 28)


### PR DESCRIPTION
Needed to update the start dates in EdinburghCityCouncil.py to newer 2025 ones.
There start dates are used by get_dates_every_x_days to calculate a range of 28 dates. With the original dates being in 2024 the ranges calculated were coming to an end, which was preventing next collections from being added to HomeAssistants calendar.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated collection schedules for Edinburgh with corrected 2025 start dates for recycling, glass, and refuse collections to ensure accurate scheduling information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->