### PR TITLE
feat(North Northamptonshire): food caddy bin type in calendar scraper

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/NorthNorthamptonshireCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/NorthNorthamptonshireCouncil.py
@@ -56,6 +56,8 @@ class CouncilClass(AbstractGetBinDataClass):
                 bin_type = "Recycling"
             elif "garden" in sov:
                 bin_type = "Garden"
+            elif "food" in sov or "caddy" in sov:
+                bin_type = "Food caddy"
             elif "refuse" in sov:
                 bin_type = "General"
             else:

--- a/uk_bin_collection/uk_bin_collection/councils/NorthNorthamptonshireCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/NorthNorthamptonshireCouncil.py
@@ -57,7 +57,7 @@ class CouncilClass(AbstractGetBinDataClass):
             elif "garden" in sov:
                 bin_type = "Garden"
             elif "food" in sov or "caddy" in sov:
-                bin_type = "Food caddy"
+                bin_type = "Food Caddy"
             elif "refuse" in sov:
                 bin_type = "General"
             else:


### PR DESCRIPTION
Extends the North Northamptonshire calendar parser so food waste / caddy collections are classified as **`Food caddy`** instead of falling through to **`Unknown`**.
- **`NorthNorthamptonshireCouncil`**: after **Garden**, match event titles (lowercased) containing **`food`** or **`caddy`**, and set **`bin_type`** to **`Food caddy`**, before the existing **`refuse`** → **General** branch.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bin-type classification for North Northamptonshire Council to correctly identify food caddy/food collections, ensuring collection schedules show accurate bin types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->