### PR TITLE
Fix: January bin dates being treated as past during December

### DIFF
--- a/custom_components/uk_bin_collection/__init__.py
+++ b/custom_components/uk_bin_collection/__init__.py
@@ -413,6 +413,17 @@ class HouseholdBinCoordinator(DataUpdateCoordinator):
                 )
                 continue
 
+            if (
+                collection_date < current_date
+                and current_date.month == 12
+                and collection_date.month == 1
+            ):
+                collection_date = collection_date.replace(year=current_date.year + 1)
+                _LOGGER.debug(
+                    f"{LOG_PREFIX} Corrected rollover year for '{bin_type}' to {collection_date}"
+                )
+            
+
             existing_date = next_collection_dates.get(bin_type)
             if collection_date >= current_date and (
                 not existing_date or collection_date < existing_date


### PR DESCRIPTION
Some councils return January collection dates using the current year during December. For example, Bromley just lists the day and month, which is then interpreted as the current year rather than next year. This causes valid upcoming collections to be dropped. This change corrects the year in Dec → Jan rollover cases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed bin collection date handling for collections that cross year boundaries. When viewing upcoming collections in December scheduled for January, dates now correctly reflect the following year.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->