### PR TITLE
fix: Norwich after u1 to ul change

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/NorwichCityCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/NorwichCityCouncil.py
@@ -69,13 +69,17 @@ class CouncilClass(AbstractGetBinDataClass):
         if soup.find("span", id="waste-hint"):
             raise Exception("No scheduled services at this address")
 
-        u1s = soup.find("section", id="scheduled-collections").find_all("u1")
+        uls = soup.find("section", id="scheduled-collections").find_all("ul")
 
-        for u1 in u1s:
-            lis = u1.find_all("li", recursive=False)
+        for ul in uls:
+            lis = ul.find_all("li", recursive=False)
 
-            date = lis[1].text.replace("\n", "")
-            bin_type = lis[2].text.replace("\n", "")
+            # Skip if not enough list items
+            if len(lis) < 3:
+                continue
+
+            date = lis[1].text.replace("\n", "").strip()
+            bin_type = lis[2].text.replace("\n", "").strip()
 
             dict_data = {
                 "type": bin_type,


### PR DESCRIPTION
fix: switched tags from u1 to ul to match updated website. added extra error handling for IndexErrors and stripping whitespace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated bin collection data retrieval for Norwich City Council to correctly process collection schedules.
  * Enhanced data validation to skip incomplete entries and improve reliability.
  * Improved data quality by removing excess whitespace from collection information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->