### PR TITLE
Fix garden collection for plymouth council

### DIFF
--- a/custom_components/uk_bin_collection/manifest.json
+++ b/custom_components/uk_bin_collection/manifest.json
@@ -9,7 +9,7 @@
     "integration_type": "service",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/robbrad/UKBinCollectionData/issues",
-    "requirements": ["uk-bin-collection>=0.165.0"],
+    "requirements": ["uk-bin-collection@git+https://github.com/Menace-Dennis/UKBinCollectionData.git@master"],
     "version": "0.165.0",
     "zeroconf": []
 }

--- a/custom_components/uk_bin_collection/manifest.json
+++ b/custom_components/uk_bin_collection/manifest.json
@@ -9,7 +9,7 @@
     "integration_type": "service",
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/robbrad/UKBinCollectionData/issues",
-    "requirements": ["uk-bin-collection@git+https://github.com/Menace-Dennis/UKBinCollectionData.git@master"],
+    "requirements": ["uk-bin-collection>=0.165.0"],
     "version": "0.165.0",
     "zeroconf": []
 }

--- a/uk_bin_collection/uk_bin_collection/councils/PlymouthCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/PlymouthCouncil.py
@@ -1,24 +1,13 @@
 import time
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import requests
 
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
-import json
-import logging
-
-_LOGGER = logging.getLogger(__name__)
-
 
 class CouncilClass(AbstractGetBinDataClass):
-    """
-    Concrete classes have to implement all abstract operations of the
-    base class. They can also override some operations with a default
-    implementation.
-    """
-
     def parse_data(self, page: str, **kwargs) -> dict:
         user_uprn = kwargs.get("uprn")
         check_uprn(user_uprn)
@@ -38,8 +27,7 @@ class CouncilClass(AbstractGetBinDataClass):
         s = requests.session()
         r = s.get(SESSION_URL)
         r.raise_for_status()
-        session_data = r.json()
-        sid = session_data["auth-session"]
+        sid = r.json()["auth-session"]
 
         def run_lookup(lookup_id: str, data: dict) -> dict:
             params = {
@@ -55,27 +43,19 @@ class CouncilClass(AbstractGetBinDataClass):
             r = s.post(API_URL, json=data, headers=headers, params=params)
             r.raise_for_status()
             response_data = r.json()
-        
-            _LOGGER.warning(
-                "PLYMOUTH lookup %s raw response: %s",
-                lookup_id,
-                json.dumps(response_data, indent=2),
-            )
-        
+
             transformed = response_data.get("integration", {}).get("transformed")
             if transformed is None:
                 raise ValueError(
-                    f"Plymouth lookup {lookup_id} returned no transformed data: "
-                    f"{json.dumps(response_data, indent=2)}"
+                    f"Plymouth lookup {lookup_id} returned no transformed data: {response_data}"
                 )
-        
+
             rows_data = transformed.get("rows_data")
             if not isinstance(rows_data, dict):
                 raise ValueError(
-                    f"Plymouth lookup {lookup_id} returned invalid rows_data: "
-                    f"{json.dumps(response_data, indent=2)}"
+                    f"Plymouth lookup {lookup_id} returned invalid rows_data: {response_data}"
                 )
-        
+
             return rows_data
 
         standard_data = {
@@ -83,37 +63,84 @@ class CouncilClass(AbstractGetBinDataClass):
                 "Section 1": {
                     "number1": {"value": user_uprn},
                     "lastncoll": {"value": "0"},
-                    "nextncoll": {"value": "9"},
+                    "nextncoll": {"value": "20"},
                 }
             },
         }
-
         standard_rows = run_lookup("5c99439d85f83", standard_data)
 
