### PR TITLE
fix: address selection in Broxbourne Council

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/BroxbourneCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/BroxbourneCouncil.py
@@ -57,15 +57,21 @@ class CouncilClass(AbstractGetBinDataClass):
             postcode_input = WebDriverWait(driver, 20).until(
                 EC.element_to_be_clickable((By.XPATH, "//input[@autocomplete='postal-code']"))
             )
+
             postcode_input.clear()
             postcode_input.send_keys(user_postcode)
-            
+
             # Press Enter to lookup
             postcode_input.send_keys(Keys.RETURN)
-            
+
             # Select address
             address_select = WebDriverWait(driver, 15).until(
-                EC.presence_of_element_located((By.XPATH, "//select"))
+                EC.presence_of_element_located(
+                    (
+                        By.XPATH,
+                        "//label[normalize-space()='Choose address']/following::select[1]",
+                    )
+                )
             )
             Select(address_select).select_by_value(user_uprn)
             


### PR DESCRIPTION

<img width="789" height="278" alt="image" src="https://github.com/user-attachments/assets/82c7ad09-e902-4cb0-a928-a6a4060ce484" />

The addition `<select>` elements shown above leak into our lookup and cause `Cannot locate option with value ...` errors when we try to select the UPRN. This change makes the selector target the `Choose address` drop-down explicitly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved address selection reliability for Broxbourne Council lookups, reducing the risk of selecting incorrect addresses during postcode searches.
  * Enhanced postcode input handling to ensure proper data entry when searching for collection details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->