### PR TITLE
fix: BlabyDistrictCouncil - add User-Agent header to prevent 403

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/BlabyDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/BlabyDistrictCouncil.py
@@ -30,7 +30,8 @@ class CouncilClass(AbstractGetBinDataClass):
         session.headers.update({
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36"
         })
-        response = session.get(URI, verify=False)
+        response = session.get(URI, verify=False, timeout=30)
+        response.raise_for_status()
 
         # Parse the HTML
         soup = BeautifulSoup(response.content, "html.parser")

--- a/uk_bin_collection/uk_bin_collection/councils/BlabyDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/BlabyDistrictCouncil.py
@@ -25,8 +25,12 @@ class CouncilClass(AbstractGetBinDataClass):
 
         URI = f"https://my.blaby.gov.uk/set-location.php?ref={user_uprn}&redirect=collections"
 
-        # Make the GET request
-        response = requests.get(URI, verify=False)
+        # Make the GET request (User-Agent required to avoid 403)
+        session = requests.Session()
+        session.headers.update({
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36"
+        })
+        response = session.get(URI, verify=False)
 
         # Parse the HTML
         soup = BeautifulSoup(response.content, "html.parser")


### PR DESCRIPTION
Blaby's server returns 403 for requests without a User-Agent header. Added a standard browser User-Agent to the requests session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of bin collection retrieval for Blaby District Council by adding request timeout, consistent request headers, and proper HTTP error handling to prevent parsing of failed responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->