-        collective_data = {
+        start_date = datetime.now().strftime("%Y-%m-%dT00:00:00")
+        end_date = (datetime.now() + timedelta(days=24)).strftime("%Y-%m-%dT00:00:00")
+
+        collective_key_data = {
+            "stopOnFailure": True,
+            "usePHPIntegrations": True,
+            "stage_id": "AF-Stagedba4a7d5-e916-46b6-abdb-643d38bec875",
+            "stage_name": "Check Bin Day",
+            "formId": "AF-Form-b8823128-0c85-47e1-b344-4fc81480edd0",
             "formValues": {
                 "Section 1": {
                     "request_type": {"value": "GARDEN"},
-                    "number1": {"value": user_uprn},
-                    "UPRN": {"value": str(user_uprn)},
+                    "addressDetails": {"value": ""},
+                    "number1": {"value": ""},
+                    "UPRN": {"value": ""},
+                    "collectiveKey": {"value": ""},
+                    "collectiveUPRN": {"value": ""},
+                    "collectiveGetJobStartDate": {"value": start_date},
+                    "collectiveGetJobEndDate": {"value": end_date},
+                    "lastncoll": {"value": "0"},
+                    "nextncoll": {"value": "9"},
+                    "displayChecker": {"value": "false"},
+                    "hiddenPN": {"value": "Waste - Check your bin day"},
+                    "productArea1": {"value": "Self"},
+                    "ffDirectorate": {"value": "Place"},
+                    "ffDepartment": {"value": "Street Services"},
+                    "ffIntExt": {"value": "External"},
+                    "ffPreSubmission": {"value": "preSubmission"},
+                }
+            },
+            "isPublished": True,
+            "formName": "Waste - Check your bin day",
+            "processId": "AF-Process-31283f9a-3ae7-4225-af71-bf3884e0ac1b",
+        }
+
+        key_rows = run_lookup("6936e38f6d376", collective_key_data)
+        collective_key = key_rows.get("0", {}).get("collectiveKey")
+        if not collective_key:
+            raise ValueError("Plymouth collective key lookup returned no collectiveKey")
+
+        collective_data = {
+            "stopOnFailure": True,
+            "usePHPIntegrations": True,
+            "stage_id": "AF-Stagedba4a7d5-e916-46b6-abdb-643d38bec875",
+            "stage_name": "Check Bin Day",
+            "formId": "AF-Form-b8823128-0c85-47e1-b344-4fc81480edd0",
+            "formValues": {
+                "Section 1": {
+                    "request_type": {"value": "GARDEN"},
                     "addressDetails": {
                         "value": {
                             "Section 1": {
-                                "ChooseAddress": {"value": str(user_uprn)},
+                                "ChooseAddress": {"value": str(user_uprn)}
                             }
                         }
                     },
+                    "number1": {"value": str(user_uprn)},
+                    "UPRN": {"value": str(user_uprn)},
+                    "collectiveKey": {"value": collective_key},
+                    "collectiveUPRN": {"value": str(user_uprn)},
+                    "collectiveGetJobStartDate": {"value": start_date},
+                    "collectiveGetJobEndDate": {"value": end_date},
                 }
-            }
+            },
+            "isPublished": True,
+            "formName": "Waste - Check your bin day",
+            "processId": "AF-Process-31283f9a-3ae7-4225-af71-bf3884e0ac1b",
         }
 
-        collective_rows = {}
-        try:
-            collective_rows = run_lookup("698b9c49a3c13", collective_data)
-        except Exception as exc:
-            _LOGGER.warning("PLYMOUTH collective lookup failed: %s", exc)
+        collective_rows = run_lookup("698b9c49a3c13", collective_data)
 
-        BIN_TYPES = {
+        bin_type_dict = {
             "DO": "Brown Domestic Bin",
             "RE": "Green Recycling Bin",
             "OR": "Garden Waste Bin",
@@ -122,7 +149,7 @@ class CouncilClass(AbstractGetBinDataClass):
         seen = set()
 
         for row in standard_rows.values():
-            bin_type = BIN_TYPES.get(row["Round_Type"], row["Round_Type"])
+            bin_type = bin_type_dict.get(row["Round_Type"], row["Round_Type"])
             collection_date = datetime.strptime(
                 row["Date"].split("T")[0], "%Y-%m-%d"
             ).strftime("%d/%m/%Y")
@@ -136,9 +163,9 @@ class CouncilClass(AbstractGetBinDataClass):
 
         for row in collective_rows.values():
             waste_type = row.get("collectiveWasteType", "").lower()
-            collection_date = row.get("collectiveCollectionDate")
+            collection_date = row.get("collectiveCollectionDate", "").strip()
 
-            if not collection_date:
+            if not collection_date or waste_type == "no jobs found":
                 continue
 
             if "garden" in waste_type:

--- a/uk_bin_collection/uk_bin_collection/councils/PlymouthCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/PlymouthCouncil.py
@@ -78,7 +78,13 @@ class CouncilClass(AbstractGetBinDataClass):
                 }
             },
         }
-        standard_rows = run_lookup(STANDARD_LOOKUP_ID, standard_data)
+
+        standard_rows = {}
+        standard_error = None
+        try:
+            standard_rows = run_lookup(STANDARD_LOOKUP_ID, standard_data)
+        except (requests.RequestException, ValueError) as exc:
+            standard_error = exc
 
         collective_key_data = {
             "stopOnFailure": True,
@@ -112,49 +118,55 @@ class CouncilClass(AbstractGetBinDataClass):
             "processId": "AF-Process-31283f9a-3ae7-4225-af71-bf3884e0ac1b",
         }
 
-        key_rows = run_lookup(COLLECTIVE_KEY_LOOKUP_ID, collective_key_data)
+        collective_rows = {}
+        collective_error = None
 
-        collective_key = None
-        for row in key_rows.values():
-            if isinstance(row, dict) and row.get("collectiveKey"):
-                collective_key = row["collectiveKey"]
-                break
+        try:
+            key_rows = run_lookup(COLLECTIVE_KEY_LOOKUP_ID, collective_key_data)
 
-        if not collective_key:
-            raise ValueError(
-                f"Plymouth collective key lookup returned no collectiveKey: {key_rows}"
-            )
+            collective_key = None
+            for row in key_rows.values():
+                if isinstance(row, dict) and row.get("collectiveKey"):
+                    collective_key = row["collectiveKey"]
+                    break
 
