### PR TITLE
fix: Newham Council fix

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/NewhamCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/NewhamCouncil.py
@@ -36,13 +36,20 @@ class CouncilClass(AbstractGetBinDataClass):
         if len(sections_recycling) > 0:
             sections.append(sections_recycling[0])
 
+        # as well as one for food waste
+        sections_food_waste = soup.find_all(
+            "div", {"class": "card h-100 card-food"}
+        )
+        if len(sections_food_waste) > 0:
+            sections.append(sections_food_waste[0])
+
         # For each bin section, get the text and the list elements
         for item in sections:
             header = item.find("div", {"class": "card-header"})
             bin_type_element = header.find_next("b")
             if bin_type_element is not None:
                 bin_type = bin_type_element.text
-                array_expected_types = ["Domestic", "Recycling"]
+                array_expected_types = ["Domestic", "Recycling", "Food Waste"]
                 if bin_type in array_expected_types:
                     date = (
                         item.find_next("p", {"class": "card-text"})


### PR DESCRIPTION
This PR contains 2 fixes and I've also added one type of bin collection (food waste)

Fixes:
- disable SSL verification to resolve certificate verification error
  - HA was giving me the below error so bypassing with `verify=False`
`Failed setup, will retry: Unexpected error: HTTPSConnectionPool(host='bincollection.newham.gov.uk', port=443): Max retries exceeded with url: /Details/Index/XXXXXXXX (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1032)')))`
  - seems to be due to an incomplete cert chain
- correct datetime parsing from DD/MM/YYYY to MM/DD/YYYY
  - for some reason, the date format was changed to MM/DD/YYYY so changed the format

Features:
- Newham is rolling out a food waste bin so although not all residents have it yet, the collection website does display a date if your UPRN has one

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking Food Waste bin collection alongside existing bin types.

* **Bug Fixes**
  * Corrected collection date parsing to ensure accurate date recognition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->