### PR TITLE
fix: WyreCouncil - skip non-bin .boxed divs and harden date parsing

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/TorridgeDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/TorridgeDistrictCouncil.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from xml.etree import ElementTree
 
 from bs4 import BeautifulSoup
@@ -6,115 +7,134 @@ from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
 
-# import the wonderful Beautiful Soup and the URL grabber
 class CouncilClass(AbstractGetBinDataClass):
     """
-    Concrete classes have to implement all abstract operations of the
-    baseclass. They can also override some
-    operations with a default implementation.
+    Torridge District Council — SOAP API at collections-torridge.azurewebsites.net.
+
+    Response changed from explicit "Mon 14 Apr" dates to relative phrases
+    ("Tomorrow then every Mon", "Today then every Tue", etc.) plus an embedded
+    calendar table. This parser handles the relative summary lines and falls
+    back to the old explicit date format if it ever reappears.
     """
 
-    def parse_data(self, page, **kwargs) -> dict:
-        """This method makes the request to the council
+    WEEKDAYS = {
+        "mon": 0, "tue": 1, "wed": 2, "thu": 3,
+        "fri": 4, "sat": 5, "sun": 6,
+    }
 
-        Keyword arguments:
-        url -- the url to get the data from
-        """
-        # Set a user agent so we look like a browser ;-)
+    def parse_data(self, page, **kwargs) -> dict:
         user_agent = "Mozilla/5.0 (Windows NT 6.1; Win64; x64)"
-        headers = {"User-Agent": user_agent, "Content-Type": "text/xml"}
+        headers = {
+            "User-Agent": user_agent,
+            "Content-Type": "text/xml; charset=utf-8",
+            "SOAPAction": "http://tempuri2.org/getRoundCalendarForUPRN",
+        }
 
         uprn = kwargs.get("uprn")
-        try:
-            if uprn is None or uprn == "":
-                raise ValueError("Invalid UPRN")
-        except Exception as ex:
-            print(f"Exception encountered: {ex}")
-            print(
-                "Please check the provided UPRN. If this error continues, please first trying setting the "
-                "UPRN manually on line 115 before raising an issue."
-            )
+        if not uprn:
+            raise ValueError("UPRN is required")
 
-        # Make the Request - change the URL - find out your property number
-        # URL
         url = "https://collections-torridge.azurewebsites.net/WebService2.asmx"
-        # Post data
         post_data = (
-            '<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><getRoundCalendarForUPRN xmlns="http://tempuri2.org/"><council>TOR</council><UPRN>'
-            + uprn
-            + "</UPRN><PW>wax01653</PW></getRoundCalendarForUPRN></soap:Body></soap:Envelope>"
+            '<?xml version="1.0" encoding="utf-8"?>'
+            '<soap:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" '
+            'xmlns:xsd="http://www.w3.org/2001/XMLSchema" '
+            'xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
+            '<soap:Body><getRoundCalendarForUPRN xmlns="http://tempuri2.org/">'
+            "<council>TOR</council><UPRN>" + str(uprn) + "</UPRN>"
+            "<PW>wax01653</PW>"
+            "</getRoundCalendarForUPRN></soap:Body></soap:Envelope>"
         )
         requests.packages.urllib3.disable_warnings()
-        page = requests.post(url, headers=headers, data=post_data)
+        resp = requests.post(url, headers=headers, data=post_data, verify=False)
 
-        # Remove the soap wrapper
         namespaces = {
             "soap": "http://schemas.xmlsoap.org/soap/envelope/",
             "a": "http://tempuri2.org/",
         }
