### PR TITLE
Fix: API server returning double-encoded JSON string

### DIFF
--- a/uk_bin_collection_api_server/server.py
+++ b/uk_bin_collection_api_server/server.py
@@ -4,7 +4,7 @@ import connexion
 from uk_bin_collection.uk_bin_collection.collect_data import UKBinCollectionApp
 import logging
 import traceback
-
+import json
 
 def council_data(
     council,
@@ -32,10 +32,11 @@ def council_data(
     if skip_get_url is True:
         args.append(f"-s")
 
-    try:
+try:
         CollectData = UKBinCollectionApp()
         CollectData.set_args(args)
-        return CollectData.run()
+        raw_string_output = CollectData.run()
+        return json.loads(raw_string_output)
     except Exception as err:
         logging.error(traceback.format_exc())
         logging.info(f"Schema: {err}")


### PR DESCRIPTION
Issue: > When running the API server, CollectData.run() returns a JSON-formatted string rather than a Python dictionary. Because Connexion automatically serializes the return value, it wraps the already-stringified JSON in another layer of quotes and escape characters (e.g., "{\n \"bins\": [\n..."). This prevents external dashboards and tools from natively parsing the JSON response.

Fix:
Imported the json module and wrapped the return statement in json.loads(). This converts the string back into a dictionary before handing it to Connexion, allowing the API to serve clean, native JSON payloads.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed API response format to return structured JSON data instead of raw strings, improving data accessibility and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->