-        collective_data = {
-            "stopOnFailure": True,
-            "usePHPIntegrations": True,
-            "stage_id": "AF-Stagedba4a7d5-e916-46b6-abdb-643d38bec875",
-            "stage_name": "Check Bin Day",
-            "formId": "AF-Form-b8823128-0c85-47e1-b344-4fc81480edd0",
-            "formValues": {
-                "Section 1": {
-                    "request_type": {"value": "GARDEN"},
-                    "addressDetails": {
-                        "value": {
-                            "Section 1": {
-                                "ChooseAddress": {"value": str(user_uprn)}
+            if not collective_key:
+                raise ValueError(
+                    f"Plymouth collective key lookup returned no collectiveKey: {key_rows}"
+                )
+
+            collective_data = {
+                "stopOnFailure": True,
+                "usePHPIntegrations": True,
+                "stage_id": "AF-Stagedba4a7d5-e916-46b6-abdb-643d38bec875",
+                "stage_name": "Check Bin Day",
+                "formId": "AF-Form-b8823128-0c85-47e1-b344-4fc81480edd0",
+                "formValues": {
+                    "Section 1": {
+                        "request_type": {"value": "GARDEN"},
+                        "addressDetails": {
+                            "value": {
+                                "Section 1": {
+                                    "ChooseAddress": {"value": str(user_uprn)}
+                                }
                             }
-                        }
-                    },
-                    "number1": {"value": str(user_uprn)},
-                    "UPRN": {"value": str(user_uprn)},
-                    "collectiveKey": {"value": collective_key},
-                    "collectiveUPRN": {"value": str(user_uprn)},
-                    "collectiveGetJobStartDate": {"value": start_date},
-                    "collectiveGetJobEndDate": {"value": end_date},
-                }
-            },
-            "isPublished": True,
-            "formName": "Waste - Check your bin day",
-            "processId": "AF-Process-31283f9a-3ae7-4225-af71-bf3884e0ac1b",
-        }
+                        },
+                        "number1": {"value": str(user_uprn)},
+                        "UPRN": {"value": str(user_uprn)},
+                        "collectiveKey": {"value": collective_key},
+                        "collectiveUPRN": {"value": str(user_uprn)},
+                        "collectiveGetJobStartDate": {"value": start_date},
+                        "collectiveGetJobEndDate": {"value": end_date},
+                    }
+                },
+                "isPublished": True,
+                "formName": "Waste - Check your bin day",
+                "processId": "AF-Process-31283f9a-3ae7-4225-af71-bf3884e0ac1b",
+            }
 
-        collective_rows = run_lookup(COLLECTIVE_JOBS_LOOKUP_ID, collective_data)
+            collective_rows = run_lookup(COLLECTIVE_JOBS_LOOKUP_ID, collective_data)
+        except (requests.RequestException, ValueError) as exc:
+            collective_error = exc
 
         bin_type_dict = {
             "DO": "Brown Domestic Bin",
@@ -203,6 +215,19 @@ class CouncilClass(AbstractGetBinDataClass):
                 bindata["bins"].append(
                     {"type": bin_type, "collectionDate": collection_date}
                 )
+
+        if not standard_rows and not collective_rows:
+            if standard_error and collective_error:
+                raise ValueError(
+                    f"Plymouth standard and collective lookups both failed. "
+                    f"Standard error: {standard_error}. "
+                    f"Collective error: {collective_error}"
+                )
+            if standard_error:
+                raise ValueError(f"Plymouth standard lookup failed: {standard_error}")
+            if collective_error:
+                raise ValueError(f"Plymouth collective lookup failed: {collective_error}")
+            raise ValueError("Plymouth lookups returned no collection rows")
 
         bindata["bins"].sort(
             key=lambda x: datetime.strptime(x["collectionDate"], "%d/%m/%Y")

--- a/uk_bin_collection/uk_bin_collection/councils/PlymouthCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/PlymouthCouncil.py
@@ -112,44 +112,49 @@ class CouncilClass(AbstractGetBinDataClass):
             "processId": "AF-Process-31283f9a-3ae7-4225-af71-bf3884e0ac1b",
         }
 
-        collective_rows = {}
-        try:
-            key_rows = run_lookup(COLLECTIVE_KEY_LOOKUP_ID, collective_key_data)
-            collective_key = key_rows.get("0", {}).get("collectiveKey")
+        key_rows = run_lookup(COLLECTIVE_KEY_LOOKUP_ID, collective_key_data)
 
-            if collective_key:
-                collective_data = {
-                    "stopOnFailure": True,
-                    "usePHPIntegrations": True,
-                    "stage_id": "AF-Stagedba4a7d5-e916-46b6-abdb-643d38bec875",
-                    "stage_name": "Check Bin Day",
-                    "formId": "AF-Form-b8823128-0c85-47e1-b344-4fc81480edd0",
-                    "formValues": {
-                        "Section 1": {
-                            "request_type": {"value": "GARDEN"},
-                            "addressDetails": {
-                                "value": {
-                                    "Section 1": {
-                                        "ChooseAddress": {"value": str(user_uprn)}
-                                    }
-                                }
-                            },
-                            "number1": {"value": str(user_uprn)},
-                            "UPRN": {"value": str(user_uprn)},
-                            "collectiveKey": {"value": collective_key},
-                            "collectiveUPRN": {"value": str(user_uprn)},
-                            "collectiveGetJobStartDate": {"value": start_date},
-                            "collectiveGetJobEndDate": {"value": end_date},
+        collective_key = None
+        for row in key_rows.values():
+            if isinstance(row, dict) and row.get("collectiveKey"):
+                collective_key = row["collectiveKey"]
+                break
+
+        if not collective_key:
+            raise ValueError(
+                f"Plymouth collective key lookup returned no collectiveKey: {key_rows}"
+            )
+
+        collective_data = {
+            "stopOnFailure": True,
+            "usePHPIntegrations": True,
+            "stage_id": "AF-Stagedba4a7d5-e916-46b6-abdb-643d38bec875",
+            "stage_name": "Check Bin Day",
+            "formId": "AF-Form-b8823128-0c85-47e1-b344-4fc81480edd0",
+            "formValues": {
+                "Section 1": {
+                    "request_type": {"value": "GARDEN"},
+                    "addressDetails": {
+                        "value": {
+                            "Section 1": {
+                                "ChooseAddress": {"value": str(user_uprn)}
+                            }
                         }
                     },
-                    "isPublished": True,
-                    "formName": "Waste - Check your bin day",
-                    "processId": "AF-Process-31283f9a-3ae7-4225-af71-bf3884e0ac1b",
+                    "number1": {"value": str(user_uprn)},
+                    "UPRN": {"value": str(user_uprn)},
+                    "collectiveKey": {"value": collective_key},
+                    "collectiveUPRN": {"value": str(user_uprn)},
+                    "collectiveGetJobStartDate": {"value": start_date},
+                    "collectiveGetJobEndDate": {"value": end_date},
                 }
+            },
+            "isPublished": True,
+            "formName": "Waste - Check your bin day",
+            "processId": "AF-Process-31283f9a-3ae7-4225-af71-bf3884e0ac1b",
+        }
 
-                collective_rows = run_lookup(COLLECTIVE_JOBS_LOOKUP_ID, collective_data)
-        except Exception:
-            collective_rows = {}
+        collective_rows = run_lookup(COLLECTIVE_JOBS_LOOKUP_ID, collective_data)
 
         bin_type_dict = {
             "DO": "Brown Domestic Bin",
@@ -181,12 +186,16 @@ class CouncilClass(AbstractGetBinDataClass):
 
             if "garden" in waste_type:
                 bin_type = "Garden Waste Bin"
+            elif "food waste" in waste_type or "food" in waste_type:
+                bin_type = "Food Waste Bin"
             elif "recycling" in waste_type or "recycl" in waste_type:
                 bin_type = "Green Recycling Bin"
             elif "residual" in waste_type or "general" in waste_type:
                 bin_type = "Brown Domestic Bin"
             else:
-                continue
+                raise ValueError(
+                    f"Unexpected Plymouth collectiveWasteType '{waste_type}' in row: {row}"
+                )
 
             key = (bin_type, collection_date)
             if key not in seen:

--- a/uk_bin_collection/uk_bin_collection/councils/PlymouthCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/PlymouthCouncil.py
@@ -6,6 +6,11 @@ import requests
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
+import json
+import logging
+
+_LOGGER = logging.getLogger(__name__)
+
 
 class CouncilClass(AbstractGetBinDataClass):
     """
@@ -50,9 +55,27 @@ class CouncilClass(AbstractGetBinDataClass):
             r = s.post(API_URL, json=data, headers=headers, params=params)
             r.raise_for_status()
             response_data = r.json()
-            rows_data = response_data["integration"]["transformed"]["rows_data"]
+        
+            _LOGGER.warning(
+                "PLYMOUTH lookup %s raw response: %s",
+                lookup_id,
+                json.dumps(response_data, indent=2),
+            )
+        
+            transformed = response_data.get("integration", {}).get("transformed")
+            if transformed is None:
+                raise ValueError(
+                    f"Plymouth lookup {lookup_id} returned no transformed data: "
+                    f"{json.dumps(response_data, indent=2)}"
+                )
+        
+            rows_data = transformed.get("rows_data")
             if not isinstance(rows_data, dict):
-                raise ValueError("Invalid data returned from API")
+                raise ValueError(
+                    f"Plymouth lookup {lookup_id} returned invalid rows_data: "
+                    f"{json.dumps(response_data, indent=2)}"
+                )
+        
             return rows_data
 
         standard_data = {
@@ -73,11 +96,22 @@ class CouncilClass(AbstractGetBinDataClass):
                     "request_type": {"value": "GARDEN"},
                     "number1": {"value": user_uprn},
                     "UPRN": {"value": str(user_uprn)},
+                    "addressDetails": {
+                        "value": {
+                            "Section 1": {
+                                "ChooseAddress": {"value": str(user_uprn)},
+                            }
+                        }
+                    },
                 }
             }
         }
 
-        collective_rows = run_lookup("698b9c49a3c13", collective_data)
+        collective_rows = {}
+        try:
+            collective_rows = run_lookup("698b9c49a3c13", collective_data)
+        except Exception as exc:
+            _LOGGER.warning("PLYMOUTH collective lookup failed: %s", exc)
 
         BIN_TYPES = {
             "DO": "Brown Domestic Bin",

--- a/uk_bin_collection/uk_bin_collection/councils/PlymouthCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/PlymouthCouncil.py
@@ -22,6 +22,7 @@ STANDARD_LOOKUP_ID = "5c99439d85f83"
 COLLECTIVE_KEY_LOOKUP_ID = "6936e38f6d376"
 COLLECTIVE_JOBS_LOOKUP_ID = "698b9c49a3c13"
 LOOKAHEAD_DAYS = 24
+REQUEST_TIMEOUT = 30
 
 
 class CouncilClass(AbstractGetBinDataClass):
@@ -31,9 +32,20 @@ class CouncilClass(AbstractGetBinDataClass):
         bindata = {"bins": []}
 
         s = requests.session()
-        r = s.get(SESSION_URL)
+        r = s.get(SESSION_URL, timeout=REQUEST_TIMEOUT)
         r.raise_for_status()
-        sid = r.json()["auth-session"]
+        session_data = r.json()
+
+        if not isinstance(session_data, dict):
+            raise ValueError(
+                f"Plymouth session lookup returned invalid JSON structure: {session_data}"
+            )
+
+        sid = session_data.get("auth-session")
+        if not sid:
+            raise ValueError(
+                f"Plymouth session lookup returned no auth-session: {session_data}"
+            )
 
         def run_lookup(lookup_id: str, data: dict) -> dict:
             params = {
@@ -46,14 +58,37 @@ class CouncilClass(AbstractGetBinDataClass):
                 "_": str(int(time.time() * 1000)),
                 "sid": sid,
             }
-            r = s.post(API_URL, json=data, headers=HEADERS, params=params)
+            r = s.post(
+                API_URL,
+                json=data,
+                headers=HEADERS,
+                params=params,
+                timeout=REQUEST_TIMEOUT,
+            )
             r.raise_for_status()
             response_data = r.json()
 
-            transformed = response_data.get("integration", {}).get("transformed")
+            if not isinstance(response_data, dict):
+                raise ValueError(
+                    f"Plymouth lookup {lookup_id} returned invalid JSON structure: {response_data}"
+                )
+
+            integration = response_data.get("integration")
+            if integration is None:
+                integration = {}
+            elif not isinstance(integration, dict):
+                raise ValueError(
+                    f"Plymouth lookup {lookup_id} returned invalid integration structure: {response_data}"
+                )
+
+            transformed = integration.get("transformed")
             if transformed is None:
                 raise ValueError(
                     f"Plymouth lookup {lookup_id} returned no transformed data: {response_data}"
+                )
+            if not isinstance(transformed, dict):
+                raise ValueError(
+                    f"Plymouth lookup {lookup_id} returned invalid transformed structure: {response_data}"
                 )
 
             rows_data = transformed.get("rows_data")

--- a/uk_bin_collection/uk_bin_collection/councils/PlymouthCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/PlymouthCouncil.py
@@ -1,15 +1,12 @@
 import time
+from datetime import datetime
 
 import requests
-import json
-import logging
 
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
-_LOGGER = logging.getLogger(__name__)
 
-# import the wonderful Beautiful Soup and the URL grabber
 class CouncilClass(AbstractGetBinDataClass):
     """
     Concrete classes have to implement all abstract operations of the
@@ -18,16 +15,47 @@ class CouncilClass(AbstractGetBinDataClass):
     """
 
     def parse_data(self, page: str, **kwargs) -> dict:
-
         user_uprn = kwargs.get("uprn")
         check_uprn(user_uprn)
         bindata = {"bins": []}
 
         SESSION_URL = "https://plymouth-self.achieveservice.com/authapi/isauthenticated?uri=https%253A%252F%252Fplymouth-self.achieveservice.com%252Fen%252FAchieveForms%252F%253Fform_uri%253Dsandbox-publish%253A%252F%252FAF-Process-31283f9a-3ae7-4225-af71-bf3884e0ac1b%252FAF-Stagedba4a7d5-e916-46b6-abdb-643d38bec875%252Fdefinition.json%2526redirectlink%253D%25252Fen%2526cancelRedirectLink%253D%25252Fen%2526consentMessage%253Dyes&hostname=plymouth-self.achieveservice.com&withCredentials=true"
-
         API_URL = "https://plymouth-self.achieveservice.com/apibroker/runLookup"
 
-        data = {
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": "Mozilla/5.0",
+            "X-Requested-With": "XMLHttpRequest",
+            "Referer": "https://plymouth-self.achieveservice.com/fillform/?iframe_id=fillform-frame-1&db_id=",
+        }
+
+        s = requests.session()
+        r = s.get(SESSION_URL)
+        r.raise_for_status()
+        session_data = r.json()
+        sid = session_data["auth-session"]
+
+        def run_lookup(lookup_id: str, data: dict) -> dict:
+            params = {
+                "id": lookup_id,
+                "repeat_against": "",
+                "noRetry": "false",
+                "getOnlyTokens": "undefined",
+                "log_id": "",
+                "app_name": "AF-Renderer::Self",
+                "_": str(int(time.time() * 1000)),
+                "sid": sid,
+            }
+            r = s.post(API_URL, json=data, headers=headers, params=params)
+            r.raise_for_status()
+            response_data = r.json()
+            rows_data = response_data["integration"]["transformed"]["rows_data"]
+            if not isinstance(rows_data, dict):
+                raise ValueError("Invalid data returned from API")
+            return rows_data
+
+        standard_data = {
             "formValues": {
                 "Section 1": {
                     "number1": {"value": user_uprn},
@@ -37,67 +65,66 @@ class CouncilClass(AbstractGetBinDataClass):
             },
         }
 
-        headers = {
-            "Content-Type": "application/json",
-            "Accept": "application/json",
-            "User-Agent": "Mozilla/5.0",
-            "X-Requested-With": "XMLHttpRequest",
-            "Referer": "https://plymouth-self.achieveservice.com/fillform/?iframe_id=fillform-frame-1&db_id=",
-        }
-        s = requests.session()
-        r = s.get(SESSION_URL)
-        r.raise_for_status()
-        session_data = r.json()
-        sid = session_data["auth-session"]
-        params = {
-            "id": "5c99439d85f83",
-            "repeat_against": "",
-            "noRetry": "false",
-            "getOnlyTokens": "undefined",
-            "log_id": "",
-            "app_name": "AF-Renderer::Self",
-            # unix_timestamp
-            "_": str(int(time.time() * 1000)),
-            "sid": sid,
-        }
-        r = s.post(API_URL, json=data, headers=headers, params=params)
-        r.raise_for_status()
-        data = r.json()
+        standard_rows = run_lookup("5c99439d85f83", standard_data)
 
-        _LOGGER.warning("PLYMOUTH raw response: %s", json.dumps(data, indent=2))
-        
-        transformed = data.get("integration", {}).get("transformed", {})
-        _LOGGER.warning("PLYMOUTH transformed keys: %s", list(transformed.keys()))
-        _LOGGER.warning("PLYMOUTH transformed: %s", json.dumps(transformed, indent=2))
-        
-        rows_data = transformed.get("rows_data", {})
-        _LOGGER.warning("PLYMOUTH rows_data: %s", json.dumps(rows_data, indent=2))
-        
-        all_row_keys = set()
-        if isinstance(rows_data, dict):
-            for key, row in rows_data.items():
-                if isinstance(row, dict):
-                    all_row_keys.update(row.keys())
-                    _LOGGER.warning("PLYMOUTH row %s: %s", key, json.dumps(row, indent=2))
-        
-        _LOGGER.warning("PLYMOUTH all row keys seen: %s", sorted(all_row_keys))
-        
-        rows_data = transformed.get("rows_data", {})
-        if not isinstance(rows_data, dict):
-            raise ValueError("Invalid data returned from API")
-        BIN_TYPES = [
-            ("OR", "Garden Waste Bin"),
-            ("DO", "Brown Domestic Bin"),
-            ("RE", "Green Recycling Bin"),
-        ]
-        bin_type_dict = dict(BIN_TYPES)
+        collective_data = {
+            "formValues": {
+                "Section 1": {
+                    "request_type": {"value": "GARDEN"},
+                    "number1": {"value": user_uprn},
+                    "UPRN": {"value": str(user_uprn)},
+                }
+            }
+        }
 
-        for row in rows_data.items():
-            bin_type = bin_type_dict.get(row[1]["Round_Type"], row[1]["Round_Type"])
+        collective_rows = run_lookup("698b9c49a3c13", collective_data)
+
+        BIN_TYPES = {
+            "DO": "Brown Domestic Bin",
+            "RE": "Green Recycling Bin",
+            "OR": "Garden Waste Bin",
+        }
+
+        seen = set()
+
+        for row in standard_rows.values():
+            bin_type = BIN_TYPES.get(row["Round_Type"], row["Round_Type"])
             collection_date = datetime.strptime(
-                row[1]["Date"].split("T")[0], "%Y-%m-%d"
+                row["Date"].split("T")[0], "%Y-%m-%d"
             ).strftime("%d/%m/%Y")
-            dict_data = {"type": bin_type, "collectionDate": collection_date}
-            bindata["bins"].append(dict_data)
+
+            key = (bin_type, collection_date)
+            if key not in seen:
+                seen.add(key)
+                bindata["bins"].append(
+                    {"type": bin_type, "collectionDate": collection_date}
+                )
+
+        for row in collective_rows.values():
+            waste_type = row.get("collectiveWasteType", "").lower()
+            collection_date = row.get("collectiveCollectionDate")
+
+            if not collection_date:
+                continue
+
+            if "garden" in waste_type:
+                bin_type = "Garden Waste Bin"
+            elif "recycling" in waste_type or "recycl" in waste_type:
+                bin_type = "Green Recycling Bin"
+            elif "residual" in waste_type or "general" in waste_type:
+                bin_type = "Brown Domestic Bin"
+            else:
+                continue
+
+            key = (bin_type, collection_date)
+            if key not in seen:
+                seen.add(key)
+                bindata["bins"].append(
+                    {"type": bin_type, "collectionDate": collection_date}
+                )
+
+        bindata["bins"].sort(
+            key=lambda x: datetime.strptime(x["collectionDate"], "%d/%m/%Y")
+        )
 
         return bindata

--- a/uk_bin_collection/uk_bin_collection/councils/PlymouthCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/PlymouthCouncil.py
@@ -7,22 +7,28 @@ from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
 
+SESSION_URL = "https://plymouth-self.achieveservice.com/authapi/isauthenticated?uri=https%253A%252F%252Fplymouth-self.achieveservice.com%252Fen%252FAchieveForms%252F%253Fform_uri%253Dsandbox-publish%253A%252F%252FAF-Process-31283f9a-3ae7-4225-af71-bf3884e0ac1b%252FAF-Stagedba4a7d5-e916-46b6-abdb-643d38bec875%252Fdefinition.json%2526redirectlink%253D%25252Fen%2526cancelRedirectLink%253D%25252Fen%2526consentMessage%253Dyes&hostname=plymouth-self.achieveservice.com&withCredentials=true"
+API_URL = "https://plymouth-self.achieveservice.com/apibroker/runLookup"
+
+HEADERS = {
+    "Content-Type": "application/json",
+    "Accept": "application/json",
+    "User-Agent": "Mozilla/5.0",
+    "X-Requested-With": "XMLHttpRequest",
+    "Referer": "https://plymouth-self.achieveservice.com/fillform/?iframe_id=fillform-frame-1&db_id=",
+}
+
+STANDARD_LOOKUP_ID = "5c99439d85f83"
+COLLECTIVE_KEY_LOOKUP_ID = "6936e38f6d376"
+COLLECTIVE_JOBS_LOOKUP_ID = "698b9c49a3c13"
+LOOKAHEAD_DAYS = 24
+
+
 class CouncilClass(AbstractGetBinDataClass):
     def parse_data(self, page: str, **kwargs) -> dict:
         user_uprn = kwargs.get("uprn")
         check_uprn(user_uprn)
         bindata = {"bins": []}
-
-        SESSION_URL = "https://plymouth-self.achieveservice.com/authapi/isauthenticated?uri=https%253A%252F%252Fplymouth-self.achieveservice.com%252Fen%252FAchieveForms%252F%253Fform_uri%253Dsandbox-publish%253A%252F%252FAF-Process-31283f9a-3ae7-4225-af71-bf3884e0ac1b%252FAF-Stagedba4a7d5-e916-46b6-abdb-643d38bec875%252Fdefinition.json%2526redirectlink%253D%25252Fen%2526cancelRedirectLink%253D%25252Fen%2526consentMessage%253Dyes&hostname=plymouth-self.achieveservice.com&withCredentials=true"
-        API_URL = "https://plymouth-self.achieveservice.com/apibroker/runLookup"
-
-        headers = {
-            "Content-Type": "application/json",
-            "Accept": "application/json",
-            "User-Agent": "Mozilla/5.0",
-            "X-Requested-With": "XMLHttpRequest",
-            "Referer": "https://plymouth-self.achieveservice.com/fillform/?iframe_id=fillform-frame-1&db_id=",
-        }
 
         s = requests.session()
         r = s.get(SESSION_URL)
@@ -40,7 +46,7 @@ class CouncilClass(AbstractGetBinDataClass):
                 "_": str(int(time.time() * 1000)),
                 "sid": sid,
             }
-            r = s.post(API_URL, json=data, headers=headers, params=params)
+            r = s.post(API_URL, json=data, headers=HEADERS, params=params)
             r.raise_for_status()
             response_data = r.json()
 
@@ -58,6 +64,11 @@ class CouncilClass(AbstractGetBinDataClass):
 
             return rows_data
 
+        start_date = datetime.now().strftime("%Y-%m-%dT00:00:00")
+        end_date = (datetime.now() + timedelta(days=LOOKAHEAD_DAYS)).strftime(
+            "%Y-%m-%dT00:00:00"
+        )
+
         standard_data = {
             "formValues": {
                 "Section 1": {
@@ -67,10 +78,7 @@ class CouncilClass(AbstractGetBinDataClass):
                 }
             },
         }
-        standard_rows = run_lookup("5c99439d85f83", standard_data)
-
-        start_date = datetime.now().strftime("%Y-%m-%dT00:00:00")
-        end_date = (datetime.now() + timedelta(days=24)).strftime("%Y-%m-%dT00:00:00")
+        standard_rows = run_lookup(STANDARD_LOOKUP_ID, standard_data)
 
         collective_key_data = {
             "stopOnFailure": True,
@@ -104,41 +112,44 @@ class CouncilClass(AbstractGetBinDataClass):
             "processId": "AF-Process-31283f9a-3ae7-4225-af71-bf3884e0ac1b",
         }
 
-        key_rows = run_lookup("6936e38f6d376", collective_key_data)
-        collective_key = key_rows.get("0", {}).get("collectiveKey")
-        if not collective_key:
-            raise ValueError("Plymouth collective key lookup returned no collectiveKey")
+        collective_rows = {}
+        try:
+            key_rows = run_lookup(COLLECTIVE_KEY_LOOKUP_ID, collective_key_data)
+            collective_key = key_rows.get("0", {}).get("collectiveKey")
 
-        collective_data = {
-            "stopOnFailure": True,
-            "usePHPIntegrations": True,
-            "stage_id": "AF-Stagedba4a7d5-e916-46b6-abdb-643d38bec875",
-            "stage_name": "Check Bin Day",
-            "formId": "AF-Form-b8823128-0c85-47e1-b344-4fc81480edd0",
-            "formValues": {
-                "Section 1": {
-                    "request_type": {"value": "GARDEN"},
-                    "addressDetails": {
-                        "value": {
-                            "Section 1": {
-                                "ChooseAddress": {"value": str(user_uprn)}
-                            }
+            if collective_key:
+                collective_data = {
+                    "stopOnFailure": True,
+                    "usePHPIntegrations": True,
+                    "stage_id": "AF-Stagedba4a7d5-e916-46b6-abdb-643d38bec875",
+                    "stage_name": "Check Bin Day",
+                    "formId": "AF-Form-b8823128-0c85-47e1-b344-4fc81480edd0",
+                    "formValues": {
+                        "Section 1": {
+                            "request_type": {"value": "GARDEN"},
+                            "addressDetails": {
+                                "value": {
+                                    "Section 1": {
+                                        "ChooseAddress": {"value": str(user_uprn)}
+                                    }
+                                }
+                            },
+                            "number1": {"value": str(user_uprn)},
+                            "UPRN": {"value": str(user_uprn)},
+                            "collectiveKey": {"value": collective_key},
+                            "collectiveUPRN": {"value": str(user_uprn)},
+                            "collectiveGetJobStartDate": {"value": start_date},
+                            "collectiveGetJobEndDate": {"value": end_date},
                         }
                     },
-                    "number1": {"value": str(user_uprn)},
-                    "UPRN": {"value": str(user_uprn)},
-                    "collectiveKey": {"value": collective_key},
-                    "collectiveUPRN": {"value": str(user_uprn)},
-                    "collectiveGetJobStartDate": {"value": start_date},
-                    "collectiveGetJobEndDate": {"value": end_date},
+                    "isPublished": True,
+                    "formName": "Waste - Check your bin day",
+                    "processId": "AF-Process-31283f9a-3ae7-4225-af71-bf3884e0ac1b",
                 }
-            },
-            "isPublished": True,
-            "formName": "Waste - Check your bin day",
-            "processId": "AF-Process-31283f9a-3ae7-4225-af71-bf3884e0ac1b",
-        }
 
-        collective_rows = run_lookup("698b9c49a3c13", collective_data)
+                collective_rows = run_lookup(COLLECTIVE_JOBS_LOOKUP_ID, collective_data)
+        except Exception:
+            collective_rows = {}
 
         bin_type_dict = {
             "DO": "Brown Domestic Bin",

--- a/uk_bin_collection/uk_bin_collection/councils/PlymouthCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/PlymouthCouncil.py
@@ -1,10 +1,13 @@
 import time
 
 import requests
+import json
+import logging
 
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
+_LOGGER = logging.getLogger(__name__)
 
 # import the wonderful Beautiful Soup and the URL grabber
 class CouncilClass(AbstractGetBinDataClass):
@@ -60,7 +63,26 @@ class CouncilClass(AbstractGetBinDataClass):
         r = s.post(API_URL, json=data, headers=headers, params=params)
         r.raise_for_status()
         data = r.json()
-        rows_data = data["integration"]["transformed"]["rows_data"]
+
+        _LOGGER.warning("PLYMOUTH raw response: %s", json.dumps(data, indent=2))
+        
+        transformed = data.get("integration", {}).get("transformed", {})
+        _LOGGER.warning("PLYMOUTH transformed keys: %s", list(transformed.keys()))
+        _LOGGER.warning("PLYMOUTH transformed: %s", json.dumps(transformed, indent=2))
+        
+        rows_data = transformed.get("rows_data", {})
+        _LOGGER.warning("PLYMOUTH rows_data: %s", json.dumps(rows_data, indent=2))
+        
+        all_row_keys = set()
+        if isinstance(rows_data, dict):
+            for key, row in rows_data.items():
+                if isinstance(row, dict):
+                    all_row_keys.update(row.keys())
+                    _LOGGER.warning("PLYMOUTH row %s: %s", key, json.dumps(row, indent=2))
+        
+        _LOGGER.warning("PLYMOUTH all row keys seen: %s", sorted(all_row_keys))
+        
+        rows_data = transformed.get("rows_data", {})
         if not isinstance(rows_data, dict):
             raise ValueError("Invalid data returned from API")
         BIN_TYPES = [


### PR DESCRIPTION
For whatever reason garden collection is no longer visible on the same request response as the general and recycling waste. It is available in the initial collective response.

As such, I've added in two additional requests, one to get a new collectivekey that can then be used with the second new request to get the garden waste collection.

I'm not sure about food waste (not sure we have this in Plymouth) but this fixes the garden waste issue referenced in #1890.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate bin collection schedules via a two-step data retrieval and stricter response validation
  * Broader support for collective waste collections, including food waste mapping and handling of unrecognized types
  * Increased lookup window to show more upcoming collections
  * Removed duplicate bin entries to prevent scheduling confusion
  * Collection schedules consistently sorted by date and clearer errors when no jobs are found
<!-- end of auto-generated comment: release notes by coderabbit.ai -->