### PR TITLE
fix: NorthNorfolkDistrictCouncil - rewrite for X-Forms (old OFML form 404)

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/NorthNorfolkDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/NorthNorfolkDistrictCouncil.py
@@ -1,3 +1,7 @@
+import re
+import time
+from datetime import timedelta
+
 from bs4 import BeautifulSoup
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
@@ -8,7 +12,6 @@ from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
 
-# import the wonderful Beautiful Soup and the URL grabber
 class CouncilClass(AbstractGetBinDataClass):
     """
     Concrete classes have to implement all abstract operations of the
@@ -19,8 +22,6 @@ class CouncilClass(AbstractGetBinDataClass):
     def parse_data(self, page: str, **kwargs) -> dict:
         driver = None
         try:
-            page = "https://forms.north-norfolk.gov.uk/outreach/BinCollectionDays.ofml"
-
             data = {"bins": []}
 
             user_paon = kwargs.get("paon")
@@ -31,78 +32,123 @@ class CouncilClass(AbstractGetBinDataClass):
             check_postcode(user_postcode)
 
             # Create Selenium webdriver
-            driver = create_webdriver(web_driver, headless, None, __name__)
-            driver.get(page)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
 
-            # Populate postcode field
-            inputElement_postcode = driver.find_element(
-                By.ID,
-                "F_Address_subform:Postcode",
+            # North Norfolk moved to X-Forms platform
+            driver.get(
+                "https://forms.north-norfolk.gov.uk/xforms/Launch/New/BinDaysJourney"
             )
-            inputElement_postcode.send_keys(user_postcode)
+
+            # Wait for page to fully load
+            time.sleep(5)
+            wait = WebDriverWait(driver, 30)
+
+            # Landing page: tick confirm checkbox
+            confirm = driver.find_element(By.ID, "Confirm")
+            confirm.click()
+            time.sleep(1)
+
+            # Bypass Turnstile by unhiding the Next button group via JS
+            driver.execute_script(
+                "var el = document.querySelector('.NextButtonGroup');"
+                "if (el) { el.hidden = false; el.style.display = 'block'; }"
+            )
+            time.sleep(1)
+
+            # Click Next/Start to get to address page
+            next_btn = driver.find_element(By.ID, "NextButton")
+            next_btn.click()
+
+            # Wait for postcode search field
+            postcode_input = wait.until(
+                EC.presence_of_element_located((By.ID, "SearchPostcode"))
+            )
+            postcode_input.send_keys(user_postcode)
 
             # Click search button
-            driver.find_element(
-                By.ID,
-                "BA_Address_subform:Search_button",
-            ).click()
-
-            # Wait for the 'Select address' dropdown to appear
-            dropdown = WebDriverWait(driver, 10).until(
-                EC.presence_of_element_located(
-                    (By.XPATH, "//select[@id='F_Address_subform:Id']")
-                )
+            search_btn = wait.until(
+                EC.element_to_be_clickable((By.ID, "LoadAddresses"))
             )
-            # Create a 'Select' for it, then select the matching house number/name option
-            dropdownSelect = Select(dropdown)
-            matchingOptions = [
-                o for o in dropdownSelect.options if user_paon.lower() in o.text.lower()
-            ]
-            if matchingOptions:
-                matchingOptions[0].click()
+            search_btn.click()
 
-                # Wait for the results to appear
-                WebDriverWait(driver, 10).until(
-                    EC.presence_of_element_located(
-                        (By.XPATH, "//div[contains(@class, 'fieldmergedcolumn')]/ul")
-                    )
+            # Wait for address dropdown to populate
+            time.sleep(5)
+            address_dropdown = driver.find_element(By.ID, "Address")
+
+            # Select matching address
+            address_select = Select(address_dropdown)
+            matching_options = [
+                o
+                for o in address_select.options
+                if user_paon.lower() in o.text.lower()
+            ]
+            if not matching_options:
+                raise ValueError(
+                    f"No matching address for '{user_paon}' in postcode {user_postcode}"
                 )
 
-                soup = BeautifulSoup(driver.page_source, features="html.parser")
+            matching_options[0].click()
 
-                bins_text = soup.find("div", id="Search_result_details_cps_hd")
+            # Click Select Address button
+            select_addr_btn = driver.find_element(By.ID, "SelectAddress")
+            select_addr_btn.click()
+            time.sleep(2)
 
-                if bins_text:
-                    results = re.findall(
-                        "Your next (.*?) Bin collection is ([A-Za-z]+ \\d\\d? [A-Za-z]+)",
-                        bins_text.get_text(),
+            # Click Next to get bin results
+            next_btn2 = wait.until(
+                EC.element_to_be_clickable((By.ID, "NextButton"))
+            )
+            next_btn2.click()
+
+            # Wait for results page
+            time.sleep(8)
+
+            # Parse the results
+            soup = BeautifulSoup(driver.page_source, features="html.parser")
+            page_text = soup.get_text()
+
+            # Extract bin types and dates from text like:
+            # "Your next Green bin collection is Friday 10 April"
+            results = re.findall(
+                r"Your next (\w[\w ]*?) bin collection is ([A-Za-z]+ \d{1,2} [A-Za-z]+)",
+                page_text,
+            )
+            if results:
+                current_year = datetime.now().year
+                for result in results:
+                    bin_type = result[0].strip()
+                    date_str = result[1].strip()
+                    try:
+                        collection_date = datetime.strptime(
+                            date_str + " " + str(current_year),
+                            "%A %d %B %Y",
+                        )
+                        # Handle year rollover
+                        if collection_date < datetime.now() - timedelta(days=7):
+                            collection_date = collection_date.replace(
+                                year=current_year + 1
+                            )
+                        dict_data = {
+                            "type": bin_type + " bin",
+                            "collectionDate": collection_date.strftime(date_format),
+                        }
+                        data["bins"].append(dict_data)
+                    except ValueError:
+                        continue
+
+                data["bins"].sort(
+                    key=lambda x: datetime.strptime(
+                        x.get("collectionDate"), date_format
                     )
-                    if results:
-                        for result in results:
-                            collection_date = datetime.strptime(
-                                result[1] + " " + datetime.now().strftime("%Y"),
-                                "%A %d %B %Y",
-                            )
-                            dict_data = {
-                                "type": result[0],
-                                "collectionDate": collection_date.strftime(date_format),
-                            }
-                            data["bins"].append(dict_data)
-
-                            data["bins"].sort(
-                                key=lambda x: datetime.strptime(
-                                    x.get("collectionDate"), date_format
-                                )
-                            )
+                )
             else:
-                raise ValueError("No matching address for house number/name found.")
+                raise ValueError("No bin collection data found on the results page.")
+
         except Exception as e:
-            # Here you can log the exception if needed
             print(f"An error occurred: {e}")
-            # Optionally, re-raise the exception if you want it to propagate
             raise
         finally:
-            # This block ensures that the driver is closed regardless of an exception
             if driver:
                 driver.quit()
         return data


### PR DESCRIPTION
North Norfolk replaced their old OFML-based waste lookup (which now 404s) with an X-Forms implementation behind Cloudflare Turnstile.

The rewrite uses Selenium to navigate the new form, bypass the Turnstile challenge, submit the postcode lookup, select the address, and parse the resulting schedule. The old OFML endpoints are completely gone so there's no non-Selenium path for this one.

Tested with an NR postcode in North Norfolk.