### PR TITLE
fix: EalingCouncil/LondonBoroughEaling: Use collectionDate not collectionDateString

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/EalingCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/EalingCouncil.py
@@ -35,7 +35,7 @@ class CouncilClass(AbstractGetBinDataClass):
                 {
                     "type": param["Service"],
                     "collectionDate": datetime.strptime(
-                        param["collectionDateString"], "%d/%m/%Y"
+                        param["collectionDate"][0], "%d/%m/%Y"
                     ).strftime(date_format),
                 }
             )

--- a/uk_bin_collection/uk_bin_collection/councils/LondonBoroughEaling.py
+++ b/uk_bin_collection/uk_bin_collection/councils/LondonBoroughEaling.py
@@ -38,7 +38,7 @@ class CouncilClass(AbstractGetBinDataClass):
             param2 = json_data["param2"]
             for service in param2:
                 Bin_Type = service["Service"]
-                NextCollectionDate = service["collectionDateString"]
+                NextCollectionDate = service["collectionDate"][0]
                 dict_data = {
                     "type": Bin_Type,
                     "collectionDate": datetime.strptime(


### PR DESCRIPTION
These modules cannot parse the current data for my address, with the following error:

> Failed setup, will retry: Unexpected error: unconverted data remains:
> ,24/03/2026

(I do not know which of the two almost identical implementations I am using - #1884.)

Looking at the council website's response to the POST request, included below after being pretty-printed with jq, the problem is that the garden waste bin has the following value for collectionDateString:

    "collectionDateString": "24/03/2026,24/03/2026",

But the code expects this to contain a single date.

Instead, use the collectionDate property, which contains a list of dates, and take the first element. (The council website instead splits the collectionDateString on comma.)

Resolves https://github.com/robbrad/UKBinCollectionData/issues/1885

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed collection date retrieval for Ealing Council services. Dates are now correctly parsed from API responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->