### PR TITLE
Changed to use dedicated API to retrieve collection data

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/SouthHollandDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/SouthHollandDistrictCouncil.py
@@ -14,7 +14,9 @@ class CouncilClass(AbstractGetBinDataClass):
     def parse_data(self, page: str, **kwargs) -> dict:
 
         user_uprn = kwargs.get("uprn")
-        check_uprn(user_uprn)
+        if not check_uprn(user_uprn):
+            raise ValueError("Invalid UPRN provided")
+        
         bindata = {"bins": []}
 
         URI = "https://www.sholland.gov.uk/apiserver/ajaxlibrary"
@@ -25,8 +27,9 @@ class CouncilClass(AbstractGetBinDataClass):
             "method": "SouthHolland.Waste.getCollectionDates",
             "params": {"UPRN": user_uprn}
         }
-        # Make the GET request
-        response = requests.post(URI, json=data)
+        
+        # Make the POST request
+        response = requests.post(URI, json=data, timeout=30)
 
         # Parse the JSON response
         bin_collection = response.json()


### PR DESCRIPTION
Changed SouthHollandDistrictCouncil.py as per issue #1741 - now using dedicated endpoint to retrieve collection dates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined bin collection lookup for South Holland with a direct data-fetching flow, improving speed and reliability of schedule retrieval.
  * Simplified control flow and response handling, returning normalized bin entries sorted by collection date.

* **Bug Fixes**
  * Added UPRN validation to surface invalid-input errors earlier.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->