### PR TITLE
fix: ChelmsfordCityCouncil - dismiss email-signup modal blocking form

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/ChelmsfordCityCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/ChelmsfordCityCouncil.py
@@ -58,8 +58,17 @@ class CouncilClass(AbstractGetBinDataClass):
                 )
                 accept_btn.click()
                 time.sleep(1)
-            except Exception as e:
-                # Cookie banner not present or already accepted
+            except Exception:
+                pass
+
+            # Dismiss email-signup popup ("Website popup 3") which overlays the form
+            try:
+                close_btn = driver.find_element(
+                    By.XPATH, "//dialog//button[contains(@aria-label, 'Close') or contains(text(), 'Close')]"
+                )
+                close_btn.click()
+                time.sleep(1)
+            except Exception:
                 pass
 
             # Find postcode input field (dynamic ID)
@@ -68,14 +77,29 @@ class CouncilClass(AbstractGetBinDataClass):
                     (By.XPATH, "//input[contains(@id, '_keyword')]")
                 )
             )
-            postcode_input.clear()
-            postcode_input.send_keys(postcode)
+            # Scroll into view + JS click fallback in case a dialog still overlays
+            driver.execute_script("arguments[0].scrollIntoView({block:'center'});", postcode_input)
+            try:
+                postcode_input.clear()
+                postcode_input.send_keys(postcode)
+            except Exception:
+                driver.execute_script(
+                    "arguments[0].value = arguments[1];"
+                    "arguments[0].dispatchEvent(new Event('input', {bubbles:true}));",
+                    postcode_input, postcode,
+                )
 
-            # Click search button
-            submit_btn = wait.until(
-                EC.element_to_be_clickable((By.CLASS_NAME, "__submitButton"))
-            )
-            submit_btn.click()
+            # Click search button (first try class, then text-based fallback)
+            try:
+                submit_btn = wait.until(
+                    EC.element_to_be_clickable((By.CLASS_NAME, "__submitButton"))
+                )
+                submit_btn.click()
+            except Exception:
+                submit_btn = driver.find_element(
+                    By.XPATH, "//button[normalize-space()='Search' and not(ancestor::*[@role='search'])]"
+                )
+                driver.execute_script("arguments[0].click();", submit_btn)
 
             # Wait for results table
             wait.until(EC.presence_of_element_located((By.TAG_NAME, "table")))


### PR DESCRIPTION
## Problem

`www.chelmsford.gov.uk/bins-and-recycling/check-your-collection-day/` now renders a \"Sign up to City News\" modal dialog (`Website popup 3`) on page load. It overlays the postcode search form, so after the cookie-accept step the scraper's `postcode_input.send_keys(postcode)` raises:

\`\`\`
selenium.common.exceptions.ElementNotInteractableException: Message: element not interactable
\`\`\`

The existing cookie-accept click doesn't close this modal.

## Fix

Close the modal via its Close button before interacting with the form. Scope the XPath to `//dialog//button` so we don't accidentally click the site's unrelated \"Close success\" banner button, and match on either `aria-label=\"Close\"` or visible text `Close`.

Also add JS fallbacks for the postcode input and Search button in case any other overlay intercepts a native click — minor hardening only.

## Verification

Fixture postcode `CM3 7AE` + full-address paon (per wiki_note, `1 Celeborn Street, South Woodham Ferrers, Chelmsford, CM3 7AE`) returns the expected Tuesday B calendar (multiple upcoming collections for food waste / brown bin / plastics / etc).