### PR TITLE
fix: OxfordCityCouncil - handle multiple editor divs

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/OxfordCityCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/OxfordCityCouncil.py
@@ -44,7 +44,8 @@ class CouncilClass(AbstractGetBinDataClass):
         soup = BeautifulSoup(collection_response.text, "html.parser")
         #print(soup)
 
-        for paragraph in soup.find("div", class_="editor").find_all("p"):
+        for editor_div in soup.find_all("div", class_="editor"):
+          for paragraph in editor_div.find_all("p"):
             matches = re.match(r"^Your next (\w+) collections: (.*)", paragraph.text)
             if matches:
                 collection_type, date_string = matches.groups()


### PR DESCRIPTION
The council added an Easter message in a second div with class "editor", so soup.find("div", class_="editor") was returning the wrong one. Changed to find_all and iterate to the div that actually contains bin data.

Fixes #1908