### PR TITLE
fix: EastLothianCouncil - rewrite for Drupal migration (ASP site gone)

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/EastLothianCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/EastLothianCouncil.py
@@ -19,53 +19,130 @@ class CouncilClass(AbstractGetBinDataClass):
         check_paon(user_paon)
         bindata = {"bins": []}
 
-        # Get address ID from the streets endpoint
-        streets_uri = "https://collectiondates.eastlothian.gov.uk/ajax/your-calendar/load-streets-summer-2025.asp"
+        base_url = "https://collectiondates.eastlothian.gov.uk/waste-collection-schedule"
         headers = {
-            "Referer": "https://collectiondates.eastlothian.gov.uk/your-calendar",
             "User-Agent": "Mozilla/5.0",
         }
-        
-        response = requests.get(streets_uri, params={"postcode": user_postcode}, headers=headers)
+
+        session = requests.Session()
+
+        # Step 1: GET the page to obtain session cookie and form_build_id
+        response = session.get(base_url, headers=headers)
+        response.raise_for_status()
         soup = BeautifulSoup(response.text, "html.parser")
-        
-        select = soup.find("select", id="SelectStreet")
+
+        form_build_id = soup.find("input", {"name": "form_build_id"})
+        if not form_build_id:
+            raise ValueError("Could not find form_build_id on initial page")
+
+        # Step 2: POST postcode to get address list
+        response = session.post(
+            base_url,
+            headers=headers,
+            data={
+                "postcode": user_postcode,
+                "op": "Find",
+                "form_build_id": form_build_id["value"],
+                "form_id": "localgov_waste_collection_postcode_form",
+            },
+            allow_redirects=True,
+        )
+        response.raise_for_status()
+        soup = BeautifulSoup(response.text, "html.parser")
+
+        # Find matching address by house number
+        select = soup.find("select", {"name": "uprn"})
         if not select:
-            raise ValueError(f"No streets found for postcode {user_postcode}")
-        
-        address = select.find("option", string=lambda text: text and user_paon in text)
-        if not address:
-            raise ValueError(f"Address '{user_paon}' not found for postcode {user_postcode}")
-        
-        address_id = address["value"]
-        
-        # Get collection data using the correct endpoint
-        collections_uri = "https://collectiondates.eastlothian.gov.uk/ajax/your-calendar/load-recycling-summer-2025.asp"
-        response = requests.get(collections_uri, params={"id": address_id}, headers=headers)
-        
+            raise ValueError(f"No addresses found for postcode {user_postcode}")
+
+        # Normalise user input: strip spaces, lowercase for comparison
+        # Council formats as "87 B" but user may pass "87b" or "87B"
+        norm_paon = user_paon.replace(" ", "").lower()
+
+        uprn = None
+        for option in select.find_all("option"):
+            if not option.get("value"):
+                continue
+            addr_text = option.text.strip()
+            addr_parts = addr_text.split()
+            candidate = ""
+            for i, part in enumerate(addr_parts):
+                candidate += part.lower()
+                if candidate == norm_paon:
+                    # If the next part is a single letter (sub-unit suffix like "B"),
+                    # keep accumulating — "87" should not match "87 B ..."
+                    if i + 1 < len(addr_parts):
+                        next_part = addr_parts[i + 1]
+                        if len(next_part) == 1 and next_part.isalpha():
+                            continue
+                    uprn = option["value"]
+                    break
+            if uprn:
+                break
+
+        if not uprn:
+            raise ValueError(
+                f"Address '{user_paon}' not found for postcode {user_postcode}"
+            )
+
+        # Get the form action URL and new form_build_id
+        form = soup.find(
+            "form", {"id": "localgov-waste-collection-address-select-form"}
+        )
+        if not form:
+            raise ValueError("Could not find address select form")
+
+        action_url = form.get("action", "")
+        if action_url.startswith("/"):
+            action_url = "https://collectiondates.eastlothian.gov.uk" + action_url
+
+        form_build_id = form.find("input", {"name": "form_build_id"})
+        if not form_build_id:
+            raise ValueError("Could not find form_build_id in address form")
+
+        # Step 3: POST selected UPRN to get collection schedule
+        response = session.post(
+            action_url,
+            headers=headers,
+            data={
+                "uprn": uprn,
+                "op": "Find",
+                "form_build_id": form_build_id["value"],
+                "form_id": "localgov_waste_collection_address_select_form",
+            },
+            allow_redirects=True,
+        )
+        response.raise_for_status()
         soup = BeautifulSoup(response.text, "html.parser")
-        
-        # Extract collection details
-        calendar_items = soup.find_all("div", class_="calendar-item")
-        for item in calendar_items:
-            waste_label = item.find("div", class_="waste-label").text.strip()
-            waste_value = item.find("div", class_="waste-value").find("h4").text.strip()
-            
+
+        # Parse collection dates from <time datetime="YYYY-MM-DD"> elements
+        days = soup.find_all("li", class_="waste-collection__day")
+        for day in days:
+            time_el = day.find("time")
+            type_el = day.find("span", class_="waste-collection__day--type")
+
+            if not time_el or not type_el:
+                continue
+
+            date_str = time_el.get("datetime", "")
+            waste_type = type_el.text.strip()
+
+            if not date_str or not waste_type:
+                continue
+
             try:
-                collection_date = datetime.strptime(
-                    remove_ordinal_indicator_from_date_string(waste_value),
-                    "%A %d %B %Y",
+                collection_date = datetime.strptime(date_str, "%Y-%m-%d")
+                bindata["bins"].append(
+                    {
+                        "type": waste_type,
+                        "collectionDate": collection_date.strftime(date_format),
+                    }
                 )
-                
-                bindata["bins"].append({
-                    "type": waste_label.replace(" is:", ""),
-                    "collectionDate": collection_date.strftime(date_format),
-                })
             except ValueError:
                 continue
-        
+
         bindata["bins"].sort(
             key=lambda x: datetime.strptime(x.get("collectionDate"), date_format)
         )
-        
+
         return bindata


### PR DESCRIPTION
East Lothian migrated from their old ASP.NET site to a Drupal-based platform. The old scraper relied on ASP form state that no longer exists.

The new site uses a 3-step form flow with CSRF tokens. The rewrite follows the form steps: POST the postcode, select the address from the results, then parse the schedule table from the final page. CSRF tokens are extracted from hidden inputs on each step.

Tested with an EH postcode in East Lothian.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved reliability of East Lothian Council bin collection schedule retrieval with enhanced address matching accuracy.
* More robust extraction of collection dates and schedule information from council systems.
* Enhanced error reporting when schedules cannot be retrieved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->