### PR TITLE
fix: add realistic user_agent to all Selenium scrapers missing one

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/ArgyllandButeCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/ArgyllandButeCouncil.py
@@ -46,7 +46,8 @@ class CouncilClass(AbstractGetBinDataClass):
             check_postcode(user_postcode)
             user_uprn = str(user_uprn).zfill(12)
             # Create Selenium webdriver
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get(page)
 
             # Accept cookies

--- a/uk_bin_collection/uk_bin_collection/councils/AshfordBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/AshfordBoroughCouncil.py
@@ -33,7 +33,8 @@ class CouncilClass(AbstractGetBinDataClass):
             API_URL = "https://secure.ashford.gov.uk/waste/collectiondaylookup/"
 
             # Create Selenium webdriver
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get(API_URL)
 
             # Wait for the postcode field to appear then populate it

--- a/uk_bin_collection/uk_bin_collection/councils/BaberghDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/BaberghDistrictCouncil.py
@@ -38,7 +38,8 @@ class CouncilClass(AbstractGetBinDataClass):
             url = "https://www.babergh.gov.uk/check-your-collection-day"
 
             # Get our initial session running
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get(url)
 
             wait = WebDriverWait(driver, 30)

--- a/uk_bin_collection/uk_bin_collection/councils/BarkingDagenham.py
+++ b/uk_bin_collection/uk_bin_collection/councils/BarkingDagenham.py
@@ -35,7 +35,8 @@ class CouncilClass(AbstractGetBinDataClass):
                 f"Creating webdriver with: web_driver={web_driver}, headless={headless}"
             )
 
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             print(f"Navigating to URL: {url}")
             driver.get(url)
             print("Successfully loaded the page")

--- a/uk_bin_collection/uk_bin_collection/councils/BlackburnCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/BlackburnCouncil.py
@@ -50,7 +50,8 @@ class CouncilClass(AbstractGetBinDataClass):
                 f"https://mybins.blackburn.gov.uk/api/mybins/getbincollectiondays?uprn={uprn}&month={current_month}"
                 f"&year={current_year}"
             )
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get(url)
 
             soup = BeautifulSoup(driver.page_source, "html.parser")

--- a/uk_bin_collection/uk_bin_collection/councils/BlaenauGwentCountyBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/BlaenauGwentCountyBoroughCouncil.py
@@ -23,7 +23,8 @@ class CouncilClass(AbstractGetBinDataClass):
             check_postcode(user_postcode)
 
             # Create Selenium webdriver
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             
             # Navigate to the main page first
             driver.get("https://www.blaenau-gwent.gov.uk/en/resident/waste-recycling/")

--- a/uk_bin_collection/uk_bin_collection/councils/BrightonandHoveCityCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/BrightonandHoveCityCouncil.py
@@ -56,7 +56,8 @@ class CouncilClass(AbstractGetBinDataClass):
             postcode = kwargs.get("postcode")
             web_driver = kwargs.get("web_driver")
             headless = kwargs.get("headless")
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get(url)
 
             wait = WebDriverWait(driver, 60)

--- a/uk_bin_collection/uk_bin_collection/councils/BroadlandDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/BroadlandDistrictCouncil.py
@@ -39,7 +39,8 @@ class CouncilClass(AbstractGetBinDataClass):
                 f"Creating webdriver with: web_driver={web_driver}, headless={headless}"
             )
 
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             print(f"Navigating to URL: {url}")
             driver.get(url)
             print("Successfully loaded the page")

--- a/uk_bin_collection/uk_bin_collection/councils/BroxtoweBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/BroxtoweBoroughCouncil.py
@@ -31,7 +31,8 @@ class CouncilClass(AbstractGetBinDataClass):
             check_postcode(user_postcode)
 
             # Create Selenium webdriver
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get(page)
 
             # Populate postcode field

--- a/uk_bin_collection/uk_bin_collection/councils/CalderdaleCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/CalderdaleCouncil.py
@@ -39,7 +39,8 @@ class CouncilClass(AbstractGetBinDataClass):
             data = {"bins": []}
 
             # Get our initial session running
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get(kwargs.get("url"))
 
             wait = WebDriverWait(driver, 30)

--- a/uk_bin_collection/uk_bin_collection/councils/CeredigionCountyCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/CeredigionCountyCouncil.py
@@ -28,7 +28,8 @@ class CouncilClass(AbstractGetBinDataClass):
             check_postcode(user_postcode)
 
             # Create Selenium webdriver
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get("https://www.ceredigion.gov.uk/resident/bins-recycling/")
 
             try:

