### PR TITLE
Fix: HuntingdonDistrictCouncil parsing

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/HuntingdonDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/HuntingdonDistrictCouncil.py
@@ -44,11 +44,18 @@ class CouncilClass(AbstractGetBinDataClass):
             if no_garden_message in result.get_text(strip=True):
                 continue
             else:
+                text = result.get_text(strip=True)
+                # Example: The next collection for your domestic waste in your 240lt wheeled bin is on
+                before = "collection for your "
+                after = " waste"
+                # grab words in between
+                bin_type = text[
+                    text.index(before) + len(before) : text.index(after)
+                ].capitalize()
+
                 data["bins"].append(
                     {
-                        "type": " ".join(
-                            result.get_text(strip=True).split(" ")[5:7]
-                        ).capitalize(),
+                        "type": bin_type,
                         "collectionDate": datetime.strptime(
                             result.find("strong").get_text(strip=True), "%A %d %B %Y"
                         ).strftime(date_format),


### PR DESCRIPTION
This is based on an assumption. I have attempted to make it a little more robust -- looking for specific surrounding words instead of finding words by index.

Current output from `collect_data.py`

<img width="382" height="288" alt="image" src="https://github.com/user-attachments/assets/6db4b519-3ae1-434c-b2c9-b2d4720e87d3" />


After fix:

<img width="384" height="290" alt="image" src="https://github.com/user-attachments/assets/fead2591-0165-4b5c-9696-33ab317b6cb3" />


I tested this at my address only but I believe this should work in general.

Thanks for this project!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced bin type extraction for Huntingdon District Council to ensure more accurate and reliable parsing of waste collection information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->