### PR TITLE
fix: Built Docker image does not contain latest version

### DIFF
--- a/uk_bin_collection_api_server/Dockerfile
+++ b/uk_bin_collection_api_server/Dockerfile
@@ -9,7 +9,7 @@ COPY requirements.txt .
 
 # Install any needed packages specified in requirements.txt
 RUN apk add --no-cache gcc musl-dev libffi-dev openssl-dev \
-    && pip install --no-cache-dir -r requirements.txt \
+    && pip install --upgrade --no-cache-dir -r requirements.txt \
     && apk del gcc musl-dev libffi-dev openssl-dev
 
 # Copy the application code into the container


### PR DESCRIPTION
Fixes #1717... hopefully

I believe this PR should fix the issue described in #1717, where `pip` is selecting an out-of-date version when building the Docker image. However, it's a bit difficult for me to test! I don't think adding this option should cause any build issues. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build process now performs upgrades of listed packages during installation, so packages in build artifacts may be newer than before. This can alter runtime behavior, patch levels, and reproducibility of builds even when application code is unchanged. Consider verifying affected environments and restarting any deployments to pick up updated components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->