--- a/uk_bin_collection/uk_bin_collection/councils/ChichesterDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/ChichesterDistrictCouncil.py
@@ -24,7 +24,8 @@ class CouncilClass(AbstractGetBinDataClass):
             web_driver = kwargs.get("web_driver")
             headless = kwargs.get("headless")
 
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get(page)
 
             wait = WebDriverWait(driver, 60)

--- a/uk_bin_collection/uk_bin_collection/councils/ColchesterCityCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/ColchesterCityCouncil.py
@@ -27,7 +27,8 @@ class CouncilClass(AbstractGetBinDataClass):
             check_postcode(user_postcode)
 
             # Create Selenium webdriver
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get(
                 "https://www.colchester.gov.uk/your-recycling-calendar/?start=true"
             )

--- a/uk_bin_collection/uk_bin_collection/councils/CotswoldDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/CotswoldDistrictCouncil.py
@@ -35,7 +35,8 @@ class CouncilClass(AbstractGetBinDataClass):
             headless = kwargs.get("headless")
 
             # Create Selenium webdriver
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get(page)
 
             # Wait for page to load completely

--- a/uk_bin_collection/uk_bin_collection/councils/CroydonCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/CroydonCouncil.py
@@ -30,7 +30,8 @@ class CouncilClass(AbstractGetBinDataClass):
             check_paon(user_paon)
             headless = kwargs.get("headless")
             web_driver = kwargs.get("web_driver")
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             page = "https://service.croydon.gov.uk/wasteservices/w/webpage/bin-day-enter-address"
 
             driver.maximize_window()

--- a/uk_bin_collection/uk_bin_collection/councils/DacorumBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/DacorumBoroughCouncil.py
@@ -27,7 +27,8 @@ class CouncilClass(AbstractGetBinDataClass):
             check_postcode(user_postcode)
 
             # Create Selenium webdriver
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get("https://webapps.dacorum.gov.uk/bincollections/")
 
             # Wait for the postcode field to appear then populate it

--- a/uk_bin_collection/uk_bin_collection/councils/EastLindseyDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/EastLindseyDistrictCouncil.py
@@ -27,7 +27,8 @@ class CouncilClass(AbstractGetBinDataClass):
             check_postcode(user_postcode)
 
             # Create Selenium webdriver
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get("https://www.e-lindsey.gov.uk/mywastecollections")
 
             # Wait for the postcode field to appear then populate it

--- a/uk_bin_collection/uk_bin_collection/councils/EastRenfrewshireCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/EastRenfrewshireCouncil.py
@@ -27,7 +27,8 @@ class CouncilClass(AbstractGetBinDataClass):
             check_postcode(user_postcode)
 
             # Create Selenium webdriver
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get("https://eastrenfrewshire.gov.uk/bin-days")
 
             # Wait for the postcode field to appear then populate it

--- a/uk_bin_collection/uk_bin_collection/councils/EastRidingCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/EastRidingCouncil.py
@@ -31,7 +31,8 @@ class CouncilClass(AbstractGetBinDataClass):
             # Create Selenium webdriver
             page = "https://www.eastriding.gov.uk/environment/bins-rubbish-recycling/bins-and-collections/bin-collection-dates/#"
 
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get(page)
 
             wait = WebDriverWait(driver, 60)

--- a/uk_bin_collection/uk_bin_collection/councils/EastSuffolkCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/EastSuffolkCouncil.py
@@ -28,7 +28,8 @@ class CouncilClass(AbstractGetBinDataClass):
             check_postcode(user_postcode)
 
             # Create Selenium webdriver
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get(
                 "https://my.eastsuffolk.gov.uk/service/Bin_collection_dates_finder"
             )

--- a/uk_bin_collection/uk_bin_collection/councils/EpsomandEwellBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/EpsomandEwellBoroughCouncil.py
@@ -26,10 +26,11 @@ class CouncilClass(AbstractGetBinDataClass):
 
         driver = None
         try:
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
             driver = create_webdriver(
                 kwargs.get("web_driver"),
                 kwargs.get("headless", True),
-                None,
+                user_agent,
                 __name__
             )
             

--- a/uk_bin_collection/uk_bin_collection/councils/ForestOfDeanDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/ForestOfDeanDistrictCouncil.py
@@ -36,7 +36,8 @@ class CouncilClass(AbstractGetBinDataClass):
             headless = kwargs.get("headless")
 
             # Create Selenium webdriver
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get(page)
 
             # If you bang in the house number (or property name) and postcode in the box it should find your property

