### PR TITLE
fix: add User-Agent header to KingsLynnandWestNorfolkBC scraper

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/KingsLynnandWestNorfolkBC.py
+++ b/uk_bin_collection/uk_bin_collection/councils/KingsLynnandWestNorfolkBC.py
@@ -22,7 +22,10 @@ class CouncilClass(AbstractGetBinDataClass):
 
         URI = "https://www.west-norfolk.gov.uk/info/20174/bins_and_recycling_collection_dates"
 
-        headers = {"Cookie": f"bcklwn_uprn={user_uprn}"}
+        headers = {
+            "Cookie": f"bcklwn_uprn={user_uprn}",
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36",
+        }
 
         # Make the GET request
         response = requests.get(URI, headers=headers)


### PR DESCRIPTION
The Kings Lynn and West Norfolk council scraper was returning empty bin data because the website (https://www.west-norfolk.gov.uk) was blocking requests without a proper User-Agent header, resulting in a 403 Forbidden HTTP error.

Root cause:
- The scraper was sending HTTP requests with only a Cookie header
- The council website's server requires a User-Agent header to identify the client
- Without this header, the server rejected the request with HTTP 403 Forbidden
- This caused BeautifulSoup to parse an error page instead of bin collection data
- The scraper found zero bin_date_container divs, resulting in empty bins array

Solution:
- Added a standard Chrome User-Agent string to the request headers
- The website now accepts the request and returns the expected HTML content
- The scraper successfully parses bin collection dates from the response

Testing:
- Verified with test UPRN - now returns bin collections successfully
- Integration test passes successfully
- All unit tests continue to pass (76/77, unrelated Chrome driver failure)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved HTTP request handling for enhanced compatibility with external services.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->