### PR TITLE
Fix: South Lanarkshire Council

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/SouthLanarkshireCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/SouthLanarkshireCouncil.py
@@ -71,6 +71,11 @@ class CouncilClass(AbstractGetBinDataClass):
             for day in week_days:
                 for row in collection_schedule:
                     schedule_type = row.find("th").get_text().strip()
+
+                    # collection schedule contains area name -> filter out
+                    if schedule_type == "Area":
+                        continue
+
                     results2 = re.search("([^(]+)", row.find("td").get_text().strip())
                     schedule_cadence = row.find("td").get_text().strip().split(" ")[1]
                     if results2:


### PR DESCRIPTION
fix: #1771

The collections table contains "Area", e.g. [here](https://www.southlanarkshire.gov.uk/directory_record/576623/allanshaw_street_hamilton) (linked in the issue). I have reproduced the same issue on my local street with "Area" also being "Hamilton".

The fix here is to simply skip "Area" if we see it as the schedule type.

(I have also noticed the fix seems to be a part of a batch fix in https://github.com/robbrad/UKBinCollectionData/pull/1772. What's the best practice here? I'm only opening the PR since it bugged me on my HA and I finally had some time to poke about :eyes: )

<img width="804" height="598" alt="image" src="https://github.com/user-attachments/assets/9c8729dd-a5a6-468a-93b7-37fe459f7e0f" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed South Lanarkshire Council schedules where area-name rows were being included with bin collection entries. These extraneous area identifiers are now filtered out, so users see only relevant, accurate collection schedules.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->