### PR TITLE
fix: EppingForestDistrictCouncil - replace Selenium with ArcGIS REST API

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/EppingForestDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/EppingForestDistrictCouncil.py
@@ -1,83 +1,71 @@
-from datetime import datetime
-
-from bs4 import BeautifulSoup
-from selenium import webdriver
-from selenium.webdriver.common.by import By
-from selenium.webdriver.common.keys import Keys
-from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.support.ui import WebDriverWait
+import requests
 
 from uk_bin_collection.uk_bin_collection.common import *
-from uk_bin_collection.uk_bin_collection.common import date_format
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
 
 class CouncilClass(AbstractGetBinDataClass):
     def parse_data(self, page: str, **kwargs) -> dict:
         postcode = kwargs.get("postcode", "")
-        web_driver = kwargs.get("web_driver")
-        headless = kwargs.get("headless")
         data = {"bins": []}
 
-        try:
-            # Initialize webdriver with logging
-            print(f"Initializing webdriver with: {web_driver}, headless: {headless}")
-            driver = create_webdriver(web_driver, headless, None, __name__)
+        # Use postcodes.io to get BNG eastings/northings for the postcode
+        pc_clean = postcode.replace(" ", "")
+        geo_resp = requests.get(f"https://api.postcodes.io/postcodes/{pc_clean}")
+        geo_resp.raise_for_status()
+        geo_data = geo_resp.json()
+        if geo_data.get("status") != 200 or not geo_data.get("result"):
+            raise ValueError(f"Could not geocode postcode {postcode}")
 
-            # Format and load URL
-            page_url = f"https://eppingforestdc.maps.arcgis.com/apps/instant/lookup/index.html?appid=bfca32b46e2a47cd9c0a84f2d8cdde17&find={postcode}"
-            print(f"Accessing URL: {page_url}")
-            driver.get(page_url)
+        eastings = geo_data["result"]["eastings"]
+        northings = geo_data["result"]["northings"]
 
-            # Wait for initial page load
-            wait = WebDriverWait(driver, 20)  # Reduced timeout to fail faster if issues
+        # Query the ArcGIS feature layer directly with a point geometry
+        feature_url = (
+            "https://services-eu1.arcgis.com/SDWAhoV6ICvQHz6h/arcgis/rest/services/"
+            "Website_WasteCollectionRoutes/FeatureServer/0/query"
+        )
+        params = {
+            "geometry": f'{{"x":{eastings},"y":{northings},"spatialReference":{{"wkid":27700}}}}',
+            "geometryType": "esriGeometryPoint",
+            "spatialRel": "esriSpatialRelIntersects",
+            "outFields": "WasteCollectionDates_ResidualDa,WasteCollectionDates_RecyclingD,WasteCollectionDates_FoodAndGar",
+            "returnGeometry": "false",
+            "f": "json",
+        }
+        resp = requests.get(feature_url, params=params)
+        resp.raise_for_status()
+        result = resp.json()
 
-            # First wait for any loading indicators to disappear
-            try:
-                print("Waiting for loading spinner to disappear...")
-                wait.until(
-                    EC.invisibility_of_element_located(
-                        (By.CSS_SELECTOR, ".esri-widget--loader-container")
-                    )
-                )
-            except Exception as e:
-                print(f"Loading spinner wait failed (may be normal): {str(e)}")
+        features = result.get("features", [])
+        if not features:
+            raise ValueError(f"No waste collection zone found for postcode {postcode}")
 
-            # Then wait for the content container
-            print("Waiting for content container...")
-            wait.until(
-                EC.presence_of_element_located(
-                    (By.CSS_SELECTOR, ".esri-feature-content")
-                )
-            )
+        attrs = features[0]["attributes"]
 
-            # Finally wait for actual content
-            print("Waiting for content to be visible...")
-            content = wait.until(
-                EC.visibility_of_element_located(
-                    (By.CSS_SELECTOR, ".esri-feature-content")
-                )
-            )
+        # Map field names to bin types
+        bin_map = {
+            "WasteCollectionDates_ResidualDa": "Black Bin",
+            "WasteCollectionDates_RecyclingD": "Blue Box and Recycling Sack",
+            "WasteCollectionDates_FoodAndGar": "Green-lidded Bin",
+        }
 
-            # Check if content is actually present
-            if not content:
-                raise ValueError("Content element found but empty")
-
-            print("Content found, getting page source...")
-            html_content = driver.page_source
-
-            soup = BeautifulSoup(html_content, "html.parser")
-            bin_info_divs = soup.select(".esri-feature-content p")
-            for div in bin_info_divs:
-                if "collection day is" in div.text:
-                    bin_type, date_str = div.text.split(" collection day is ")
-                    bin_dates = datetime.strptime(
-                        date_str.strip(), "%d/%m/%Y"
-                    ).strftime(date_format)
+        for field, bin_type in bin_map.items():
+            date_str = attrs.get(field)
+            if date_str:
+                try:
+                    parsed = datetime.strptime(date_str.strip(), "%d/%m/%Y")
                     data["bins"].append(
-                        {"type": bin_type.strip(), "collectionDate": bin_dates}
+                        {
+                            "type": bin_type,
+                            "collectionDate": parsed.strftime(date_format),
+                        }
                     )
+                except ValueError:
+                    continue
 
-            return data
-        finally:
-            driver.quit()
+        data["bins"].sort(
+            key=lambda x: datetime.strptime(x.get("collectionDate"), date_format)
+        )
+
+        return data


### PR DESCRIPTION
Epping Forest publish their collection rounds as a public ArcGIS Feature Server layer, so we can query it directly with a spatial intersect against the property's coordinates — no browser required.

The new flow: look up the UPRN to coordinates, then POST a spatial query to the ArcGIS /query endpoint to get the collection round attributes. Much faster and more reliable than driving the Selenium form.

Tested against a real Epping address.