### PR TITLE
fix:Rushcliffe BC broken scraping

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/RushcliffeBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/RushcliffeBoroughCouncil.py
@@ -7,8 +7,6 @@ from selenium.webdriver.support.wait import WebDriverWait
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
-import string
-
 
 # import the wonderful Beautiful Soup and the URL grabber
 class CouncilClass(AbstractGetBinDataClass):
@@ -84,23 +82,31 @@ class CouncilClass(AbstractGetBinDataClass):
 
             if bins_text:
                 results = re.findall(
-                    r"Your (.*?) bin will next be collected on (\d\d?\/\d\d?\/\d{4})",
+                    r"Your next (.*?)(?:\s\(.*\))? bin collections will be (\d\d?\/\d\d?\/\d{4}) and (\d\d?\/\d\d?\/\d{4})",
                     bins_text.get_text(),
                 )
                 if results:
                     for result in results:
-                        collection_date = datetime.strptime(result[1], "%d/%m/%Y")
-                        dict_data = {
-                            "type": result[0],
-                            "collectionDate": collection_date.strftime(date_format),
-                        }
-                        data["bins"].append(dict_data)
-
-                        data["bins"].sort(
-                            key=lambda x: datetime.strptime(
-                                x.get("collectionDate"), "%d/%m/%Y"
-                            )
+                        collection_one = datetime.strptime(result[1], "%d/%m/%Y")
+                        data["bins"].append(
+                            {
+                                "type": result[0],
+                                "collectionDate": collection_one.strftime(date_format),
+                            }
                         )
+                        collection_two = datetime.strptime(result[2], "%d/%m/%Y")
+                        data["bins"].append(
+                            {
+                                "type": result[0],
+                                "collectionDate": collection_two.strftime(date_format),
+                            }
+                        )
+
+                    data["bins"].sort(
+                        key=lambda x: datetime.strptime(
+                            x.get("collectionDate"), "%d/%m/%Y"
+                        )
+                    )
         except Exception as e:
             # Here you can log the exception if needed
             print(f"An error occurred: {e}")


### PR DESCRIPTION
Rushcliffe BC have updated its self-service response to contain an additional collection type and collection date.

e.g.
```text
Your next grey bin collections will be 16/12/2025 and 30/12/2025
Your next blue bin collections will be 09/12/2025 and 23/12/2025
Your next garden waste bin collections will be 09/12/2025 and 20/01/2026
Your next glass (purple lid) bin collections will be 16/12/2025 and 27/01/2026
```
This PR updates the regex to handle the change in presentation.

We now include the additional collection date in the result data.

Verified that the behaviour test for RushcliffeBoroughCouncil now passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rushcliffe Borough Council bin collection schedules now capture multiple collection dates per bin type, providing more detailed scheduling information.

* **Bug Fixes**
  * Improved error handling and data processing robustness for collection schedule retrieval.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->