### PR TITLE
fix: BexleyCouncil - replace Selenium with requests (WasteWorks HTML)

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/BexleyCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/BexleyCouncil.py
@@ -17,6 +17,7 @@ class CouncilClass(AbstractGetBinDataClass):
 
     def parse_data(self, page: str, **kwargs) -> dict:
         user_uprn = kwargs.get("uprn")
+        check_uprn(user_uprn)
 
         page = f"https://waste.bexley.gov.uk/waste/{user_uprn}"
 
@@ -25,12 +26,17 @@ class CouncilClass(AbstractGetBinDataClass):
         }
 
         # First request may trigger async page generation; retry if content not ready
+        found = False
         for attempt in range(3):
             response = requests.get(page, headers=headers, timeout=30)
             response.raise_for_status()
             if "waste-service-name" in response.text:
+                found = True
                 break
             time.sleep(3)
+
+        if not found:
+            raise ValueError("Bexley WasteWorks page did not return expected content after 3 attempts")
 
         soup = BeautifulSoup(response.text, features="html.parser")
 
@@ -80,5 +86,8 @@ class CouncilClass(AbstractGetBinDataClass):
                     except ValueError as e:
                         print(f"Error parsing date for {bin_type}: {e}")
                     break
+
+        if not data["bins"]:
+            raise ValueError("No collection dates found — page structure may have changed")
 
         return data

--- a/uk_bin_collection/uk_bin_collection/councils/BexleyCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/BexleyCouncil.py
@@ -1,17 +1,11 @@
 import time
 from datetime import datetime
 
+import requests
 from bs4 import BeautifulSoup
-from selenium.webdriver.common.by import By
-from selenium.webdriver.common.keys import Keys
-from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.support.ui import Select
-from selenium.webdriver.support.wait import WebDriverWait
 
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
-
-# import the wonderful Beautiful Soup and the URL grabber
 
 
 class CouncilClass(AbstractGetBinDataClass):
