### PR TITLE
fix: SwaleBoroughCouncil - add user_agent to webdriver

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/SwaleBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/SwaleBoroughCouncil.py
@@ -88,9 +88,6 @@ class CouncilClass(AbstractGetBinDataClass):
 
             data = {"bins": []}
 
-            current_year = datetime.now().year
-            next_year = current_year + 1
-
             next_collection_date = soup.find(
                 "strong", id="SBC-YBD-collectionDate"
             ).text.strip()
@@ -111,12 +108,7 @@ class CouncilClass(AbstractGetBinDataClass):
             future_bins = [li.text.strip() for li in soup.select("#FirstFutureBins li")]
 
             for bin in next_bins:
-                collection_date = datetime.strptime(next_collection_date, "%A, %d %B")
-                if (datetime.now().month == 12) and (collection_date.month == 1):
-                    collection_date = collection_date.replace(year=next_year)
-                else:
-                    collection_date = collection_date.replace(year=current_year)
-
+                collection_date = parse_collection_date(next_collection_date)
                 dict_data = {
                     "type": bin,
                     "collectionDate": collection_date.strftime(date_format),
@@ -124,11 +116,7 @@ class CouncilClass(AbstractGetBinDataClass):
                 data["bins"].append(dict_data)
 
             for bin in future_bins:
-                collection_date = datetime.strptime(future_collection_date, "%A, %d %B")
-                if (datetime.now().month == 12) and (collection_date.month == 1):
-                    collection_date = collection_date.replace(year=next_year)
-                else:
-                    collection_date = collection_date.replace(year=current_year)
+                collection_date = parse_collection_date(future_collection_date)
                 dict_data = {
                     "type": bin,
                     "collectionDate": collection_date.strftime(date_format),

--- a/uk_bin_collection/uk_bin_collection/councils/SwaleBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/SwaleBoroughCouncil.py
@@ -42,7 +42,8 @@ class CouncilClass(AbstractGetBinDataClass):
             council_url = "https://swale.gov.uk/bins-littering-and-the-environment/bins/check-your-bin-day"
 
             # Create Selenium webdriver
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get(council_url)
 
             # Wait for the postcode field to appear then populate it


### PR DESCRIPTION
Swale's site was intermittently rejecting headless Chrome without a user agent. Passed a realistic user_agent string to create_webdriver.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved bin collection date handling for Swale Borough Council by streamlining date parsing and year inference logic. Enhanced WebDriver initialization for better browser compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->