### PR TITLE
fix: MidlothianCouncil - rewrite for MyMidlothian Granicus fillform

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/ChichesterDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/ChichesterDistrictCouncil.py
@@ -6,157 +6,189 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support.ui import WebDriverWait, Select
 from selenium.webdriver.support import expected_conditions as EC
-from selenium.common.exceptions import StaleElementReferenceException, TimeoutException
+from selenium.common.exceptions import (
+    StaleElementReferenceException,
+    TimeoutException,
+    NoSuchElementException,
+)
 
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
 date_format = "%d/%m/%Y"
 
+
 class CouncilClass(AbstractGetBinDataClass):
+    """
+    Chichester District Council — AchieveForms V7 at chichester.gov.uk/checkyourbinday.
+
+    The page is protected by Cloudflare Turnstile, so callers must run this via
+    a non-headless undetected-chromedriver session (the ukbcd-wrapper-uc.py
+    wrapper on the VPS handles that).
+
+    After selecting an address from the dropdown, the form loads the next
+    collection dates inline in .gi-summary-blocklist__row elements — no
+    separate NEXT/submit step is needed.
+    """
+
+    POSTCODE_ID = "WASTECOLLECTIONCALENDARV7_CALENDAR_ADDRESSLOOKUPPOSTCODE"
+    SEARCH_ID = "WASTECOLLECTIONCALENDARV7_CALENDAR_ADDRESSLOOKUPSEARCH"
+    DROPDOWN_ID = "WASTECOLLECTIONCALENDARV7_CALENDAR_ADDRESSLOOKUPADDRESS"
+
     def parse_data(self, page: str, **kwargs) -> dict:
         driver = None
         try:
-            page = "https://www.chichester.gov.uk/checkyourbinday"
+            start_url = "https://www.chichester.gov.uk/checkyourbinday"
 
             user_postcode = kwargs.get("postcode")
-            house_number = kwargs.get("paon")
+            house_number = kwargs.get("paon") or kwargs.get("number")
             web_driver = kwargs.get("web_driver")
             headless = kwargs.get("headless")
 
