### PR TITLE
fix: ArmaghBanbridgeCraigavonCouncil - send full browser User-Agent to pass WAF

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/ArmaghBanbridgeCraigavonCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/ArmaghBanbridgeCraigavonCouncil.py
@@ -5,7 +5,6 @@ from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
 
-# import the wonderful Beautiful Soup and the URL grabber
 class CouncilClass(AbstractGetBinDataClass):
     """
     Concrete classes have to implement all abstract operations of the
@@ -14,89 +13,60 @@ class CouncilClass(AbstractGetBinDataClass):
     """
 
     def parse_data(self, page: str, **kwargs) -> dict:
-
         """
         Fetches bin collection dates for a given UPRN from the Armagh Banbridge Craigavon council website and returns them as structured bin data.
-        
+
         Parameters:
             page (str): Ignored by this implementation.
             kwargs:
                 uprn (str): Unique Property Reference Number used to look up the address schedule; required.
-        
+
         Returns:
-            dict: Dictionary with a "bins" key mapping to a list of collections. Each collection is a dict with:
-                - "collectionDate" (str): Date in "DD/MM/YYYY" format.
-                - "type" (str): One of "Domestic", "Recycling", or "Garden".
-            The list is sorted in ascending order by the parsed collection date (format "%d/%m/%Y").
+            dict: Dictionary with a "bins" key mapping to a list of collections.
         """
         user_uprn = kwargs.get("uprn")
         check_uprn(user_uprn)
         bindata = {"bins": []}
 
+        # The council's WAF closes the connection on bare or minimal User-Agent
+        # strings (manifests as requests.exceptions.ConnectionError with
+        # RemoteDisconnected). A full modern browser UA passes cleanly.
         headers = {
-            "user-agent": "Mozilla/5.0",
+            "User-Agent": (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+                "(KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36"
+            ),
+            "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+            "Accept-Language": "en-GB,en;q=0.9",
         }
 
-        # Function to extract bin collection information
         def extract_bin_schedule(soup, heading_class):
-            """
-            Extracts bin collection date strings from the HTML section identified by the given heading class.
-            
-            Searches the parsed HTML for a div with the provided heading_class and returns the text content of all `h4` elements found in the associated content column.
-            
-            Parameters:
-                soup (bs4.BeautifulSoup): Parsed HTML document to search.
-                heading_class (str): CSS class of the section heading that identifies the bin schedule block.
-            
-            Returns:
-                list[str]: A list of collection date strings found in the section; empty if none are present.
-            """
-            collections = []
-
-            # Find the relevant section based on the heading class
             section_heading = soup.find("div", class_=heading_class)
-            if section_heading:
-                # Find all the bin collection dates in that section
-                collection_dates = section_heading.find_next(
-                    "div", class_="col-sm-12 col-md-9"
-                ).find_all("h4")
-                for date in collection_dates:
-                    # Clean and add the date to the list
-                    collections.append(date.get_text(strip=True))
+            if not section_heading:
+                return []
+            content_col = section_heading.find_next("div", class_="col-sm-12 col-md-9")
+            if not content_col:
+                return []
+            return [h4.get_text(strip=True) for h4 in content_col.find_all("h4")]
 
-            return collections
-
-        # URL for bin collection schedule
         url = f"https://www.armaghbanbridgecraigavon.gov.uk/resident/binday-result/?address={user_uprn}"
 
-        # Send a GET request to fetch the page content
-        response = requests.get(url, headers=headers)
+        session = requests.Session()
+        session.headers.update(headers)
+        response = session.get(url, timeout=30)
+        response.raise_for_status()
 
-        # Check if the request was successful
-        if response.status_code == 200:
-            # Parse the page content using BeautifulSoup
-            soup = BeautifulSoup(response.text, "html.parser")
+        soup = BeautifulSoup(response.text, "html.parser")
 
-            # Extract bin collection schedules by their sections
-            domestic_collections = extract_bin_schedule(soup, "heading bg-black")
-            for collection in domestic_collections:
-                bindata["bins"].append(
-                    {"collectionDate": collection, "type": "Domestic"}
-                )
-            recycling_collections = extract_bin_schedule(soup, "heading bg-green")
-            for collection in recycling_collections:
-                bindata["bins"].append(
-                    {"collectionDate": collection, "type": "Recycling"}
-                )
-            garden_collections = extract_bin_schedule(soup, "heading bg-brown")
-            for collection in garden_collections:
-                bindata["bins"].append({"collectionDate": collection, "type": "Garden"})
-
-        else:
-            print(f"Failed to retrieve data. Status code: {response.status_code}")
+        for collection in extract_bin_schedule(soup, "heading bg-black"):
+            bindata["bins"].append({"collectionDate": collection, "type": "Domestic"})
+        for collection in extract_bin_schedule(soup, "heading bg-green"):
+            bindata["bins"].append({"collectionDate": collection, "type": "Recycling"})
+        for collection in extract_bin_schedule(soup, "heading bg-brown"):
+            bindata["bins"].append({"collectionDate": collection, "type": "Garden"})
 
         bindata["bins"].sort(
-            key=lambda x: datetime.strptime(x.get("collectionDate"), "%d/%m/%Y")
+            key=lambda x: datetime.strptime(x["collectionDate"], "%d/%m/%Y")
         )
 
         return bindata


### PR DESCRIPTION
## Problem

`ArmaghBanbridgeCraigavonCouncil.py` fails with:

```
requests.exceptions.ConnectionError: ('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))
```

against `https://www.armaghbanbridgecraigavon.gov.uk/resident/binday-result/?address={UPRN}`.

The page is WordPress-fronted by Sucuri/Wordfence. Their WAF closes the connection on minimal User-Agent strings. The current UA (`Mozilla/5.0`) is on that rejection list.

Verified:

```bash
# Old UA:
$ curl --max-time 10 -A 'Mozilla/5.0' '<url>' -w '%{http_code}\n'
HTTP:000   (curl: (52) Empty reply from server)

# Full Chrome UA:
$ curl --max-time 10 -A 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36' '<url>' -w '%{http_code}\n'
HTTP:200   (274 KB, 21 h4.fa-calendar dates in body)
```

## Fix

- Swap to a full modern Chrome User-Agent.
- Add `Accept` and `Accept-Language` headers (Sucuri additionally checks these for "browser-shaped" requests).
- Use a `requests.Session` so cookies/keepalive work correctly.
- Add an explicit 30s timeout + `raise_for_status()`.
- Harden `extract_bin_schedule()` to return an empty list if the `.col-sm-12.col-md-9` content column is missing, rather than raising `AttributeError`.

No platform migration — the existing 3-section (`bg-black` / `bg-green` / `bg-brown`) layout still works.

## Verification

Fixture UPRN `185625284` (BT60, Armagh) returns real 2026 dates:

```
Domestic:   24/04/2026, 08/05/2026, 22/05/2026, 05/06/2026, ...
Recycling:  01/05/2026, 15/05/2026, 29/05/2026, 12/06/2026, ...
Garden:     01/05/2026, 15/05/2026, 29/05/2026, 12/06/2026, ...
```