### PR TITLE
fix: TewkesburyBoroughCouncil - handle new API response format

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/TewkesburyBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/TewkesburyBoroughCouncil.py
@@ -11,18 +11,18 @@ class CouncilClass(AbstractGetBinDataClass):
         check_uprn(user_uprn)
 
         url = f"https://api-2.tewkesbury.gov.uk/incab/rounds/{user_uprn}/next-collection"
-        response = requests.get(url)
+        response = requests.get(url, timeout=30)
         response.raise_for_status()
 
         json_data = response.json()
 
         data = {"bins": []}
 
-        if json_data.get("status") == "OK" and "body" in json_data:
+        # Legacy format: {"status":"OK","body":[{"collectionType":"...","NextCollection":"YYYY-MM-DD"}]}
+        if isinstance(json_data, dict) and json_data.get("status") == "OK" and "body" in json_data:
             for entry in json_data["body"]:
                 bin_type = entry.get("collectionType")
                 date_str = entry.get("NextCollection")
-
                 if bin_type and date_str:
                     try:
                         collection_date = datetime.strptime(date_str, "%Y-%m-%d")
@@ -32,9 +32,34 @@ class CouncilClass(AbstractGetBinDataClass):
                         })
                     except ValueError:
                         continue
+        # Current format: {"food":{"nextCollectionDate":"...Z"},"garden":{...},"recycling":{...},"refuse":{...}}
+        elif isinstance(json_data, dict):
+            type_map = {
+                "refuse": "Refuse",
+                "recycling": "Recycling",
+                "garden": "Garden",
+                "food": "Food",
+            }
+            for key, display_name in type_map.items():
+                entry = json_data.get(key)
+                if not isinstance(entry, dict):
+                    continue
+                date_str = entry.get("nextCollectionDate")
+                if not date_str:
+                    continue
+                try:
+                    # "2026-04-23T01:00:00.000Z"
+                    collection_date = datetime.strptime(date_str[:10], "%Y-%m-%d")
+                    data["bins"].append({
+                        "type": display_name,
+                        "collectionDate": collection_date.strftime(date_format)
+                    })
+                except ValueError:
+                    continue
 
-        # Sort by date
-        data["bins"].sort(key=lambda x: x["collectionDate"])
+        data["bins"].sort(
+            key=lambda x: datetime.strptime(x["collectionDate"], date_format)
+        )
 
         print(json.dumps(data, indent=2))
         return data


### PR DESCRIPTION
## Problem

`api-2.tewkesbury.gov.uk/incab/rounds/{uprn}/next-collection` now returns a dict keyed by bin type (`food`, `garden`, `recycling`, `refuse`) with `nextCollectionDate` ISO strings, not the legacy `{\"status\":\"OK\",\"body\":[{\"collectionType\":..., \"NextCollection\":...}]}` array. The scraper returned no bins against live data.

Live response today:

\`\`\`json
{
  \"food\":      {\"nextCollectionDate\": \"2026-04-23T01:00:00.000Z\", ...},
  \"garden\":    {\"nextCollectionDate\": \"2026-04-23T01:00:00.000Z\", ...},
  \"recycling\": {\"nextCollectionDate\": \"2026-04-30T01:00:00.000Z\", ...},
  \"refuse\":    {\"nextCollectionDate\": \"2026-04-23T01:00:00.000Z\", ...}
}
\`\`\`

## Fix

Parse both shapes. If the legacy envelope is present, use it. Otherwise map the four known keys to display names and parse the ISO date prefix. Also bound `requests.get` with a 30s timeout (was unbounded).

## Verification

Fixture UPRN `10067626314` (from `tests/input.json`) now returns 4 bins:

\`\`\`
Refuse    23/04/2026
Garden    23/04/2026
Food      23/04/2026
Recycling 30/04/2026
\`\`\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network reliability by adding timeout to data retrieval requests
  * Extended support for updated bin collection data format from council source
  * Fixed date sorting to ensure accurate collection schedule ordering

<!-- end of auto-generated comment: release notes by coderabbit.ai -->