@@ -22,106 +16,69 @@ class CouncilClass(AbstractGetBinDataClass):
     """
 
     def parse_data(self, page: str, **kwargs) -> dict:
-        driver = None
-        try:
-            user_uprn = kwargs.get("uprn")
-            web_driver = kwargs.get("web_driver")
-            headless = kwargs.get("headless")
+        user_uprn = kwargs.get("uprn")
 
-            page = f"https://waste.bexley.gov.uk/waste/{user_uprn}"
+        page = f"https://waste.bexley.gov.uk/waste/{user_uprn}"
 
-            print(f"Trying URL: {page}")  # Debug
+        headers = {
+            "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+        }
 
-            # Create Selenium webdriver
-            driver = create_webdriver(web_driver, headless, None, __name__)
-            driver.get(page)
+        # First request may trigger async page generation; retry if content not ready
+        for attempt in range(3):
+            response = requests.get(page, headers=headers, timeout=30)
+            response.raise_for_status()
+            if "waste-service-name" in response.text:
+                break
+            time.sleep(3)
 
-            # Wait for the main content container to be present
-            wait = WebDriverWait(driver, 30)  # Increased timeout to 30 seconds
+        soup = BeautifulSoup(response.text, features="html.parser")
 
-            # First wait for container
-            main_content = wait.until(
-                EC.presence_of_element_located(
-                    (By.XPATH, "/html/body/div[1]/div/div[2]/div")
-                )
-            )
+        data = {"bins": []}
 
-            # Then wait for loading indicator to disappear
-            wait.until(EC.invisibility_of_element_located((By.ID, "loading-indicator")))
+        grids = soup.find_all("div", class_="waste-service-grid")
 
-            # Add after the loading indicator wait
-            time.sleep(3)  # Give extra time for JavaScript to populate the data
+        for grid in grids:
+            h3 = grid.find("h3", class_="waste-service-name")
+            if not h3:
+                continue
 
-            # Then wait for at least one bin section to appear
-            wait.until(
-                EC.presence_of_element_located((By.CLASS_NAME, "waste-service-name"))
-            )
+            # Get the main service name (first line of h3, before subtitle)
+            service_name_elem = h3.find("span") or h3
+            # Extract just the first text node for the bin type
+            bin_type = h3.get_text(separator="\n", strip=True).split("\n")[0]
 
-            # Now parse the page content
-            soup = BeautifulSoup(driver.page_source, features="html.parser")
+            # Find 'Next collection' in the summary list
+            summary_list = grid.find("dl", class_="govuk-summary-list")
+            if not summary_list:
+                continue
 
-            data = {"bins": []}
-            bin_sections = soup.find_all("h3", class_="waste-service-name")
+            rows = summary_list.find_all("div", class_="govuk-summary-list__row")
+            for row in rows:
+                dt = row.find("dt")
+                if dt and "Next collection" in dt.get_text():
+                    dd = row.find("dd")
+                    if not dd:
+                        continue
 
-            if not bin_sections:
-                print("No bin sections found after waiting for content")
-                print(f"Page source: {driver.page_source}")
-                return data
+                    next_collection = dd.get_text(strip=True)
+                    try:
+                        # Parse date like "Wednesday 8 April 2026" or "Tuesday, 8th April 2026"
+                        cleaned = remove_ordinal_indicator_from_date_string(next_collection)
+                        # Try with comma format first
+                        try:
+                            parsed_date = datetime.strptime(cleaned, "%A, %d %B %Y")
+                        except ValueError:
+                            parsed_date = datetime.strptime(cleaned, "%A %d %B %Y")
 
-            # Rest of your existing bin processing code
-            for bin_section in bin_sections:
-                # Extract the bin type (e.g., "Brown Caddy", "Green Wheelie Bin", etc.)
-                bin_type = bin_section.get_text(strip=True).split("\n")[
-                    0
-                ]  # The first part is the bin type
+                        data["bins"].append(
+                            {
+                                "type": bin_type,
+                                "collectionDate": parsed_date.strftime(date_format),
+                            }
+                        )
+                    except ValueError as e:
+                        print(f"Error parsing date for {bin_type}: {e}")
+                    break
 
-                # Find the next sibling <dl> tag that contains the next collection information
-                summary_list = bin_section.find_next("dl", class_="govuk-summary-list")
-
-                if summary_list:
-                    # Now, instead of finding by class, we'll search by text within the dt element
-                    next_collection_dt = summary_list.find(
-                        "dt", string=lambda text: "Next collection" in text
-                    )
-
-                    if next_collection_dt:
-                        # Find the sibling <dd> tag for the collection date
-                        next_collection = next_collection_dt.find_next_sibling(
-                            "dd"
-                        ).get_text(strip=True)
-
-                        if next_collection:
-                            try:
-                                # Parse the next collection date (assuming the format is like "Tuesday 15 October 2024")
-                                parsed_date = datetime.strptime(
-                                    next_collection, "%A %d %B %Y"
-                                )
-
-                                # Add the bin information to the data dictionary
-                                data["bins"].append(
-                                    {
-                                        "type": bin_type,
-                                        "collectionDate": parsed_date.strftime(
-                                            date_format
-                                        ),
-                                    }
-                                )
-                            except ValueError as e:
-                                print(f"Error parsing date for {bin_type}: {e}")
-                        else:
-                            print(f"No next collection date found for {bin_type}")
-                    else:
-                        print(f"No 'Next collection' text found for {bin_type}")
-                else:
-                    print(f"No summary list found for {bin_type}")
-
-        except Exception as e:
-            # Here you can log the exception if needed
-            print(f"An error occurred: {e}")
-            # Optionally, re-raise the exception if you want it to propagate
-            raise
-        finally:
-            # This block ensures that the driver is closed regardless of an exception
-            if driver:
-                driver.quit()
         return data


### PR DESCRIPTION
Bexley migrated to WasteWorks, and the new results page is plain static HTML — no JavaScript needed to render the bin schedule.

Dropped the Selenium flow entirely and switched to a requests + BeautifulSoup scrape against the WasteWorks results URL. Much faster and no webdriver dependency for this council.

Tested with a real UPRN in Bexley.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Bexley Council bin collection schedule retrieval with automatic retry logic
  * Enhanced performance and speed of bin collection data updates

<!-- end of auto-generated comment: release notes by coderabbit.ai -->