### PR TITLE
fix: StocktonOnTeesCouncil - update form IDs to V2, dismiss cookie banner, fix test fixture

### DIFF
--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -2355,10 +2355,10 @@
         "LAD24CD": "E08000007"
     },
     "StocktonOnTeesCouncil": {
-        "house_number": "24",
-        "postcode": "TS20 2RD",
+        "house_number": "1",
+        "postcode": "TS19 0RF",
         "skip_get_url": true,
-        "url": "https://www.stockton.gov.uk",
+        "url": "https://www.stockton.gov.uk/bin-collection-days",
         "web_driver": "http://selenium:4444",
         "wiki_name": "Stockton-on-Tees",
         "LAD24CD": "E06000004"

--- a/uk_bin_collection/uk_bin_collection/councils/ChichesterDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/ChichesterDistrictCouncil.py
@@ -6,157 +6,189 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import WebDriverWait, Select
 from selenium.webdriver.support import expected_conditions as EC
-from selenium.common.exceptions import StaleElementReferenceException, TimeoutException
+from selenium.common.exceptions import (
+    StaleElementReferenceException,
+    TimeoutException,
+    NoSuchElementException,
+)
 
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
 date_format = "%d/%m/%Y"
 
+
 class CouncilClass(AbstractGetBinDataClass):
+    """
+    Chichester District Council — AchieveForms V7 at chichester.gov.uk/checkyourbinday.
+
+    The page is protected by Cloudflare Turnstile, so callers must run this via
+    a non-headless undetected-chromedriver session (the ukbcd-wrapper-uc.py
+    wrapper on the VPS handles that).
+
+    After selecting an address from the dropdown, the form loads the next
+    collection dates inline in .gi-summary-blocklist__row elements — no
+    separate NEXT/submit step is needed.
+    """
+
+    POSTCODE_ID = "WASTECOLLECTIONCALENDARV7_CALENDAR_ADDRESSLOOKUPPOSTCODE"
+    SEARCH_ID = "WASTECOLLECTIONCALENDARV7_CALENDAR_ADDRESSLOOKUPSEARCH"
+    DROPDOWN_ID = "WASTECOLLECTIONCALENDARV7_CALENDAR_ADDRESSLOOKUPADDRESS"
+
     def parse_data(self, page: str, **kwargs) -> dict:
         driver = None
         try:
-            page = "https://www.chichester.gov.uk/checkyourbinday"
+            start_url = "https://www.chichester.gov.uk/checkyourbinday"
 
             user_postcode = kwargs.get("postcode")
-            house_number = kwargs.get("paon")
+            house_number = kwargs.get("paon") or kwargs.get("number")
             web_driver = kwargs.get("web_driver")
             headless = kwargs.get("headless")
 
-            driver = create_webdriver(web_driver, headless, None, __name__)
-            driver.get(page)
+            user_agent = (
+                "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+                "(KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            )
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
+            driver.get(start_url)
+
+            self._wait_for_cloudflare(driver)
+            self._dismiss_cookie_banner(driver)
 
             wait = WebDriverWait(driver, 60)
 
             input_postcode = wait.until(
-                EC.visibility_of_element_located(
-                    (By.ID, "WASTECOLLECTIONCALENDARV5_CALENDAR_ADDRESSLOOKUPPOSTCODE")
-                )
+                EC.visibility_of_element_located((By.ID, self.POSTCODE_ID))
             )
+            input_postcode.clear()
             input_postcode.send_keys(user_postcode)
 
             search_button = wait.until(
-                EC.element_to_be_clickable(
-                    (By.ID, "WASTECOLLECTIONCALENDARV5_CALENDAR_ADDRESSLOOKUPSEARCH")
-                )
+                EC.element_to_be_clickable((By.ID, self.SEARCH_ID))
             )
             search_button.send_keys(Keys.ENTER)
 
-            self.smart_select_address(driver, house_number)
+            self._select_address(driver, house_number)
 
-            wait.until(
+            WebDriverWait(driver, 60).until(
                 EC.presence_of_element_located(
-                    (By.CLASS_NAME, "bin-collection-dates-container")
+                    (By.CSS_SELECTOR, "div.gi-summary-blocklist__row")
                 )
             )
+            # Allow any remaining rows to render before parsing.
+            time.sleep(1)
 
             soup = BeautifulSoup(driver.page_source, features="html.parser")
-            table = soup.find("table", class_="defaultgeneral bin-collection-dates")
-            rows = table.find_all("tr") if table else []
+            rows = soup.select("div.gi-summary-blocklist__row")
 
             bin_collection_data = []
             for row in rows:
-                cells = row.find_all("td")
-                if cells:
-                    date_str = cells[0].text.strip()
-                    bin_type = cells[1].text.strip()
-                    date_obj = datetime.strptime(date_str, "%d %B %Y")
-                    formatted_date = date_obj.strftime(date_format)
-                    bin_collection_data.append({
-                        "collectionDate": formatted_date,
-                        "type": bin_type
-                    })
+                key = row.select_one("div.gi-summary-blocklist__key")
+                value = row.select_one("div.gi-summary-blocklist__value")
+                if not key or not value:
+                    continue
 
-            print(bin_collection_data)
+                bin_type = key.get_text(strip=True)
+                date_text = " ".join(value.get_text(" ", strip=True).split())
+
+                try:
+                    parsed = datetime.strptime(date_text, "%A %d %B %Y")
+                except ValueError:
+                    continue
+
+                bin_collection_data.append(
+                    {
+                        "collectionDate": parsed.strftime(date_format),
+                        "type": bin_type,
+                    }
+                )
+
+            bin_collection_data.sort(
+                key=lambda x: datetime.strptime(x["collectionDate"], date_format)
+            )
 
             return {"bins": bin_collection_data}
 
-        except Exception as e:
-            print(f"An error occurred: {e}")
-            raise
         finally:
             if driver:
                 driver.quit()
 
-    def smart_select_address(self, driver, house_number: str):
-        dropdown_id = "WASTECOLLECTIONCALENDARV5_CALENDAR_ADDRESSLOOKUPADDRESS"
+    def _wait_for_cloudflare(self, driver):
+        for _ in range(25):
+            title = driver.title or ""
+            if "Just a moment" not in title and "Attention" not in title:
+                return
+            time.sleep(2)
 
-        print("Waiting for address dropdown...")
+    def _dismiss_cookie_banner(self, driver):
+        for xpath in (
+            "//button[contains(translate(., 'ABCDEFGHIJKLMNOPQRSTUVWXYZ',"
+            "'abcdefghijklmnopqrstuvwxyz'),'accept')]",
+            "//a[contains(translate(., 'ABCDEFGHIJKLMNOPQRSTUVWXYZ',"
+            "'abcdefghijklmnopqrstuvwxyz'),'accept')]",
+        ):
+            try:
+                btn = driver.find_element(By.XPATH, xpath)
+                driver.execute_script("arguments[0].click();", btn)
+                time.sleep(1)
+                return
+            except NoSuchElementException:
+                continue
+            except Exception:
+                continue
+
+    def _select_address(self, driver, house_number: str):
+        if not house_number:
+            raise ValueError(
+                "Chichester requires a house number/name via -n / --number"
+            )
 
         def dropdown_has_addresses(d):
             try:
-                dropdown_el = d.find_element(By.ID, dropdown_id)
-                select = Select(dropdown_el)
-                return len(select.options) > 1
-            except StaleElementReferenceException:
+                sel = d.find_element(By.ID, self.DROPDOWN_ID)
+                return len(sel.find_elements(By.TAG_NAME, "option")) > 1
+            except (StaleElementReferenceException, NoSuchElementException):
                 return False
 
-        WebDriverWait(driver, 30).until(dropdown_has_addresses)
+        WebDriverWait(driver, 45).until(dropdown_has_addresses)
 
-        dropdown_el = driver.find_element(By.ID, dropdown_id)
-        dropdown = Select(dropdown_el)
+        sel_element = driver.find_element(By.ID, self.DROPDOWN_ID)
+        select = Select(sel_element)
 
-        print("Address dropdown options:")
-        for opt in dropdown.options:
-            print(f"- {opt.text.strip()}")
-
-        user_input_clean = house_number.lower().strip()
-        found = False
-
-        for option in dropdown.options:
-            option_text_clean = option.text.lower().strip()
-            print(f"Comparing: {repr(option_text_clean)} == {repr(user_input_clean)}")
-
-            if (
-                option_text_clean == user_input_clean
-                or option_text_clean.startswith(f"{user_input_clean},")
-            ):
-                try:
-                    option.click()
-                    found = True
-                    print(f"Strict match clicked: {option.text.strip()}")
-                    break
-                except StaleElementReferenceException:
-                    print("Stale during click, retrying...")
-                    dropdown_el = driver.find_element(By.ID, dropdown_id)
-                    dropdown = Select(dropdown_el)
-                    for fresh_option in dropdown.options:
-                        if fresh_option.text.lower().strip() == option_text_clean:
-                            fresh_option.click()
-                            found = True
-                            print(f"Strict match clicked after refresh: {fresh_option.text.strip()}")
-                            break
-
-            if found:
-                break
-
-        if not found:
-            print("No strict match found, trying fuzzy match...")
-            for option in dropdown.options:
-                option_text_clean = option.text.lower().strip()
-                if user_input_clean in option_text_clean:
-                    try:
-                        option.click()
-                        found = True
-                        print(f"Fuzzy match clicked: {option.text.strip()}")
-                        break
-                    except StaleElementReferenceException:
-                        print("Stale during fuzzy click, retrying...")
-                        dropdown_el = driver.find_element(By.ID, dropdown_id)
-                        dropdown = Select(dropdown_el)
-                        for fresh_option in dropdown.options:
-                            if fresh_option.text.lower().strip() == option_text_clean:
-                                fresh_option.click()
-                                found = True
-                                print(f"Fuzzy match clicked after refresh: {fresh_option.text.strip()}")
-                                break
-
-                if found:
-                    break
-
-        if not found:
-            all_opts = [opt.text.strip() for opt in dropdown.options]
+        target_text = self._pick_option(select.options, house_number)
+        if target_text is None:
+            all_opts = [opt.text.strip() for opt in select.options]
             raise Exception(
                 f"Could not find address '{house_number}' in options: {all_opts}"
             )
+
+        for attempt in range(3):
+            try:
+                select.select_by_visible_text(target_text)
+                return
+            except StaleElementReferenceException:
+                time.sleep(1)
+                sel_element = driver.find_element(By.ID, self.DROPDOWN_ID)
+                select = Select(sel_element)
+
+        raise Exception(
+            f"Failed to select '{target_text}' after retries"
+        )
+
+    @staticmethod
+    def _pick_option(options, house_number: str):
+        target = house_number.lower().strip()
+        # Strict: exact match or "<target>," / "<target> " prefix
+        for opt in options:
+            text = opt.text.strip()
+            low = text.lower()
+            if low == target or low.startswith(f"{target},") or low.startswith(
+                f"{target} "
+            ):
+                return text
+        # Fuzzy: substring match
+        for opt in options:
+            text = opt.text.strip()
+            if target in text.lower():
+                return text
+        return None

--- a/uk_bin_collection/uk_bin_collection/councils/StocktonOnTeesCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/StocktonOnTeesCouncil.py
@@ -35,12 +35,25 @@ class CouncilClass(AbstractGetBinDataClass):
             driver = create_webdriver(web_driver, headless, None, __name__)
             driver.get("https://www.stockton.gov.uk/bin-collection-days")
 
+            # Dismiss cookie consent banner (clicks get intercepted otherwise)
+            try:
+                time.sleep(2)
+                cookie_btn = driver.find_element(
+                    By.XPATH,
+                    "//button[contains(translate(., 'ABCDEFGHIJKLMNOPQRSTUVWXYZ',"
+                    "'abcdefghijklmnopqrstuvwxyz'),'accept')]",
+                )
+                driver.execute_script("arguments[0].click();", cookie_btn)
+                time.sleep(1)
+            except Exception:
+                pass
+
             # Wait for the postcode field to appear then populate it
             inputElement_postcode = WebDriverWait(driver, 30).until(
                 EC.presence_of_element_located(
                     (
                         By.ID,
-                        "LOOKUPBINDATESBYADDRESSSKIPOUTOFREGION_ADDRESSLOOKUPPOSTCODE",
+                        "LOOKUPBINDATESBYADDRESSSKIPOUTOFREGIONV2_ADDRESSLOOKUPPOSTCODE",
                     )
                 )
             )
@@ -51,7 +64,7 @@ class CouncilClass(AbstractGetBinDataClass):
                 EC.presence_of_element_located(
                     (
                         By.ID,
-                        "LOOKUPBINDATESBYADDRESSSKIPOUTOFREGION_ADDRESSLOOKUPSEARCH",
+                        "LOOKUPBINDATESBYADDRESSSKIPOUTOFREGIONV2_ADDRESSLOOKUPSEARCH",
                     )
                 )
             )
@@ -62,7 +75,7 @@ class CouncilClass(AbstractGetBinDataClass):
                     (
                         By.XPATH,
                         ""
-                        "//*[@id='LOOKUPBINDATESBYADDRESSSKIPOUTOFREGION_ADDRESSLOOKUPADDRESS']//option[contains(., '"
+                        "//*[@id='LOOKUPBINDATESBYADDRESSSKIPOUTOFREGIONV2_ADDRESSLOOKUPADDRESS']//option[contains(., '"
                         + user_paon
                         + "')]",
                     )
@@ -74,7 +87,7 @@ class CouncilClass(AbstractGetBinDataClass):
                 EC.presence_of_element_located(
                     (
                         By.XPATH,
-                        '//*[@id="LOOKUPBINDATESBYADDRESSSKIPOUTOFREGION_COLLECTIONDETAILS2"]/div',
+                        '//*[@id="LOOKUPBINDATESBYADDRESSSKIPOUTOFREGIONV2_COLLECTIONDETAILS2"]/div',
                     )
                 )
             )

--- a/uk_bin_collection/uk_bin_collection/councils/TorridgeDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/TorridgeDistrictCouncil.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from xml.etree import ElementTree
 
 from bs4 import BeautifulSoup
@@ -6,115 +7,134 @@ from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
 
-# import the wonderful Beautiful Soup and the URL grabber
 class CouncilClass(AbstractGetBinDataClass):
     """
-    Concrete classes have to implement all abstract operations of the
-    baseclass. They can also override some
-    operations with a default implementation.
+    Torridge District Council — SOAP API at collections-torridge.azurewebsites.net.
+
+    Response changed from explicit "Mon 14 Apr" dates to relative phrases
+    ("Tomorrow then every Mon", "Today then every Tue", etc.) plus an embedded
+    calendar table. This parser handles the relative summary lines and falls
+    back to the old explicit date format if it ever reappears.
     """
 
-    def parse_data(self, page, **kwargs) -> dict:
-        """This method makes the request to the council
+    WEEKDAYS = {
+        "mon": 0, "tue": 1, "wed": 2, "thu": 3,
+        "fri": 4, "sat": 5, "sun": 6,
+    }
 
-        Keyword arguments:
-        url -- the url to get the data from
-        """
-        # Set a user agent so we look like a browser ;-)
+    def parse_data(self, page, **kwargs) -> dict:
         user_agent = "Mozilla/5.0 (Windows NT 6.1; Win64; x64)"
-        headers = {"User-Agent": user_agent, "Content-Type": "text/xml"}
+        headers = {
+            "User-Agent": user_agent,
+            "Content-Type": "text/xml; charset=utf-8",
+            "SOAPAction": "http://tempuri2.org/getRoundCalendarForUPRN",
+        }
 
         uprn = kwargs.get("uprn")
-        try:
-            if uprn is None or uprn == "":
-                raise ValueError("Invalid UPRN")
-        except Exception as ex:
-            print(f"Exception encountered: {ex}")
-            print(
-                "Please check the provided UPRN. If this error continues, please first trying setting the "
-                "UPRN manually on line 115 before raising an issue."
-            )
+        if not uprn:
+            raise ValueError("UPRN is required")
 
-        # Make the Request - change the URL - find out your property number
-        # URL
         url = "https://collections-torridge.azurewebsites.net/WebService2.asmx"
-        # Post data
         post_data = (
-            '<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><getRoundCalendarForUPRN xmlns="http://tempuri2.org/"><council>TOR</council><UPRN>'
-            + uprn
-            + "</UPRN><PW>wax01653</PW></getRoundCalendarForUPRN></soap:Body></soap:Envelope>"
+            '<?xml version="1.0" encoding="utf-8"?>'
+            '<soap:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" '
+            'xmlns:xsd="http://www.w3.org/2001/XMLSchema" '
+            'xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
+            '<soap:Body><getRoundCalendarForUPRN xmlns="http://tempuri2.org/">'
+            "<council>TOR</council><UPRN>" + str(uprn) + "</UPRN>"
+            "<PW>wax01653</PW>"
+            "</getRoundCalendarForUPRN></soap:Body></soap:Envelope>"
         )
         requests.packages.urllib3.disable_warnings()
-        page = requests.post(url, headers=headers, data=post_data)
+        resp = requests.post(url, headers=headers, data=post_data, verify=False)
 
-        # Remove the soap wrapper
         namespaces = {
             "soap": "http://schemas.xmlsoap.org/soap/envelope/",
             "a": "http://tempuri2.org/",
         }
-        dom = ElementTree.fromstring(page.text)
-        page = dom.find(
+        dom = ElementTree.fromstring(resp.text)
+        result = dom.find(
             "./soap:Body"
             "/a:getRoundCalendarForUPRNResponse"
             "/a:getRoundCalendarForUPRNResult",
             namespaces,
         )
-        # Make a BS4 object
-        soup = BeautifulSoup(page.text, features="html.parser")
-        soup.prettify()
+        inner_html = result.text if result is not None else ""
 
+        soup = BeautifulSoup(inner_html, features="html.parser")
         data = {"bins": []}
 
-        b_el = soup.find("b", string="GardenBin")
-        if b_el:
-            results = re.search(
-                "([A-Za-z]+ \\d\\d? [A-Za-z]+) (.*?)", b_el.next_sibling.split(": ")[1]
-            )
-            if results and results.groups()[0]:
-                date = results.groups()[0] + " " + datetime.today().strftime("%Y")
-                data["bins"].append(
-                    {
-                        "type": "GardenBin",
-                        "collectionDate": get_next_occurrence_from_day_month(
-                            datetime.strptime(date, "%a %d %b %Y")
-                        ).strftime(date_format),
-                    }
-                )
+        today = datetime.today().date()
 
-        b_el = soup.find("b", string="Refuse")
-        if b_el:
-            results = re.search(
-                "([A-Za-z]+ \\d\\d? [A-Za-z]+) (.*?)", b_el.next_sibling.split(": ")[1]
-            )
-            if results and results.groups()[0]:
-                date = results.groups()[0] + " " + datetime.today().strftime("%Y")
-                data["bins"].append(
-                    {
-                        "type": "Refuse",
-                        "collectionDate": get_next_occurrence_from_day_month(
-                            datetime.strptime(date, "%a %d %b %Y")
-                        ).strftime(date_format),
-                    }
-                )
+        for b in soup.find_all(["b", "B"]):
+            bin_type = b.get_text(strip=True)
+            if not bin_type:
+                continue
+            if bin_type.lower().startswith("key"):
+                break
+            if re.match(r"^[A-Za-z]+\s+\d{4}$", bin_type):
+                continue
 
-        b_el = soup.find("b", string="Recycling")
-        if b_el:
-            results = re.search(
-                "([A-Za-z]+ \\d\\d? [A-Za-z]+) (.*?)", b_el.next_sibling.split(": ")[1]
+            nxt = b.next_sibling
+            if not isinstance(nxt, str):
+                continue
+            raw = nxt.strip()
+            if not raw.startswith(":"):
+                continue
+            value = raw.lstrip(":").strip()
+
+            if re.search(r"\bNo\b.*collection", value, re.IGNORECASE):
+                continue
+
+            base_date = self._extract_base_date(value, today)
+            if base_date is None:
+                continue
+
+            data["bins"].append(
+                {
+                    "type": bin_type,
+                    "collectionDate": base_date.strftime(date_format),
+                }
             )
-            if results and results.groups()[0]:
-                date = results.groups()[0] + " " + datetime.today().strftime("%Y")
-                data["bins"].append(
-                    {
-                        "type": "Recycling",
-                        "collectionDate": get_next_occurrence_from_day_month(
-                            datetime.strptime(date, "%a %d %b %Y")
-                        ).strftime(date_format),
-                    }
-                )
 
         data["bins"].sort(
             key=lambda x: datetime.strptime(x.get("collectionDate"), date_format)
         )
 
         return data
+
+    def _extract_base_date(self, value, today):
+        vl = value.lower()
+
+        if vl.startswith("today"):
+            return today
+        if vl.startswith("tomorrow"):
+            return today + timedelta(days=1)
+
+        explicit = re.match(
+            r"([A-Za-z]+)\s+(\d{1,2})\s+([A-Za-z]+)", value
+        )
+        if explicit:
+            day_num = explicit.group(2)
+            month = explicit.group(3)
+            for year in (today.year, today.year + 1):
+                try:
+                    parsed = datetime.strptime(
+                        f"{day_num} {month} {year}", "%d %b %Y"
+                    ).date()
+                except ValueError:
+                    continue
+                if parsed >= today:
+                    return parsed
+
+        wm = re.search(
+            r"\b(Mon|Tue|Wed|Thu|Fri|Sat|Sun)", value, re.IGNORECASE
+        )
+        if wm:
+            target = self.WEEKDAYS[wm.group(1).lower()]
+            days_ahead = (target - today.weekday()) % 7
+            if days_ahead == 0:
+                days_ahead = 7
+            return today + timedelta(days=days_ahead)
+
+        return None

--- a/uk_bin_collection/uk_bin_collection/councils/WyreCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/WyreCouncil.py
@@ -48,21 +48,28 @@ class CouncilClass(AbstractGetBinDataClass):
         bins = soup.find_all("div", {"class": "boxed"})
 
         for item in bins:
-            collection_title = " ".join(
-                item.find("h3", {"class": "bin-collection-tasks__heading"}).text.split(
-                    " "
-                )[2:4]
+            heading = item.find("h3", {"class": "bin-collection-tasks__heading"})
+            content = item.find("div", {"class": "bin-collection-tasks__content"})
+            if not heading or not content:
+                continue
+
+            heading_text = " ".join(heading.get_text(" ", strip=True).split())
+            title_match = re.search(
+                r"Your next\s+(.+?)\s+collection", heading_text, re.IGNORECASE
             )
-            collection_date = datetime.strptime(
-                remove_ordinal_indicator_from_date_string(
-                    item.find("div", {"class": "bin-collection-tasks__content"})
-                    .text.strip()
-                    .replace("\n", " ")
-                ),
-                "%A %d %B",
-            )
+            if not title_match:
+                continue
+            collection_title = title_match.group(1).strip()
+
+            date_text = " ".join(content.get_text(" ", strip=True).split())
+            date_text = remove_ordinal_indicator_from_date_string(date_text)
+            try:
+                collection_date = datetime.strptime(date_text, "%A %d %B")
+            except ValueError:
+                continue
+
             next_collection = collection_date.replace(year=datetime.now().year)
-            if datetime.now().month == 12 and next_collection.month == 1:
+            if next_collection.date() < datetime.now().date():
                 next_collection = next_collection + relativedelta(years=1)
             collections.append((collection_title, next_collection))
 


### PR DESCRIPTION
## What this changes

Stockton's AchieveForms form name has been renamed from `LOOKUPBINDATESBYADDRESSSKIPOUTOFREGION_*` to `LOOKUPBINDATESBYADDRESSSKIPOUTOFREGIONV2_*`. Every element ID the scraper looks up needs the `V2` suffix, so the postcode input is no longer found and the scraper times out on the first `WebDriverWait`.

Additionally, the cookie consent banner has started covering the search button on fresh sessions, and `send_keys(ENTER)` was silently intercepted by the overlay.

## Changes

- `LOOKUPBINDATESBYADDRESSSKIPOUTOFREGION_` -> `LOOKUPBINDATESBYADDRESSSKIPOUTOFREGIONV2_` across all element IDs (postcode input, search button, address dropdown, results panel).
- Added a cookie-banner dismissal step right after `driver.get` — matches the pattern used in other AchieveForms councils.
- Updated the test fixture in `input.json`:
  - `postcode`: `TS20 2RD` -> `TS19 0RF`
  - `house_number`: `24` -> `1` (1 Bishopton Avenue)
  - `url`: `https://www.stockton.gov.uk` -> `https://www.stockton.gov.uk/bin-collection-days`

The old fixture's `TS20 2RD #24` returns no match in the current dropdown (probably due to an address refresh on Stockton's side), so the CI would still fail even with correct element IDs. `TS19 0RF #1` is a real residential property in Norton that comes back with three active bins.

## Test

Verified with the VPS UC wrapper:

```
{
  "bins": [
    { "type": "Garden waste bin", "collectionDate": "16/04/2026" },
    { "type": "Rubbish bin",      "collectionDate": "16/04/2026" },
    { "type": "Recycling bin",    "collectionDate": "16/04/2026" }
  ]
}
```