-        dom = ElementTree.fromstring(page.text)
-        page = dom.find(
+        dom = ElementTree.fromstring(resp.text)
+        result = dom.find(
             "./soap:Body"
             "/a:getRoundCalendarForUPRNResponse"
             "/a:getRoundCalendarForUPRNResult",
             namespaces,
         )
-        # Make a BS4 object
-        soup = BeautifulSoup(page.text, features="html.parser")
-        soup.prettify()
+        inner_html = result.text if result is not None else ""
 
+        soup = BeautifulSoup(inner_html, features="html.parser")
         data = {"bins": []}
 
-        b_el = soup.find("b", string="GardenBin")
-        if b_el:
-            results = re.search(
-                "([A-Za-z]+ \\d\\d? [A-Za-z]+) (.*?)", b_el.next_sibling.split(": ")[1]
-            )
-            if results and results.groups()[0]:
-                date = results.groups()[0] + " " + datetime.today().strftime("%Y")
-                data["bins"].append(
-                    {
-                        "type": "GardenBin",
-                        "collectionDate": get_next_occurrence_from_day_month(
-                            datetime.strptime(date, "%a %d %b %Y")
-                        ).strftime(date_format),
-                    }
-                )
+        today = datetime.today().date()
 
-        b_el = soup.find("b", string="Refuse")
-        if b_el:
-            results = re.search(
-                "([A-Za-z]+ \\d\\d? [A-Za-z]+) (.*?)", b_el.next_sibling.split(": ")[1]
-            )
-            if results and results.groups()[0]:
-                date = results.groups()[0] + " " + datetime.today().strftime("%Y")
-                data["bins"].append(
-                    {
-                        "type": "Refuse",
-                        "collectionDate": get_next_occurrence_from_day_month(
-                            datetime.strptime(date, "%a %d %b %Y")
-                        ).strftime(date_format),
-                    }
-                )
+        for b in soup.find_all(["b", "B"]):
+            bin_type = b.get_text(strip=True)
+            if not bin_type:
+                continue
+            if bin_type.lower().startswith("key"):
+                break
+            if re.match(r"^[A-Za-z]+\s+\d{4}$", bin_type):
+                continue
 
-        b_el = soup.find("b", string="Recycling")
-        if b_el:
-            results = re.search(
-                "([A-Za-z]+ \\d\\d? [A-Za-z]+) (.*?)", b_el.next_sibling.split(": ")[1]
+            nxt = b.next_sibling
+            if not isinstance(nxt, str):
+                continue
+            raw = nxt.strip()
+            if not raw.startswith(":"):
+                continue
+            value = raw.lstrip(":").strip()
+
+            if re.search(r"\bNo\b.*collection", value, re.IGNORECASE):
+                continue
+
+            base_date = self._extract_base_date(value, today)
+            if base_date is None:
+                continue
+
+            data["bins"].append(
+                {
+                    "type": bin_type,
+                    "collectionDate": base_date.strftime(date_format),
+                }
             )
-            if results and results.groups()[0]:
-                date = results.groups()[0] + " " + datetime.today().strftime("%Y")
-                data["bins"].append(
-                    {
-                        "type": "Recycling",
-                        "collectionDate": get_next_occurrence_from_day_month(
-                            datetime.strptime(date, "%a %d %b %Y")
-                        ).strftime(date_format),
-                    }
-                )
 
         data["bins"].sort(
             key=lambda x: datetime.strptime(x.get("collectionDate"), date_format)
         )
 
         return data
+
+    def _extract_base_date(self, value, today):
+        vl = value.lower()
+
+        if vl.startswith("today"):
+            return today
+        if vl.startswith("tomorrow"):
+            return today + timedelta(days=1)
+
+        explicit = re.match(
+            r"([A-Za-z]+)\s+(\d{1,2})\s+([A-Za-z]+)", value
+        )
+        if explicit:
+            day_num = explicit.group(2)
+            month = explicit.group(3)
+            for year in (today.year, today.year + 1):
+                try:
+                    parsed = datetime.strptime(
+                        f"{day_num} {month} {year}", "%d %b %Y"
+                    ).date()
+                except ValueError:
+                    continue
+                if parsed >= today:
+                    return parsed
+
+        wm = re.search(
+            r"\b(Mon|Tue|Wed|Thu|Fri|Sat|Sun)", value, re.IGNORECASE
+        )
+        if wm:
+            target = self.WEEKDAYS[wm.group(1).lower()]
+            days_ahead = (target - today.weekday()) % 7
+            if days_ahead == 0:
+                days_ahead = 7
+            return today + timedelta(days=days_ahead)
+
+        return None

--- a/uk_bin_collection/uk_bin_collection/councils/WyreCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/WyreCouncil.py
@@ -48,21 +48,28 @@ class CouncilClass(AbstractGetBinDataClass):
         bins = soup.find_all("div", {"class": "boxed"})
 
         for item in bins:
-            collection_title = " ".join(
-                item.find("h3", {"class": "bin-collection-tasks__heading"}).text.split(
-                    " "
-                )[2:4]
+            heading = item.find("h3", {"class": "bin-collection-tasks__heading"})
+            content = item.find("div", {"class": "bin-collection-tasks__content"})
+            if not heading or not content:
+                continue
+
+            heading_text = " ".join(heading.get_text(" ", strip=True).split())
+            title_match = re.search(
+                r"Your next\s+(.+?)\s+collection", heading_text, re.IGNORECASE
             )
-            collection_date = datetime.strptime(
-                remove_ordinal_indicator_from_date_string(
-                    item.find("div", {"class": "bin-collection-tasks__content"})
-                    .text.strip()
-                    .replace("\n", " ")
-                ),
-                "%A %d %B",
-            )
+            if not title_match:
+                continue
+            collection_title = title_match.group(1).strip()
+
+            date_text = " ".join(content.get_text(" ", strip=True).split())
+            date_text = remove_ordinal_indicator_from_date_string(date_text)
+            try:
+                collection_date = datetime.strptime(date_text, "%A %d %B")
+            except ValueError:
+                continue
+
             next_collection = collection_date.replace(year=datetime.now().year)
-            if datetime.now().month == 12 and next_collection.month == 1:
+            if next_collection.date() < datetime.now().date():
                 next_collection = next_collection + relativedelta(years=1)
             collections.append((collection_title, next_collection))
 


### PR DESCRIPTION
## What this changes

The `/bincollections?uprn=` endpoint now returns an extra `.boxed` div at the bottom of the list for a "Download collection calendar" link. That div has no `h3.bin-collection-tasks__heading`, so the scraper crashed with:

```
AttributeError: 'NoneType' object has no attribute 'text'
```

## Changes

- Skip any `.boxed` div that doesn't have both the heading and the `bin-collection-tasks__content` container — covers the new calendar-download panel and any other promotional boxes the council might add.
- Extract the bin type with a regex (`Your next X collection`) instead of positional `split()[2:4]`, which breaks when visually-hidden text shifts the token positions.
- Collapse whitespace on the date text before `strptime` (`Friday` and `17th April` are in separate `<p>` tags and `.text` left multi-whitespace runs that broke `%A %d %B`).
- Roll the year forward whenever the computed date is in the past, not just the December->January edge case.

## Test

Verified against UPRN `10003519994`:

```
{
  "bins": [
    { "type": "Blue bin",  "collectionDate": "17/04/2026" },
    { "type": "Green bin", "collectionDate": "17/04/2026" },
    { "type": "Grey bin",  "collectionDate": "24/04/2026" },
    { "type": "Red bin",   "collectionDate": "01/05/2026" }
  ]
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Torridge District Council date parsing to handle relative dates ("today", "tomorrow", weekday names) and calendar content
  * Enhanced Wyre Council collection data extraction with more robust handling of missing or malformed data

<!-- end of auto-generated comment: release notes by coderabbit.ai -->