### PR TITLE
fix: BrentCouncil - add User-Agent header

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/BrentCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/BrentCouncil.py
@@ -27,6 +27,9 @@ class CouncilClass(AbstractGetBinDataClass):
         payload = {"postcode": user_postcode}
 
         s = requests.Session()
+        s.headers.update({
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36"
+        })
 
         # Make the POST request
         response = s.post(URI, data=payload)


### PR DESCRIPTION
Added a User-Agent header to the requests session. Without it some requests were getting blocked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with Brent Council's recycling service by enhancing how the application identifies itself when communicating with their system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->