### PR TITLE
Add User-Agent to data parser for WestSuffolkCouncil

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/WestSuffolkCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/WestSuffolkCouncil.py
@@ -15,7 +15,14 @@ class CouncilClass(AbstractGetBinDataClass):
 
         api_url = f"https://maps.westsuffolk.gov.uk/MyWestSuffolk.aspx?action=SetAddress&UniqueId={user_uprn}"
 
-        response = requests.get(api_url)
+        headers = requests.utils.default_headers()
+        headers.update(
+            {
+                'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
+            }
+        )
+
+        response = requests.get(api_url, headers=headers)
 
         soup = BeautifulSoup(response.text, features="html.parser")
         soup.prettify()


### PR DESCRIPTION
With the default Python user agent the West Suffolk website has begun returning a 404,
```html
<body>
<div id="header"><h1>Server Error</h1></div>
<div id="content">
<div class="content-container"><fieldset>
<h2>404 - File or directory not found.</h2>
<h3>The resource you are looking for might have been removed, had its name changed, or is temporarily unavailable.</h3>
</fieldset></div>
</div>
</body>
```
Resulting in no Bin data
```json
{
    "bins": []
}
```

By adding a Generic windows user agent we are able to fetch the correct page data and correctly parse the bin information.

```json
{
    "bins": [
        {
            "type": "Black bin",
            "collectionDate": "18/04/2026"
        },
        {
            "type": "Blue bin",
            "collectionDate": "13/04/2026"
        }
    ]
}
```

Fixes #1959 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bin collection data retrieval for West Suffolk Council by enhancing request headers. This update ensures more reliable access to your collection schedules, reducing potential issues when fetching data from the council system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->