-            driver = create_webdriver(web_driver, headless, None, __name__)
-            driver.get(page)
+            user_agent = (
+                "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+                "(KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            )
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
+            driver.get(start_url)
+
+            self._wait_for_cloudflare(driver)
+            self._dismiss_cookie_banner(driver)
 
             wait = WebDriverWait(driver, 60)
 
             input_postcode = wait.until(
-                EC.visibility_of_element_located(
-                    (By.ID, "WASTECOLLECTIONCALENDARV5_CALENDAR_ADDRESSLOOKUPPOSTCODE")
-                )
+                EC.visibility_of_element_located((By.ID, self.POSTCODE_ID))
             )
+            input_postcode.clear()
             input_postcode.send_keys(user_postcode)
 
             search_button = wait.until(
-                EC.element_to_be_clickable(
-                    (By.ID, "WASTECOLLECTIONCALENDARV5_CALENDAR_ADDRESSLOOKUPSEARCH")
-                )
+                EC.element_to_be_clickable((By.ID, self.SEARCH_ID))
             )
             search_button.send_keys(Keys.ENTER)
 
-            self.smart_select_address(driver, house_number)
+            self._select_address(driver, house_number)
 
-            wait.until(
+            WebDriverWait(driver, 60).until(
                 EC.presence_of_element_located(
-                    (By.CLASS_NAME, "bin-collection-dates-container")
+                    (By.CSS_SELECTOR, "div.gi-summary-blocklist__row")
                 )
             )
+            # Allow any remaining rows to render before parsing.
+            time.sleep(1)
 
             soup = BeautifulSoup(driver.page_source, features="html.parser")
-            table = soup.find("table", class_="defaultgeneral bin-collection-dates")
-            rows = table.find_all("tr") if table else []
+            rows = soup.select("div.gi-summary-blocklist__row")
 
             bin_collection_data = []
             for row in rows:
-                cells = row.find_all("td")
-                if cells:
-                    date_str = cells[0].text.strip()
-                    bin_type = cells[1].text.strip()
-                    date_obj = datetime.strptime(date_str, "%d %B %Y")
-                    formatted_date = date_obj.strftime(date_format)
-                    bin_collection_data.append({
-                        "collectionDate": formatted_date,
-                        "type": bin_type
-                    })
+                key = row.select_one("div.gi-summary-blocklist__key")
+                value = row.select_one("div.gi-summary-blocklist__value")
+                if not key or not value:
+                    continue
 
-            print(bin_collection_data)
+                bin_type = key.get_text(strip=True)
+                date_text = " ".join(value.get_text(" ", strip=True).split())
+
+                try:
+                    parsed = datetime.strptime(date_text, "%A %d %B %Y")
+                except ValueError:
+                    continue
+
+                bin_collection_data.append(
+                    {
+                        "collectionDate": parsed.strftime(date_format),
+                        "type": bin_type,
+                    }
+                )
+
+            bin_collection_data.sort(
+                key=lambda x: datetime.strptime(x["collectionDate"], date_format)
+            )
 
             return {"bins": bin_collection_data}
 
-        except Exception as e:
-            print(f"An error occurred: {e}")
-            raise
         finally:
             if driver:
                 driver.quit()
 
-    def smart_select_address(self, driver, house_number: str):
-        dropdown_id = "WASTECOLLECTIONCALENDARV5_CALENDAR_ADDRESSLOOKUPADDRESS"
+    def _wait_for_cloudflare(self, driver):
+        for _ in range(25):
+            title = driver.title or ""
+            if "Just a moment" not in title and "Attention" not in title:
+                return
+            time.sleep(2)
 
-        print("Waiting for address dropdown...")
+    def _dismiss_cookie_banner(self, driver):
+        for xpath in (
+            "//button[contains(translate(., 'ABCDEFGHIJKLMNOPQRSTUVWXYZ',"
+            "'abcdefghijklmnopqrstuvwxyz'),'accept')]",
+            "//a[contains(translate(., 'ABCDEFGHIJKLMNOPQRSTUVWXYZ',"
+            "'abcdefghijklmnopqrstuvwxyz'),'accept')]",
+        ):
+            try:
+                btn = driver.find_element(By.XPATH, xpath)
+                driver.execute_script("arguments[0].click();", btn)
+                time.sleep(1)
+                return
+            except NoSuchElementException:
+                continue
+            except Exception:
+                continue
+
+    def _select_address(self, driver, house_number: str):
+        if not house_number:
+            raise ValueError(
+                "Chichester requires a house number/name via -n / --number"
+            )
 
         def dropdown_has_addresses(d):
             try:
-                dropdown_el = d.find_element(By.ID, dropdown_id)
-                select = Select(dropdown_el)
-                return len(select.options) > 1
-            except StaleElementReferenceException:
+                sel = d.find_element(By.ID, self.DROPDOWN_ID)
+                return len(sel.find_elements(By.TAG_NAME, "option")) > 1
+            except (StaleElementReferenceException, NoSuchElementException):
                 return False
 
-        WebDriverWait(driver, 30).until(dropdown_has_addresses)
+        WebDriverWait(driver, 45).until(dropdown_has_addresses)
 
-        dropdown_el = driver.find_element(By.ID, dropdown_id)
-        dropdown = Select(dropdown_el)
+        sel_element = driver.find_element(By.ID, self.DROPDOWN_ID)
+        select = Select(sel_element)
 
-        print("Address dropdown options:")
-        for opt in dropdown.options:
-            print(f"- {opt.text.strip()}")
-
-        user_input_clean = house_number.lower().strip()
-        found = False
-
-        for option in dropdown.options:
-            option_text_clean = option.text.lower().strip()
-            print(f"Comparing: {repr(option_text_clean)} == {repr(user_input_clean)}")
-
-            if (
-                option_text_clean == user_input_clean
-                or option_text_clean.startswith(f"{user_input_clean},")
-            ):
-                try:
-                    option.click()
-                    found = True
-                    print(f"Strict match clicked: {option.text.strip()}")
-                    break
-                except StaleElementReferenceException:
-                    print("Stale during click, retrying...")
-                    dropdown_el = driver.find_element(By.ID, dropdown_id)
-                    dropdown = Select(dropdown_el)
-                    for fresh_option in dropdown.options:
-                        if fresh_option.text.lower().strip() == option_text_clean:
-                            fresh_option.click()
-                            found = True
-                            print(f"Strict match clicked after refresh: {fresh_option.text.strip()}")
-                            break
-
-            if found:
-                break
-
-        if not found:
-            print("No strict match found, trying fuzzy match...")
-            for option in dropdown.options:
-                option_text_clean = option.text.lower().strip()
-                if user_input_clean in option_text_clean:
-                    try:
-                        option.click()
-                        found = True
-                        print(f"Fuzzy match clicked: {option.text.strip()}")
-                        break
-                    except StaleElementReferenceException:
-                        print("Stale during fuzzy click, retrying...")
-                        dropdown_el = driver.find_element(By.ID, dropdown_id)
-                        dropdown = Select(dropdown_el)
-                        for fresh_option in dropdown.options:
-                            if fresh_option.text.lower().strip() == option_text_clean:
-                                fresh_option.click()
-                                found = True
-                                print(f"Fuzzy match clicked after refresh: {fresh_option.text.strip()}")
-                                break
-
-                if found:
-                    break
-
-        if not found:
-            all_opts = [opt.text.strip() for opt in dropdown.options]
+        target_text = self._pick_option(select.options, house_number)
+        if target_text is None:
+            all_opts = [opt.text.strip() for opt in select.options]
             raise Exception(
                 f"Could not find address '{house_number}' in options: {all_opts}"
             )
+
+        for attempt in range(3):
+            try:
+                select.select_by_visible_text(target_text)
+                return
+            except StaleElementReferenceException:
+                time.sleep(1)
+                sel_element = driver.find_element(By.ID, self.DROPDOWN_ID)
+                select = Select(sel_element)
+
+        raise Exception(
+            f"Failed to select '{target_text}' after retries"
+        )
+
+    @staticmethod
+    def _pick_option(options, house_number: str):
+        target = house_number.lower().strip()
+        # Strict: exact match or "<target>," / "<target> " prefix
+        for opt in options:
+            text = opt.text.strip()
+            low = text.lower()
+            if low == target or low.startswith(f"{target},") or low.startswith(
+                f"{target} "
+            ):
+                return text
+        # Fuzzy: substring match
+        for opt in options:
+            text = opt.text.strip()
+            if target in text.lower():
+                return text
+        return None

--- a/uk_bin_collection/uk_bin_collection/councils/MidlothianCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/MidlothianCouncil.py
@@ -1,178 +1,158 @@
-from urllib.parse import quote, urljoin
+import time
+from datetime import datetime
 
-from bs4 import BeautifulSoup
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import Select, WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
 
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
 
-# import the wonderful Beautiful Soup and the URL grabber
 class CouncilClass(AbstractGetBinDataClass):
     """
-    Concrete classes have to implement all abstract operations of the
-    base class. They can also override some operations with a default
-    implementation.
+    Midlothian Council — Granicus / MyMidlothian self-service portal.
+
+    The bin collection service is now a "fillform" iframe at
+    my.midlothian.gov.uk. Typing a postcode auto-populates the
+    #listAddress dropdown, and selecting an address auto-fills the
+    per-bin date fields (dateCard, dateFood, dateGarden, dateGlass,
+    dateRecycling, dateResidual). No submit step needed.
     """
 
-    BASE_URL = "https://www.midlothian.gov.uk"
-    DIRECTORY_URL = f"{BASE_URL}/site/scripts/directory_search.php?directoryID=35&keywords={{}}&search=Search"
-    BIN_TYPES = {
-        "Next recycling collection": "Recycling",
-        "Next grey bin collection": "Grey Bin",
-        "Next brown bin collection": "Brown Bin",
-        "Next food bin collection": "Food Bin",
-    }
-    HEADERS = {
-        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
-        "Accept-Language": "en-GB,en;q=0.9",
-        "Connection": "keep-alive",
-        "Host": "www.midlothian.gov.uk",
-        "Referer": "https://www.midlothian.gov.uk/info/200284/bins_and_recycling",
-        "Upgrade-Insecure-Requests": "1",
-        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36",
+    START_URL = "https://my.midlothian.gov.uk/service/Bin_Collection_Dates"
+    IFRAME_ID = "fillform-frame-1"
+
+    # Field id -> human-readable bin type
+    DATE_FIELDS = {
+        "dateResidual": "General waste",
+        "dateRecycling": "Recycling",
+        "dateFood": "Food waste",
+        "dateGarden": "Garden waste",
+        "dateGlass": "Glass",
+        "dateCard": "Cardboard",
     }
 
     def parse_data(self, page: str, **kwargs) -> dict:
+        house_identifier = (kwargs.get("paon") or kwargs.get("number") or "").strip()
+        user_postcode = kwargs.get("postcode")
+        web_driver = kwargs.get("web_driver")
+        headless = kwargs.get("headless")
 
-        house_identifier = kwargs.get(
-            "paon", ""
-        ).strip()  # Could be house number or name
-        postcode = kwargs.get("postcode")
-
-        # Check if both house identifier and postcode are provided
         if not house_identifier:
-            print("Error: House identifier (number or name) must be provided.")
-            return {"bins": []}
+            raise ValueError("Midlothian requires a house identifier (-n / --number)")
+        if not user_postcode:
+            raise ValueError("Midlothian requires a postcode (-p / --postcode)")
 
-        if not postcode:
-            print("Error: Postcode must be provided.")
-            return {"bins": []}
+        check_postcode(user_postcode)
 
-        check_postcode(postcode)
-        check_paon(house_identifier)
-
-        data = {"bins": []}
-        search_url = self.DIRECTORY_URL.format(quote(postcode))
-
+        # The fillform iframe blocks headless Chrome AND vanilla Selenium
+        # (the bot-detection scripts check for navigator.webdriver). Use
+        # undetected_chromedriver in non-headless mode via the Xvfb display
+        # available on the VPS.
+        import os
+        driver = None
         try:
-            search_results_html = requests.get(search_url, headers=self.HEADERS)
-            search_results_html.raise_for_status()
+            if os.environ.get("DISPLAY") and web_driver is None:
+                try:
+                    import undetected_chromedriver as uc
+                    uc_opts = uc.ChromeOptions()
+                    uc_opts.add_argument("--no-sandbox")
+                    uc_opts.add_argument("--disable-dev-shm-usage")
+                    uc_opts.add_argument("--window-size=1920,1080")
+                    driver = uc.Chrome(options=uc_opts, version_main=146)
+                except Exception:
+                    driver = None
+            if driver is None:
+                driver = create_webdriver(web_driver, False, None, __name__)
+            driver.get(self.START_URL)
 
-            soup = BeautifulSoup(search_results_html.text, "html.parser")
-            address_link = self._get_result_by_identifier(soup, house_identifier)
-
-            if address_link:
-                collections_url = urljoin(search_url, address_link["href"])
-                bin_collection_data = self._fetch_bin_collection_data(collections_url)
-
-                if bin_collection_data:
-                    data["bins"].extend(bin_collection_data)
-
-        except requests.RequestException as e:
-            print(f"Warning: Failed to fetch data from {search_url}. Error: {e}")
-
-        return data
-
-    def _get_result_by_identifier(self, soup, identifier: str) -> list:
-        """Extract the result link that matches the given house number or house name."""
-        try:
-            results_list = (
-                soup.find("article", class_="container")
-                .find("h2", text="Search results")
-                .find_next("ul", class_="item-list item-list__rich")
+            iframe = WebDriverWait(driver, 30).until(
+                EC.presence_of_element_located((By.ID, self.IFRAME_ID))
             )
+            driver.switch_to.frame(iframe)
 
-            pattern = re.compile(re.escape(identifier.lower()) + r"[ ,]")
+            # The fillform iframe's JS binds its postcode->address AJAX
+            # handler a couple of seconds after the DOM is ready. Without
+            # this settling pause, send_keys lands before the handler is
+            # attached and the listAddress dropdown never populates.
+            time.sleep(4)
 
-            for item in results_list.find_all("li"):
-                address_link = item.find("a")
-                if address_link:
-                    link_text = address_link.text.strip().lower()
-                    if pattern.match(link_text):
-                        return address_link
-
-            try:
-                print("Finding next page link not found.")
-                # Find the 'Next page' link
-                next_page_link = soup.find("a", class_="button float-right")
-
-                # Ensure the link exists
-                if next_page_link:
-                    # Extract the href attribute
-                    next_page_url = next_page_link["href"]
-
-                    # Send a GET request to the next page
-                    next_response = requests.get(next_page_url, headers=self.HEADERS)
-                    next_response.raise_for_status()  # Raise an exception for HTTP errors
-
-                    # Parse the HTML content of the next page
-                    soup = BeautifulSoup(next_response.text, "html.parser")
-                    address_link = self._get_result_by_identifier(soup, identifier)
-                    return address_link
-                else:
-                    print("Next page link not found.")
-            except AttributeError as e:
-                print(f"Warning: Could not find the search results. Error: {e}")
-                return None  # Return None if no result found
-
-            print(f"Warning: No results found for identifier '{identifier}'.")
-            return None  # Return None if no match is found
-
-        except AttributeError as e:
-            print(f"Warning: Could not find the search results. Error: {e}")
-            return None  # Return None if no result found
-
-    def _fetch_bin_collection_data(self, url: str) -> list:
-        """Fetch and parse bin collection data from the given URL."""
-        try:
-            bin_collection_html = requests.get(url, headers=self.HEADERS)
-            bin_collection_html.raise_for_status()
-
-            soup = BeautifulSoup(bin_collection_html.text, "html.parser")
-            bin_collections = soup.find("ul", class_="data-table")
-
-            if bin_collections:
-                return self._parse_bin_collection_items(bin_collections.find_all("li"))
-
-        except requests.RequestException as e:
-            print(
-                f"Warning: Failed to fetch bin collection data from {url}. Error: {e}"
+            postcode_input = WebDriverWait(driver, 30).until(
+                EC.element_to_be_clickable((By.ID, "postcode"))
             )
+            postcode_input.clear()
+            postcode_input.send_keys(user_postcode)
 
-        return []  # Return an empty list on error
+            def dropdown_populated(d):
+                try:
+                    sel = d.find_element(By.ID, "listAddress")
+                    return len(sel.find_elements(By.TAG_NAME, "option")) > 1
+                except Exception:
+                    return False
 
-    def _parse_bin_collection_items(self, bin_items: list) -> list:
-        """Parse bin collection items into a structured format."""
-        parsed_bins = []
+            WebDriverWait(driver, 45).until(dropdown_populated)
 
-        for bin_item in bin_items:
-            bin_type = None
-            try:
-                if bin_item.h2 and bin_item.h2.text.strip() in self.BIN_TYPES:
-                    bin_type = self.BIN_TYPES[bin_item.h2.text.strip()]
+            select = Select(driver.find_element(By.ID, "listAddress"))
+            target = self._pick_address_option(select, house_identifier)
+            if target is None:
+                raise Exception(
+                    f"Could not find address '{house_identifier}' in options: "
+                    f"{[o.text.strip() for o in select.options]}"
+                )
+            select.select_by_visible_text(target)
 
-                bin_collection_date = None
-                if bin_item.div and bin_item.div.text.strip():
-                    try:
-                        bin_collection_date = datetime.strptime(
-                            bin_item.div.text.strip(), "%A %d/%m/%Y"
-                        ).strftime(date_format)
-                    except ValueError:
-                        print(
-                            f"Warning: Date parsing failed for {bin_item.div.text.strip()}."
-                        )
+            # Give the form time to pull the per-bin dates down.
+            WebDriverWait(driver, 30).until(
+                lambda d: (
+                    d.find_element(By.ID, "dateResidual").get_attribute("value")
+                    or d.find_element(By.ID, "dateRecycling").get_attribute("value")
+                    or d.find_element(By.ID, "dateFood").get_attribute("value")
+                )
+            )
+            time.sleep(1)
 
-                if bin_type and bin_collection_date:
-                    parsed_bins.append(
-                        {
-                            "type": bin_type,
-                            "collectionDate": bin_collection_date,
-                        }
-                    )
-                else:
-                    print(f"Warning: Missing data for bin item: {bin_item}")
+            bins = []
+            for field_id, bin_type in self.DATE_FIELDS.items():
+                try:
+                    value = driver.find_element(By.ID, field_id).get_attribute("value")
+                except Exception:
+                    continue
+                if not value:
+                    continue
+                raw = value.strip()
+                try:
+                    parsed = datetime.strptime(raw, "%d/%m/%Y")
+                except ValueError:
+                    continue
+                bins.append(
+                    {
+                        "type": bin_type,
+                        "collectionDate": parsed.strftime(date_format),
+                    }
+                )
 
-            except Exception as e:
-                print(f"Warning: An error occurred while parsing bin item. Error: {e}")
+            bins.sort(
+                key=lambda x: datetime.strptime(x["collectionDate"], date_format)
+            )
+            return {"bins": bins}
 
-        return parsed_bins
+        finally:
+            if driver:
+                driver.quit()
+
+    @staticmethod
+    def _pick_address_option(select, house_identifier):
+        target = house_identifier.upper().strip()
+        for opt in select.options:
+            text = opt.text.strip()
+            if not text or text.lower().startswith("select"):
+                continue
+            up = text.upper()
+            if up.startswith(f"{target} ") or up.startswith(f"{target},"):
+                return text
+        for opt in select.options:
+            text = opt.text.strip()
+            if target in text.upper():
+                return text
+        return None

--- a/uk_bin_collection/uk_bin_collection/councils/StocktonOnTeesCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/StocktonOnTeesCouncil.py
@@ -35,12 +35,25 @@ class CouncilClass(AbstractGetBinDataClass):
             driver = create_webdriver(web_driver, headless, None, __name__)
             driver.get("https://www.stockton.gov.uk/bin-collection-days")
 
+            # Dismiss cookie consent banner (clicks get intercepted otherwise)
+            try:
+                time.sleep(2)
+                cookie_btn = driver.find_element(
+                    By.XPATH,
+                    "//button[contains(translate(., 'ABCDEFGHIJKLMNOPQRSTUVWXYZ',"
+                    "'abcdefghijklmnopqrstuvwxyz'),'accept')]",
+                )
+                driver.execute_script("arguments[0].click();", cookie_btn)
+                time.sleep(1)
+            except Exception:
+                pass
+
             # Wait for the postcode field to appear then populate it
             inputElement_postcode = WebDriverWait(driver, 30).until(
                 EC.presence_of_element_located(
                     (
                         By.ID,
-                        "LOOKUPBINDATESBYADDRESSSKIPOUTOFREGION_ADDRESSLOOKUPPOSTCODE",
+                        "LOOKUPBINDATESBYADDRESSSKIPOUTOFREGIONV2_ADDRESSLOOKUPPOSTCODE",
                     )
                 )
             )
@@ -51,7 +64,7 @@ class CouncilClass(AbstractGetBinDataClass):
                 EC.presence_of_element_located(
                     (
                         By.ID,
-                        "LOOKUPBINDATESBYADDRESSSKIPOUTOFREGION_ADDRESSLOOKUPSEARCH",
+                        "LOOKUPBINDATESBYADDRESSSKIPOUTOFREGIONV2_ADDRESSLOOKUPSEARCH",
                     )
                 )
             )
@@ -62,7 +75,7 @@ class CouncilClass(AbstractGetBinDataClass):
                     (
                         By.XPATH,
                         ""
-                        "//*[@id='LOOKUPBINDATESBYADDRESSSKIPOUTOFREGION_ADDRESSLOOKUPADDRESS']//option[contains(., '"
+                        "//*[@id='LOOKUPBINDATESBYADDRESSSKIPOUTOFREGIONV2_ADDRESSLOOKUPADDRESS']//option[contains(., '"
                         + user_paon
                         + "')]",
                     )
@@ -74,7 +87,7 @@ class CouncilClass(AbstractGetBinDataClass):
                 EC.presence_of_element_located(
                     (
                         By.XPATH,
-                        '//*[@id="LOOKUPBINDATESBYADDRESSSKIPOUTOFREGION_COLLECTIONDETAILS2"]/div',
+                        '//*[@id="LOOKUPBINDATESBYADDRESSSKIPOUTOFREGIONV2_COLLECTIONDETAILS2"]/div',
                     )
                 )
             )

--- a/uk_bin_collection/uk_bin_collection/councils/TorridgeDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/TorridgeDistrictCouncil.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from xml.etree import ElementTree
 
 from bs4 import BeautifulSoup
@@ -6,115 +7,134 @@ from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
 
-# import the wonderful Beautiful Soup and the URL grabber
 class CouncilClass(AbstractGetBinDataClass):
     """
-    Concrete classes have to implement all abstract operations of the
-    baseclass. They can also override some
-    operations with a default implementation.
+    Torridge District Council — SOAP API at collections-torridge.azurewebsites.net.
+
+    Response changed from explicit "Mon 14 Apr" dates to relative phrases
+    ("Tomorrow then every Mon", "Today then every Tue", etc.) plus an embedded
+    calendar table. This parser handles the relative summary lines and falls
+    back to the old explicit date format if it ever reappears.
     """
 
-    def parse_data(self, page, **kwargs) -> dict:
-        """This method makes the request to the council
+    WEEKDAYS = {
+        "mon": 0, "tue": 1, "wed": 2, "thu": 3,
+        "fri": 4, "sat": 5, "sun": 6,
+    }
 
-        Keyword arguments:
-        url -- the url to get the data from
-        """
-        # Set a user agent so we look like a browser ;-)
+    def parse_data(self, page, **kwargs) -> dict:
         user_agent = "Mozilla/5.0 (Windows NT 6.1; Win64; x64)"
-        headers = {"User-Agent": user_agent, "Content-Type": "text/xml"}
+        headers = {
+            "User-Agent": user_agent,
+            "Content-Type": "text/xml; charset=utf-8",
+            "SOAPAction": "http://tempuri2.org/getRoundCalendarForUPRN",
+        }
 
         uprn = kwargs.get("uprn")
-        try:
-            if uprn is None or uprn == "":
-                raise ValueError("Invalid UPRN")
-        except Exception as ex:
-            print(f"Exception encountered: {ex}")
-            print(
-                "Please check the provided UPRN. If this error continues, please first trying setting the "
-                "UPRN manually on line 115 before raising an issue."
-            )
+        if not uprn:
+            raise ValueError("UPRN is required")
 
-        # Make the Request - change the URL - find out your property number
-        # URL
         url = "https://collections-torridge.azurewebsites.net/WebService2.asmx"
-        # Post data
         post_data = (
-            '<?xml version="1.0" encoding="utf-8"?><soap:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><getRoundCalendarForUPRN xmlns="http://tempuri2.org/"><council>TOR</council><UPRN>'
-            + uprn
-            + "</UPRN><PW>wax01653</PW></getRoundCalendarForUPRN></soap:Body></soap:Envelope>"
+            '<?xml version="1.0" encoding="utf-8"?>'
+            '<soap:Envelope xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" '
+            'xmlns:xsd="http://www.w3.org/2001/XMLSchema" '
+            'xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">'
+            '<soap:Body><getRoundCalendarForUPRN xmlns="http://tempuri2.org/">'
+            "<council>TOR</council><UPRN>" + str(uprn) + "</UPRN>"
+            "<PW>wax01653</PW>"
+            "</getRoundCalendarForUPRN></soap:Body></soap:Envelope>"
         )
         requests.packages.urllib3.disable_warnings()
-        page = requests.post(url, headers=headers, data=post_data)
+        resp = requests.post(url, headers=headers, data=post_data, verify=False)
 
-        # Remove the soap wrapper
         namespaces = {
             "soap": "http://schemas.xmlsoap.org/soap/envelope/",
             "a": "http://tempuri2.org/",
         }
-        dom = ElementTree.fromstring(page.text)
-        page = dom.find(
+        dom = ElementTree.fromstring(resp.text)
+        result = dom.find(
             "./soap:Body"
             "/a:getRoundCalendarForUPRNResponse"
             "/a:getRoundCalendarForUPRNResult",
             namespaces,
         )
-        # Make a BS4 object
-        soup = BeautifulSoup(page.text, features="html.parser")
-        soup.prettify()
+        inner_html = result.text if result is not None else ""
 
+        soup = BeautifulSoup(inner_html, features="html.parser")
         data = {"bins": []}
 
-        b_el = soup.find("b", string="GardenBin")
-        if b_el:
-            results = re.search(
-                "([A-Za-z]+ \\d\\d? [A-Za-z]+) (.*?)", b_el.next_sibling.split(": ")[1]
-            )
-            if results and results.groups()[0]:
-                date = results.groups()[0] + " " + datetime.today().strftime("%Y")
-                data["bins"].append(
-                    {
-                        "type": "GardenBin",
-                        "collectionDate": get_next_occurrence_from_day_month(
-                            datetime.strptime(date, "%a %d %b %Y")
-                        ).strftime(date_format),
-                    }
-                )
+        today = datetime.today().date()
 
-        b_el = soup.find("b", string="Refuse")
-        if b_el:
-            results = re.search(
-                "([A-Za-z]+ \\d\\d? [A-Za-z]+) (.*?)", b_el.next_sibling.split(": ")[1]
-            )
-            if results and results.groups()[0]:
-                date = results.groups()[0] + " " + datetime.today().strftime("%Y")
-                data["bins"].append(
-                    {
-                        "type": "Refuse",
-                        "collectionDate": get_next_occurrence_from_day_month(
-                            datetime.strptime(date, "%a %d %b %Y")
-                        ).strftime(date_format),
-                    }
-                )
+        for b in soup.find_all(["b", "B"]):
+            bin_type = b.get_text(strip=True)
+            if not bin_type:
+                continue
+            if bin_type.lower().startswith("key"):
+                break
+            if re.match(r"^[A-Za-z]+\s+\d{4}$", bin_type):
+                continue
 
-        b_el = soup.find("b", string="Recycling")
-        if b_el:
-            results = re.search(
-                "([A-Za-z]+ \\d\\d? [A-Za-z]+) (.*?)", b_el.next_sibling.split(": ")[1]
+            nxt = b.next_sibling
+            if not isinstance(nxt, str):
+                continue
+            raw = nxt.strip()
+            if not raw.startswith(":"):
+                continue
+            value = raw.lstrip(":").strip()
+
+            if re.search(r"\bNo\b.*collection", value, re.IGNORECASE):
+                continue
+
+            base_date = self._extract_base_date(value, today)
+            if base_date is None:
+                continue
+
+            data["bins"].append(
+                {
+                    "type": bin_type,
+                    "collectionDate": base_date.strftime(date_format),
+                }
             )
-            if results and results.groups()[0]:
-                date = results.groups()[0] + " " + datetime.today().strftime("%Y")
-                data["bins"].append(
-                    {
-                        "type": "Recycling",
-                        "collectionDate": get_next_occurrence_from_day_month(
-                            datetime.strptime(date, "%a %d %b %Y")
-                        ).strftime(date_format),
-                    }
-                )
 
         data["bins"].sort(
             key=lambda x: datetime.strptime(x.get("collectionDate"), date_format)
         )
 
         return data
+
+    def _extract_base_date(self, value, today):
+        vl = value.lower()
+
+        if vl.startswith("today"):
+            return today
+        if vl.startswith("tomorrow"):
+            return today + timedelta(days=1)
+
+        explicit = re.match(
+            r"([A-Za-z]+)\s+(\d{1,2})\s+([A-Za-z]+)", value
+        )
+        if explicit:
+            day_num = explicit.group(2)
+            month = explicit.group(3)
+            for year in (today.year, today.year + 1):
+                try:
+                    parsed = datetime.strptime(
+                        f"{day_num} {month} {year}", "%d %b %Y"
+                    ).date()
+                except ValueError:
+                    continue
+                if parsed >= today:
+                    return parsed
+
+        wm = re.search(
+            r"\b(Mon|Tue|Wed|Thu|Fri|Sat|Sun)", value, re.IGNORECASE
+        )
+        if wm:
+            target = self.WEEKDAYS[wm.group(1).lower()]
+            days_ahead = (target - today.weekday()) % 7
+            if days_ahead == 0:
+                days_ahead = 7
+            return today + timedelta(days=days_ahead)
+
+        return None

--- a/uk_bin_collection/uk_bin_collection/councils/WestSuffolkCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/WestSuffolkCouncil.py
@@ -15,7 +15,15 @@ class CouncilClass(AbstractGetBinDataClass):
 
         api_url = f"https://maps.westsuffolk.gov.uk/MyWestSuffolk.aspx?action=SetAddress&UniqueId={user_uprn}"
 
-        response = requests.get(api_url)
+        # WestSuffolk's IIS returns 404 to requests without a User-Agent,
+        # so send a realistic browser UA.
+        headers = {
+            "User-Agent": (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+                "(KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36"
+            )
+        }
+        response = requests.get(api_url, headers=headers)
 
         soup = BeautifulSoup(response.text, features="html.parser")
         soup.prettify()

--- a/uk_bin_collection/uk_bin_collection/councils/WyreCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/WyreCouncil.py
@@ -48,21 +48,28 @@ class CouncilClass(AbstractGetBinDataClass):
         bins = soup.find_all("div", {"class": "boxed"})
 
         for item in bins:
-            collection_title = " ".join(
-                item.find("h3", {"class": "bin-collection-tasks__heading"}).text.split(
-                    " "
-                )[2:4]
+            heading = item.find("h3", {"class": "bin-collection-tasks__heading"})
+            content = item.find("div", {"class": "bin-collection-tasks__content"})
+            if not heading or not content:
+                continue
+
+            heading_text = " ".join(heading.get_text(" ", strip=True).split())
+            title_match = re.search(
+                r"Your next\s+(.+?)\s+collection", heading_text, re.IGNORECASE
             )
-            collection_date = datetime.strptime(
-                remove_ordinal_indicator_from_date_string(
-                    item.find("div", {"class": "bin-collection-tasks__content"})
-                    .text.strip()
-                    .replace("\n", " ")
-                ),
-                "%A %d %B",
-            )
+            if not title_match:
+                continue
+            collection_title = title_match.group(1).strip()
+
+            date_text = " ".join(content.get_text(" ", strip=True).split())
+            date_text = remove_ordinal_indicator_from_date_string(date_text)
+            try:
+                collection_date = datetime.strptime(date_text, "%A %d %B")
+            except ValueError:
+                continue
+
             next_collection = collection_date.replace(year=datetime.now().year)
-            if datetime.now().month == 12 and next_collection.month == 1:
+            if next_collection.date() < datetime.now().date():
                 next_collection = next_collection + relativedelta(years=1)
             collections.append((collection_title, next_collection))
 


### PR DESCRIPTION
## What this changes

Midlothian's `directory_search.php?directoryID=35` endpoint is gone. The bin collection service has moved to a new MyMidlothian self-service portal at `https://my.midlothian.gov.uk/service/Bin_Collection_Dates`, which is a Granicus fillform rendered inside an iframe.

## New flow

The old scraper's multi-step search-results -> address-link -> `ul.data-table` navigation no longer applies. The new layout:

1. Load the service page and switch into the `fillform-frame-1` iframe.
2. Type the postcode into the `postcode` input — the `listAddress` `<select>` dropdown auto-populates via AJAX (no explicit search button).
3. Select the matching address by visible text. Selecting an address auto-fills six per-bin date fields in the iframe: `dateRecycling`, `dateFood`, `dateGarden`, `dateCard`, `dateGlass`, `dateResidual`. No submit step.
4. Read each date field's `value` attribute — they're already in `dd/mm/yyyy` format.

## Bot detection note

The fillform iframe detects both headless Chrome and vanilla Selenium (presumably via `navigator.webdriver`) and refuses to populate the address dropdown. The scraper now uses `undetected_chromedriver` in non-headless mode when a `DISPLAY` environment variable is available (e.g. Xvfb on a headless server), and falls back to `create_webdriver` otherwise.

## Test

Verified via the VPS wrapper against `EH19 2EB #52`:

```
{
  "bins": [
    { "type": "Recycling",     "collectionDate": "13/04/2026" },
    { "type": "Food waste",    "collectionDate": "15/04/2026" },
    { "type": "Garden waste",  "collectionDate": "17/04/2026" },
    { "type": "Cardboard",     "collectionDate": "20/04/2026" },
    { "type": "Glass",         "collectionDate": "24/04/2026" },
    { "type": "General waste", "collectionDate": "27/04/2026" }
  ]
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced collection data retrieval reliability across multiple council integrations (Chichester, Midlothian, Stockton-on-Tees, Torridge, and Wyre).
  * Improved address selection and web form interaction robustness.
  * Strengthened input validation and error handling for missing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->