### PR TITLE
fix: NorthYorkshire - find HTML data dynamically in AJAX response

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/NorthYorkshire.py
+++ b/uk_bin_collection/uk_bin_collection/councils/NorthYorkshire.py
@@ -12,7 +12,6 @@ class CouncilClass(AbstractGetBinDataClass):
         uprn = kwargs.get("uprn")
         check_uprn(uprn)
 
-        # Figure bin data URL from UPRN
         url = "https://www.northyorks.gov.uk/bin-calendar/lookup"
         payload = {
             "selected_address": uprn,
@@ -21,18 +20,24 @@ class CouncilClass(AbstractGetBinDataClass):
         }
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
 
-        # This endpoint redirects to the data url.
         response = requests.request("POST", url, headers=headers, data=payload)
         bin_data_url = f"{response.url}/ajax"
 
-        # Get bin data
         response = requests.request("GET", bin_data_url)
         bin_data = response.json()
 
-        # Parse bin data
-        soup = BeautifulSoup(bin_data[1]["data"], "html.parser")
+        # Find the item containing HTML data (the index shifted from 1 to 2)
+        html_data = None
+        for item in bin_data:
+            if isinstance(item, dict) and isinstance(item.get("data"), str) and "<div" in item["data"]:
+                html_data = item["data"]
+                break
 
-        # All collection info is in the table
+        if not html_data:
+            raise ValueError("No HTML bin data found in API response")
+
+        soup = BeautifulSoup(html_data, "html.parser")
+
         table = (
             soup.find("div", {"id": "upcoming-collection"}).find("table").find("tbody")
         )
@@ -42,11 +47,7 @@ class CouncilClass(AbstractGetBinDataClass):
 
         for row in rows:
             cols = row.find_all("td")
-            # First column is date
             bin_date = datetime.strptime(cols[0].text.strip(), "%d %B %Y")
-
-            # Third column may contain multiple bin types separated by line breaks
-            # .stripped_strings yields a generator over all non-whitespace text segments
             bin_types = [txt for txt in cols[2].stripped_strings]
 
             for sub_bin in bin_types:


### PR DESCRIPTION
The AJAX endpoint at /ajax returns a list of command objects. The HTML bin data was at index [1] but has shifted to index [2] — the response now has a CSS stylesheet object at [1] instead.

Changed the parser to search the list for the first item where data is a string containing HTML, instead of hardcoding the index. This is resilient to future index shifts.

Tested with UPRN 10093091235 in Selby.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced North Yorkshire council's bin collection data parsing to dynamically locate collection information in API responses instead of assuming a fixed response structure, with improved error handling for missing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->