### PR TITLE
fix: NewhamCouncil - updated card selectors, nbsp stripping, date format fallback

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/NewhamCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/NewhamCouncil.py
@@ -26,42 +26,58 @@ class CouncilClass(AbstractGetBinDataClass):
         # Form a JSON wrapper
         data = {"bins": []}
 
-        # Find section with bins in
-        sections = soup.find_all("div", {"class": "card h-100"})
-
-        # there may also be a recycling one too
-        sections_recycling = soup.find_all(
-            "div", {"class": "card h-100 card-recycling"}
-        )
-        if len(sections_recycling) > 0:
-            sections.append(sections_recycling[0])
-
-        # as well as one for food waste
-        sections_food_waste = soup.find_all(
-            "div", {"class": "card h-100 card-food"}
-        )
-        if len(sections_food_waste) > 0:
-            sections.append(sections_food_waste[0])
+        # Find all card sections (domestic, recycling, food, garden)
+        all_cards = soup.find_all("div", class_=lambda c: c and "card" in c and "h-100" in c)
 
         # For each bin section, get the text and the list elements
-        for item in sections:
+        for item in all_cards:
             header = item.find("div", {"class": "card-header"})
+            if not header:
+                continue
             bin_type_element = header.find_next("b")
-            if bin_type_element is not None:
-                bin_type = bin_type_element.text
-                array_expected_types = ["Domestic", "Recycling", "Food Waste"]
-                if bin_type in array_expected_types:
-                    date = (
-                        item.find_next("p", {"class": "card-text"})
-                        .find_next("mark")
-                        .next_sibling.strip()
-                    )
-                    next_collection = datetime.strptime(date, "%m/%d/%Y")
+            if bin_type_element is None:
+                continue
+            bin_type = bin_type_element.text
+            array_expected_types = ["Domestic", "Recycling", "Food Waste"]
+            if bin_type not in array_expected_types:
+                continue
 
-                    dict_data = {
-                        "type": bin_type,
-                        "collectionDate": next_collection.strftime(date_format),
-                    }
-                    data["bins"].append(dict_data)
+            # Find the card-text paragraph with the date
+            card_text = item.find("p", {"class": "card-text"})
+            if not card_text:
+                continue
+
+            mark_tag = card_text.find("mark")
+            if not mark_tag:
+                continue
+
+            # The date is in the next_sibling after the mark tag
+            # Format changed: was "mm/dd/yyyy" after mark, now "\xa0mm/dd/yyyy" or similar
+            next_sib = mark_tag.next_sibling
+            if next_sib is None:
+                # Try getting text after mark from the <br> tag's next sibling
+                br_tag = mark_tag.find_next("br")
+                if br_tag and br_tag.next_sibling:
+                    next_sib = br_tag.next_sibling
+                else:
+                    continue
+
+            date_str = str(next_sib).strip().replace("\xa0", "")
+            if not date_str:
+                continue
+
+            try:
+                next_collection = datetime.strptime(date_str, "%m/%d/%Y")
+            except ValueError:
+                try:
+                    next_collection = datetime.strptime(date_str, "%d/%m/%Y")
+                except ValueError:
+                    continue
+
+            dict_data = {
+                "type": bin_type,
+                "collectionDate": next_collection.strftime(date_format),
+            }
+            data["bins"].append(dict_data)
 
         return data


### PR DESCRIPTION
Newham's waste checker card markup has shifted slightly: the card classes no longer match the exact literal `card h-100` / `card h-100 card-recycling` / `card h-100 card-food` — instead cards have combined class lists that still contain `card` and `h-100`. The date after the `<mark>` tag also now has an `\xc2\xa0` (nbsp) prefix in places, and some pages render dates as `dd/mm/yyyy` instead of `mm/dd/yyyy`.

This relaxes the card selector to a substring match on `card` + `h-100`, strips `\xc2\xa0` from the date string, falls back through both date formats, and adds null guards so a single missing element doesn't kill the whole parse. Tested against a Newham address on 2026-04-06.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bin collection data retrieval for Newham Council with more robust handling of missing or malformed data.
  * Enhanced date parsing logic with support for multiple date formats and fallback mechanisms for more reliable collection date extraction.
  * Better whitespace normalization when processing collection dates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->