--- a/uk_bin_collection/uk_bin_collection/councils/GloucesterCityCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/GloucesterCityCouncil.py
@@ -34,7 +34,8 @@ class CouncilClass(AbstractGetBinDataClass):
             check_uprn(user_uprn)
             check_postcode(user_postcode)
             # Create Selenium webdriver
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get(page)
 
             cookies_button = WebDriverWait(driver, timeout=15).until(

--- a/uk_bin_collection/uk_bin_collection/councils/GreatYarmouthBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/GreatYarmouthBoroughCouncil.py
@@ -31,7 +31,8 @@ class CouncilClass(AbstractGetBinDataClass):
             check_uprn(user_uprn)
             check_postcode(user_postcode)
 
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
 
             driver.get(url)
 

--- a/uk_bin_collection/uk_bin_collection/councils/GuildfordCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/GuildfordCouncil.py
@@ -35,7 +35,8 @@ class CouncilClass(AbstractGetBinDataClass):
             web_driver = kwargs.get("web_driver")
             headless = kwargs.get("headless")
 
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get(kwargs.get("url"))
 
             wait = WebDriverWait(driver, 120)

--- a/uk_bin_collection/uk_bin_collection/councils/HertsmereBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/HertsmereBoroughCouncil.py
@@ -34,7 +34,8 @@ class CouncilClass(AbstractGetBinDataClass):
             URI = "https://hertsmere-services.onmats.com/w/webpage/round-search"
 
             # Create Selenium webdriver
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get(URI)
 
             # Wait for the postcode field to appear then populate it

--- a/uk_bin_collection/uk_bin_collection/councils/HighPeakCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/HighPeakCouncil.py
@@ -66,7 +66,8 @@ class CouncilClass(AbstractGetBinDataClass):
             headless = kwargs.get("headless")
 
             # Create Selenium webdriver
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get(page)
 
             # Enter postcode in text box and wait

--- a/uk_bin_collection/uk_bin_collection/councils/Hillingdon.py
+++ b/uk_bin_collection/uk_bin_collection/councils/Hillingdon.py
@@ -109,7 +109,8 @@ class CouncilClass(AbstractGetBinDataClass):
             check_paon(user_paon)
             check_postcode(user_postcode)
 
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get(url)
 
             # Handle cookie banner if present

--- a/uk_bin_collection/uk_bin_collection/councils/HyndburnBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/HyndburnBoroughCouncil.py
@@ -29,7 +29,8 @@ class CouncilClass(AbstractGetBinDataClass):
             user_uprn = kwargs.get("uprn")
             headless = kwargs.get("headless")
             web_driver = kwargs.get("web_driver")
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             page = "https://iapp.itouchvision.com/iappcollectionday/collection-day/?uuid=FEBA68993831481FD81B2E605364D00A8DC017A4"
 
             driver.get(page)

--- a/uk_bin_collection/uk_bin_collection/councils/KingstonUponThamesCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/KingstonUponThamesCouncil.py
@@ -32,7 +32,8 @@ class CouncilClass(AbstractGetBinDataClass):
 
             headless = kwargs.get("headless")
             web_driver = kwargs.get("web_driver")
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get(kwargs.get("url"))
             wait = WebDriverWait(driver, 15, 2)
 

--- a/uk_bin_collection/uk_bin_collection/councils/KnowsleyMBCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/KnowsleyMBCouncil.py
@@ -23,7 +23,8 @@ class CouncilClass(AbstractGetBinDataClass):
             check_paon(user_paon)
             check_postcode(user_postcode)
 
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.set_window_size(1920, 1080)  # 👈 ensure full viewport
 
             driver.get(

--- a/uk_bin_collection/uk_bin_collection/councils/LondonBoroughRedbridge.py
+++ b/uk_bin_collection/uk_bin_collection/councils/LondonBoroughRedbridge.py
@@ -34,7 +34,8 @@ class CouncilClass(AbstractGetBinDataClass):
             postcode = kwargs.get("postcode")
             web_driver = kwargs.get("web_driver")
             headless = kwargs.get("headless")
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get(kwargs.get("url"))
 
             wait = WebDriverWait(driver, 60)

--- a/uk_bin_collection/uk_bin_collection/councils/MaidstoneBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/MaidstoneBoroughCouncil.py
@@ -31,7 +31,8 @@ class CouncilClass(AbstractGetBinDataClass):
             check_postcode(user_postcode)
 
             # Create Selenium webdriver
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get(page)
 
             iframe_presense = WebDriverWait(driver, 30).until(

--- a/uk_bin_collection/uk_bin_collection/councils/MidAndEastAntrimBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/MidAndEastAntrimBoroughCouncil.py
@@ -32,7 +32,8 @@ class CouncilClass(AbstractGetBinDataClass):
             # Create Selenium webdriver
             options = webdriver.ChromeOptions()
             options.add_experimental_option("excludeSwitches", ["enable-logging"])
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
 
             driver.get(page)
 

--- a/uk_bin_collection/uk_bin_collection/councils/MidSuffolkDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/MidSuffolkDistrictCouncil.py
@@ -38,7 +38,8 @@ class CouncilClass(AbstractGetBinDataClass):
             url = "https://www.midsuffolk.gov.uk/check-your-collection-day"
 
             # Get our initial session running
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get(url)
 
             wait = WebDriverWait(driver, 30)

--- a/uk_bin_collection/uk_bin_collection/councils/MidUlsterDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/MidUlsterDistrictCouncil.py
@@ -32,7 +32,8 @@ class CouncilClass(AbstractGetBinDataClass):
 
             headless = kwargs.get("headless")
             web_driver = kwargs.get("web_driver")
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             page = "https://www.midulstercouncil.org/resident/bins-recycling"
 
             driver.get(page)

--- a/uk_bin_collection/uk_bin_collection/councils/NorthDevonCountyCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/NorthDevonCountyCouncil.py
@@ -28,7 +28,8 @@ class CouncilClass(AbstractGetBinDataClass):
             check_postcode(user_postcode)
 
             # Create Selenium webdriver
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get(
                 "https://my.northdevon.gov.uk/service/WasteRecyclingCollectionCalendar"
             )

--- a/uk_bin_collection/uk_bin_collection/councils/NorthEastDerbyshireDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/NorthEastDerbyshireDistrictCouncil.py
@@ -35,7 +35,8 @@ class CouncilClass(AbstractGetBinDataClass):
             check_uprn(user_uprn)
             check_postcode(user_postcode)
 
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get(page)
 
             iframe_presense = WebDriverWait(driver, 30).until(

--- a/uk_bin_collection/uk_bin_collection/councils/NorthWestLeicestershire.py
+++ b/uk_bin_collection/uk_bin_collection/councils/NorthWestLeicestershire.py
@@ -34,7 +34,8 @@ class CouncilClass(AbstractGetBinDataClass):
             # Create Selenium webdriver
             page = f"https://my.nwleics.gov.uk/my-property-finder?address={user_postcode}&go=1"
 
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get(page)
 
             # If you bang in the house number (or property name) and postcode in the box it should find your property

--- a/uk_bin_collection/uk_bin_collection/councils/NorthumberlandCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/NorthumberlandCouncil.py
@@ -71,7 +71,8 @@ class CouncilClass(AbstractGetBinDataClass):
             headless = kwargs.get("headless")
 
             # Create Selenium webdriver
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get(page)
 
             # Create wait object

--- a/uk_bin_collection/uk_bin_collection/councils/PortsmouthCityCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/PortsmouthCityCouncil.py
@@ -34,7 +34,8 @@ class CouncilClass(AbstractGetBinDataClass):
             check_uprn(user_uprn)
             check_postcode(user_postcode)
             # Create Selenium webdriver
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get(page)
 
             # If you bang in the house number (or property name) and postcode in the box it should find your property

--- a/uk_bin_collection/uk_bin_collection/councils/PowysCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/PowysCouncil.py
@@ -33,7 +33,8 @@ class CouncilClass(AbstractGetBinDataClass):
             user_paon = user_paon.upper()
 
             # Create Selenium webdriver
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get("https://en.powys.gov.uk/binday")
 
             accept_button = WebDriverWait(driver, timeout=10).until(

--- a/uk_bin_collection/uk_bin_collection/councils/PrestonCityCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/PrestonCityCouncil.py
@@ -35,7 +35,8 @@ class CouncilClass(AbstractGetBinDataClass):
             check_postcode(user_postcode)
 
             # Create Selenium webdriver
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get(page)
 
             # If you bang in the house number (or property name) and postcode in the box it should find your property

--- a/uk_bin_collection/uk_bin_collection/councils/RugbyBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/RugbyBoroughCouncil.py
@@ -31,7 +31,8 @@ class CouncilClass(AbstractGetBinDataClass):
 
             headless = kwargs.get("headless")
             web_driver = kwargs.get("web_driver")
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             page = "https://www.rugby.gov.uk/check-your-next-bin-day"
 
             driver.get(page)

--- a/uk_bin_collection/uk_bin_collection/councils/RushcliffeBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/RushcliffeBoroughCouncil.py
@@ -31,7 +31,8 @@ class CouncilClass(AbstractGetBinDataClass):
             check_postcode(user_postcode)
 
             # Create Selenium webdriver
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get(page)
 
             # Populate postcode field

--- a/uk_bin_collection/uk_bin_collection/councils/SevenoaksDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/SevenoaksDistrictCouncil.py
@@ -32,7 +32,8 @@ class CouncilClass(AbstractGetBinDataClass):
             user_paon = kwargs.get("paon")
 
             # Create Selenium webdriver
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get(page)
 
             # Enter postcode

--- a/uk_bin_collection/uk_bin_collection/councils/StHelensBC.py
+++ b/uk_bin_collection/uk_bin_collection/councils/StHelensBC.py
@@ -28,7 +28,8 @@ class CouncilClass(AbstractGetBinDataClass):
             check_postcode(user_postcode)
 
             # Create Selenium webdriver
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get(
                 "https://www.sthelens.gov.uk/article/3473/Check-your-collection-dates"
             )

--- a/uk_bin_collection/uk_bin_collection/councils/StaffordshireMoorlandsDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/StaffordshireMoorlandsDistrictCouncil.py
@@ -26,7 +26,8 @@ class CouncilClass(AbstractGetBinDataClass):
         check_postcode(user_postcode)
 
         # Create Selenium webdriver
-        driver = create_webdriver(web_driver, headless, None, __name__)
+        user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
         driver.get("https://www.staffsmoorlands.gov.uk/findyourbinday")
 
         # Close cookies banner

--- a/uk_bin_collection/uk_bin_collection/councils/StocktonOnTeesCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/StocktonOnTeesCouncil.py
@@ -32,7 +32,8 @@ class CouncilClass(AbstractGetBinDataClass):
             check_postcode(user_postcode)
 
             # Create Selenium webdriver
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get("https://www.stockton.gov.uk/bin-collection-days")
 
             # Wait for the postcode field to appear then populate it

--- a/uk_bin_collection/uk_bin_collection/councils/SunderlandCityCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/SunderlandCityCouncil.py
@@ -29,7 +29,8 @@ class CouncilClass(AbstractGetBinDataClass):
             check_paon(user_paon)
             check_postcode(user_postcode)
 
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get(
                 "https://webapps.sunderland.gov.uk/WEBAPPS/WSS/Sunderland_Portal/Forms/bindaychecker.aspx"
             )

--- a/uk_bin_collection/uk_bin_collection/councils/TeignbridgeCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/TeignbridgeCouncil.py
@@ -26,7 +26,8 @@ class CouncilClass(AbstractGetBinDataClass):
 
             URI = f"https://www.teignbridge.gov.uk/repositories/hidden-pages/bin-finder?uprn={user_uprn}"
 
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get(URI)
 
             soup = BeautifulSoup(driver.page_source, features="html.parser")

--- a/uk_bin_collection/uk_bin_collection/councils/TendringDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/TendringDistrictCouncil.py
@@ -64,7 +64,8 @@ class CouncilClass(AbstractGetBinDataClass):
             check_postcode(user_postcode)
 
             # Create and launch Selenium (remote or local depending on config)
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get(page)
 
             # Try to accept the cookie banner if present

--- a/uk_bin_collection/uk_bin_collection/councils/ThanetDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/ThanetDistrictCouncil.py
@@ -28,7 +28,8 @@ class CouncilClass(AbstractGetBinDataClass):
         headless = kwargs.get("headless")
 
         # Create the Selenium WebDriver
-        driver = create_webdriver(web_driver, headless, None, __name__)
+        user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
 
         try:
             print(f"Navigating to URL: {url}")

--- a/uk_bin_collection/uk_bin_collection/councils/ThreeRiversDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/ThreeRiversDistrictCouncil.py
@@ -29,7 +29,8 @@ class CouncilClass(AbstractGetBinDataClass):
             check_postcode(user_postcode)
 
             # Create Selenium webdriver
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             if not headless:
                 driver.set_window_size(1920, 1080)
 

--- a/uk_bin_collection/uk_bin_collection/councils/TorbayCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/TorbayCouncil.py
@@ -35,7 +35,8 @@ class CouncilClass(AbstractGetBinDataClass):
                 f"Creating webdriver with: web_driver={web_driver}, headless={headless}"
             )
 
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             print(f"Navigating to URL: {url}")
             driver.get("https://www.torbay.gov.uk/recycling/bin-collections/")
             print("Successfully loaded the page")

--- a/uk_bin_collection/uk_bin_collection/councils/WalthamForest.py
+++ b/uk_bin_collection/uk_bin_collection/councils/WalthamForest.py
@@ -30,7 +30,8 @@ class CouncilClass(AbstractGetBinDataClass):
             web_driver = kwargs.get("web_driver")
             headless = kwargs.get("headless")
 
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get(page)
 
             iframe_presense = WebDriverWait(driver, 30).until(

--- a/uk_bin_collection/uk_bin_collection/councils/WestBerkshireCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/WestBerkshireCouncil.py
@@ -32,7 +32,8 @@ class CouncilClass(AbstractGetBinDataClass):
             check_postcode(user_postcode)
 
             # Create Selenium webdriver
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get("https://www.westberks.gov.uk/binday")
 
             # Wait for the postcode field to appear then populate it

--- a/uk_bin_collection/uk_bin_collection/councils/WestLothianCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/WestLothianCouncil.py
@@ -27,7 +27,8 @@ class CouncilClass(AbstractGetBinDataClass):
             check_postcode(user_postcode)
 
             # Create Selenium webdriver
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get(
                 "https://www.westlothian.gov.uk/article/31528/Bin-Collection-Calendar-Dates"
             )

--- a/uk_bin_collection/uk_bin_collection/councils/WestOxfordshireDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/WestOxfordshireDistrictCouncil.py
@@ -50,7 +50,8 @@ class CouncilClass(AbstractGetBinDataClass):
             headless = kwargs.get("headless")
 
             # Create Selenium webdriver
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get(page)
             
             # Scroll to top-left to ensure components are visible

--- a/uk_bin_collection/uk_bin_collection/councils/WinchesterCityCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/WinchesterCityCouncil.py
@@ -46,7 +46,8 @@ class CouncilClass(AbstractGetBinDataClass):
             check_postcode(user_postcode)
 
             # Create Selenium webdriver
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get("http://www.winchester.gov.uk/bin-calendar")
 
             # Wait for the postcode field to appear then populate it

--- a/uk_bin_collection/uk_bin_collection/councils/WirralCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/WirralCouncil.py
@@ -24,7 +24,8 @@ class CouncilClass(AbstractGetBinDataClass):
             headless = kwargs.get("headless")
 
             # Create Selenium webdriver
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get(page)
 
             # Handle cookie consent if present

--- a/uk_bin_collection/uk_bin_collection/councils/WokinghamBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/WokinghamBoroughCouncil.py
@@ -48,7 +48,8 @@ class CouncilClass(AbstractGetBinDataClass):
             check_postcode(user_postcode)
 
             # Create Selenium webdriver
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get(
                 "https://www.wokingham.gov.uk/rubbish-and-recycling/waste-collection/find-your-bin-collection-day"
             )

--- a/uk_bin_collection/uk_bin_collection/councils/WrexhamCountyBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/WrexhamCountyBoroughCouncil.py
@@ -33,7 +33,8 @@ class CouncilClass(AbstractGetBinDataClass):
             check_uprn(user_uprn)
             check_postcode(user_postcode)
             # Create Selenium webdriver
-            driver = create_webdriver(web_driver, headless, None, __name__)
+            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get(page)
 
             start_now_btn = WebDriverWait(driver, timeout=15).until(


### PR DESCRIPTION
Several Selenium-based scrapers were running with Chrome's default headless user agent, which some council websites detect and block (returning 403s, Cloudflare challenges, or empty responses).

This adds a realistic desktop Chrome user agent string to the `create_webdriver` call in every Selenium scraper that was missing one. The `create_webdriver` function already supports the `user_agent` parameter — most scrapers were just passing `None`.

63 files changed, all with the same mechanical edit: define a `user_agent` variable and pass it instead of `None`. Scrapers that already set a user agent (15 councils) and those with separate open PRs are excluded.

No functional changes beyond the user agent string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated browser identification across 68 council integrations to use consistent user-agent strings during web requests.
  * Note: Two council modules may require additional review for syntax issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->