### PR TITLE
Update SouthStaffordshireDistrictCouncil.py - add_bin_types_to_collection

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/SouthStaffordshireDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/SouthStaffordshireDistrictCouncil.py
@@ -34,14 +34,14 @@ class CouncilClass(AbstractGetBinDataClass):
     def add_bin_types_to_collection(
         self, bin_data: {"bins": []}, collection_date: str, collectionType: str
     ):
-        if "Grey Bin" in collectionType:
+        if "General waste" in collectionType:
             bin_data["bins"].append(
                 {
                     "type": "Grey Bin",
                     "collectionDate": self.parse_date(collection_date),
                 }
             )
-        if "Green Bin" in collectionType:
+        if "Garden waste" in collectionType:
             bin_data["bins"].append(
                 {
                     "type": "Green Bin",
@@ -49,7 +49,7 @@ class CouncilClass(AbstractGetBinDataClass):
                 }
             )
 
-        if "Blue Bin" in collectionType:
+        if "Recycling" in collectionType:
             bin_data["bins"].append(
                 {
                     "type": "Blue Bin",


### PR DESCRIPTION
Modify add_bin_types_to_collection - "If x in" terms

`Grey Bin` -> `General waste`
`Green Bin` -> `Garden waste`
`Blue Bin` -> `Recycling`

(Food waste yet to be added)

I have only modified the "search term" - not the resulting "type" to minimise breaking change for existing users.
_Is this preferred? This creates a mismatch between the Council website and the integration's names for these bins. Personally, the existing names are more colloquial._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  ~~* Fixed collection type identification for South Staffordshire District Council to ensure accurate bin categorization. Grey Bin collections are now correctly identified for general waste, Green Bin for garden waste, and Blue Bin for recycling materials. Users will receive accurate bin collection notifications for their area.~~

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Summary by Human

## Release Notes

* **Bug Fixes**
  * Fixed collection type identification for South Staffordshire District Council to ensure accurate bin categorisation. Grey Bin collections are now correctly identified as "general waste", "garden waste" for Green Bin, and "recycling" for Blue Bin.