### PR TITLE
fix: NorthHertfordshireDistrictCouncil - migrate to Netcall Liberty Create portal

### DIFF
--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -1754,13 +1754,14 @@
         "LAD24CD": "E06000012"
     },
     "NorthHertfordshireDistrictCouncil": {
-        "skip_get_url": true,
-        "uprn": "100081258147",
-        "url": "https://apps.cloud9technologies.com/northherts/citizenmobile/mobileapi/100081258147/",
-        "wiki_name": "North Hertfordshire",
-        "wiki_note": "Replace the XXXXXXXX with your UPRN. You can find your UPRN using [FindMyAddress](https://www.findmyaddress.co.uk/search)",
-        "wiki_command_url_override": "https://apps.cloud9technologies.com/northherts/citizenmobile/mobileapi/XXXXXXXX/",
-        "LAD24CD": "E07000099"
+            "house_number": "Stewards Flat",
+            "postcode": "SG5 1PZ",
+            "skip_get_url": true,
+            "url": "https://waste.nc.north-herts.gov.uk/w/webpage/find-bin-collection-day-input-address",
+            "web_driver": "http://selenium:4444",
+            "wiki_name": "North Hertfordshire",
+            "wiki_note": "Pass a postcode (with space) and house_number/name. The scraper performs the Liberty Create typeahead lookup and matches house_number as a case-insensitive substring.",
+            "LAD24CD": "E07000099"
     },
     "NorthKestevenDistrictCouncil": {
         "url": "https://www.n-kesteven.org.uk/bins/display?uprn=100030869513",

--- a/uk_bin_collection/uk_bin_collection/councils/NorthHertfordshireDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/NorthHertfordshireDistrictCouncil.py
@@ -1,258 +1,198 @@
-# Uses Cloud9 mobile API to fetch waste collection data
-# API endpoint: https://apps.cloud9technologies.com/northherts/citizenmobile/mobileapi/wastecollections/{uprn}
-
-import json
+import re
+import time
 from datetime import datetime
 
-import requests
+from bs4 import BeautifulSoup
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.wait import WebDriverWait
 
-from uk_bin_collection.uk_bin_collection.common import (
-    check_paon,
-    check_postcode,
-    check_uprn,
-    date_format
-)
+from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
 
-# Mobile API constants
-MOBILE_API_BASE = "https://apps.cloud9technologies.com/northherts/citizenmobile/mobileapi"
-# This auth header is extracted from the hardcoded value present in the mobile app
-# https://play.google.com/store/apps/details?id=com.cloud9technologies.northhertsd
-MOBILE_API_AUTH = "Basic Y2xvdWQ5OmlkQmNWNGJvcjU="
-MOBILE_API_HEADERS = {
-    "Accept": "application/json",
-    "Authorization": MOBILE_API_AUTH,
-    "X-Api-Version": "2",
-    "X-App-Version": "3.0.56",
-    "X-Platform": "android",
-    "User-Agent": "okhttp/4.9.2",
-}
-MOBILE_API_NUM_CONTAINERS = 8
+_ORDINAL_RE = re.compile(r"(\d+)(?:st|nd|rd|th)", re.IGNORECASE)
 
 
-def lookup_uprn(postcode: str, paon: str) -> str:
-    """
-    Resolve the UPRN for an address given a postcode and house number/name using the Cloud9 addresses API.
-    
-    Parameters:
-        postcode (str): Postcode to search.
-        paon (str): Primary Addressable Object Name (house number or name).
-    
-    Returns:
-        str: The UPRN for the matched address.
-    
-    Raises:
-        ValueError: If postcode or paon is missing, the addresses API request fails or returns a non-200 status,
-                    the API response is invalid JSON, no addresses are found for the postcode,
-                    no addresses match the provided paon, or multiple matching addresses are found.
-    """
-
-    if not postcode:
-        raise ValueError("Postcode is required")
-
-    if not paon:
-        raise ValueError("House number/name (paon) is required")
-
-    postcode = postcode.strip()
-    paon = paon.strip().lower()
-
-    url = f"{MOBILE_API_BASE}/addresses"
-
-    try:
-        response = requests.get(url, headers=MOBILE_API_HEADERS, timeout=30, params={"postcode": postcode})
-    except requests.RequestException as exc:
-        raise ValueError("Addresses API request failed") from exc
-
-    if response.status_code != 200:
-        raise ValueError(
-            f"Addresses API returned status {response.status_code}. "
-            f"Please check your postcode is correct."
-        )
-
-    try:
-        api_response = response.json()
-    except requests.exceptions.JSONDecodeError as exc:
-        raise ValueError("Addresses API returned invalid JSON") from exc
-    addresses = api_response.get("addresses", [])
-
-    if not addresses:
-        raise ValueError(
-            f"No addresses found for postcode '{postcode}'. "
-            f"Please check your postcode is correct."
-        )
-
-    # Search for matching address by paon (house number/name)
-    # The paon could appear in addressLine1 or addressLine2
-    matching_addresses = []
-    for address in addresses:
-        address_line1 = address.get("addressLine1", "").lower()
-        address_line2 = address.get("addressLine2", "").lower()
-
-        # Check if paon matches the start of addressLine1 or addressLine2
-        first_parts = []
-        for line in (address_line1, address_line2):
-            if line.strip():
-                split_line = line.split()
-                if split_line:
-                    first_parts.append(split_line[0])
-        if paon in first_parts:
-            matching_addresses.append(address)
-
-    if not matching_addresses:
-        raise ValueError(
-            f"No address found matching house number/name '{paon}' for postcode '{postcode}'. "
-            f"Found {len(addresses)} addresses for this postcode, but none matched. "
-            f"You can find your UPRN at: https://www.findmyaddress.co.uk/search?postcode={postcode}"
-        )
-
-    if len(matching_addresses) > 1:
-        # Multiple matches - Raise a ValueError so the user can remediate
-        raise ValueError(
-            f"Multiple addresses found matching '{paon}' for postcode '{postcode}'. "
-            f"Please provide the UPRN directly for more accurate results. "
-            f"You can find your UPRN at: https://www.findmyaddress.co.uk/search?postcode={postcode}"
-        )
-
-    return matching_addresses[0]["uprn"]
-
-
-def fetch_mobile_api(uprn: str) -> dict:
-    """
-    Retrieve waste collection data for a property UPRN from the Cloud9 mobile API.
-    
-    Parameters:
-        uprn (str): Unique Property Reference Number to query.
-    
-    Returns:
-        dict: Parsed JSON response from the mobile API.
-    
-    Raises:
-        ValueError: If the HTTP request fails, the response status is not 200, or the response body is not valid JSON.
-    """
-    url = f"{MOBILE_API_BASE}/wastecollections/{uprn}"
-
-    # Perform the HTTP request and surface network-layer errors clearly
-    try:
-        response = requests.get(url, headers=MOBILE_API_HEADERS, timeout=30)
-    except requests.RequestException as exc:
-        raise ValueError("Mobile API request failed") from exc
-
-    if response.status_code != 200:
-        raise ValueError(
-            f"Mobile API returned status {response.status_code}. "
-            f"Please check your UPRN is correct."
-        )
-
-    # Decode JSON and surface parsing errors clearly
-    try:
-        return response.json()
-    except requests.exceptions.JSONDecodeError as exc:
-        raise ValueError("Mobile API returned invalid JSON") from exc
+def _strip_ordinal(date_text: str) -> str:
+    return _ORDINAL_RE.sub(r"\1", date_text).strip()
 
 
 class CouncilClass(AbstractGetBinDataClass):
-    """
-    Council class for North Hertfordshire District Council.
-    Uses the Cloud9 mobile API to fetch bin collection data.
-    """
-
     def parse_data(self, page: str, **kwargs) -> dict:
         """
-        Parse and return sorted bin collection entries for an address using the Cloud9 mobile API.
-        
-        Parameters:
-            page (str): Unused; present for interface compatibility.
-            **kwargs: Must include either:
-                - uprn (str): Validated UPRN to query the mobile API.
-                OR
-                - postcode (str) and paon (str): Postcode and property identifier used to resolve a UPRN via lookup_uprn.
-        
-        Returns:
-            dict: {"bins": [entry, ...]} where each entry is a dict with:
-                - "type" (str): Container description (e.g., "Refuse", "Recycling", or a default "Container N").
-                - "collectionDate" (str): Date formatted according to the module's date_format.
-        
-        Raises:
-            ValueError: If inputs are missing/invalid, UPRN lookup fails, the API response lacks wasteCollectionDates,
-                        no valid collection dates can be extracted, or the API request/response is malformed.
+        NHDC migrated from the Cloud9 `citizenmobile/mobileapi/{UPRN}` endpoint
+        (now 404) to a Netcall Liberty Create portal at
+        waste.nc.north-herts.gov.uk. The new flow is a typeahead search keyed
+        on postcode/address, selection of a record, and a server-rendered
+        result page. No public UPRN shortcut exists — submit URLs carry an
+        auth signature bound to the session-issued webpage_token.
+
+        kwargs:
+            postcode (str): required.
+            paon    (str): required. Matched as a case-insensitive substring
+                           against the typeahead list item text.
+            web_driver, headless: passed through to create_webdriver.
         """
-        bins_with_sort_date = []
+        driver = None
+        try:
+            user_postcode = kwargs.get("postcode")
+            user_paon = kwargs.get("paon")
+            web_driver = kwargs.get("web_driver")
+            headless = kwargs.get("headless")
+            check_postcode(user_postcode)
+            check_paon(user_paon)
 
-        # Get UPRN either directly or via lookup
-
-        uprn = kwargs.get("uprn")
-
-        if uprn:
-            check_uprn(uprn)
-        else:
-            # Try to lookup UPRN from postcode and house number
-            # This is provided to maintain backward compatibility with the existing postcode/paon input method
-            postcode = kwargs.get("postcode")
-            paon = kwargs.get("paon")
-            check_postcode(postcode)
-            check_paon(paon)
-
-            # Attempt UPRN lookup using postcode and paon
-            uprn = lookup_uprn(postcode=postcode, paon=paon)
-
-
-        # Fetch data from mobile API
-        api_response = fetch_mobile_api(uprn)
-
-        # Parse the API response - Cloud9 API returns WasteCollectionDates with 8 containers
-        # Response structure: {"wasteCollectionDates": {"container1CollectionDetails": {...}, ...}}
-        waste_collection_dates = api_response.get("wasteCollectionDates", {})
-
-        if not waste_collection_dates:
-            raise ValueError(
-                f"No wasteCollectionDates found in API response. API response: {json.dumps(api_response)[:200]}"
+            user_agent = (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+                "(KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36"
+            )
+            driver = create_webdriver(web_driver, headless, user_agent, __name__)
+            driver.get(
+                "https://waste.nc.north-herts.gov.uk/w/webpage/find-bin-collection-day-input-address"
             )
 
-        # Process all 8 possible containers
-        for container_num in range(1, MOBILE_API_NUM_CONTAINERS + 1):
-            container_key = f"container{container_num}CollectionDetails"
-            container = waste_collection_dates.get(container_key)
+            wait = WebDriverWait(driver, 30)
 
-            if not container or not isinstance(container, dict):
-                continue
+            # Typeahead input — Liberty's visible field uses this class
+            search_input = wait.until(
+                EC.element_to_be_clickable((
+                    By.CSS_SELECTOR,
+                    "input.relation_path_type_ahead_search",
+                ))
+            )
+            search_input.click()
+            search_input.clear()
+            # send_keys one char at a time so Liberty's debounced keyup fires
+            for ch in user_postcode:
+                search_input.send_keys(ch)
+                time.sleep(0.05)
+            # Nudge the debounce
+            search_input.send_keys(Keys.END)
 
-            # Extract collection date
-            collection_date_str = container.get("collectionDate", "")
+            # Wait for result list to appear and populate
+            result_list_locator = (
+                By.CSS_SELECTOR,
+                "div.relation_path_type_ahead_results_holder ul.result_list li[data-id]",
+            )
+            wait.until(EC.presence_of_element_located(result_list_locator))
+            # Give it another beat for all results to arrive
+            time.sleep(1)
 
-            # Skip empty collection dates
-            if not collection_date_str:
-                continue
+            items = driver.find_elements(*result_list_locator)
+            if not items:
+                raise ValueError(
+                    f"NHDC typeahead returned no addresses for postcode {user_postcode}"
+                )
 
-            # Extract container description (bin type)
-            bin_type = container.get("containerDescription", f"Container {container_num}")
-            try:
-                collection_datetime = datetime.fromisoformat(collection_date_str)
-            except ValueError:
-                # skip bins with invalid date format and continue processing
-                continue
+            paon_lc = str(user_paon).lower()
+            target = None
+            for li in items:
+                if paon_lc in li.text.lower():
+                    target = li
+                    break
+            if target is None:
+                # Fall back to the first result rather than blow up — caller
+                # may have supplied just a postcode for a single-property match
+                target = items[0]
 
-            # Parse the date - API returns ISO format like "2025-11-25T00:00:00"
-            bin_entry = {
-                "type": bin_type,
-                "collectionDate": collection_datetime.strftime(date_format),
-                "_sort_date": collection_datetime
+            target.click()
+            time.sleep(0.5)
+
+            submit_btn = wait.until(
+                EC.element_to_be_clickable((
+                    By.CSS_SELECTOR,
+                    'input[type="submit"][aria-label="Select address and continue"]',
+                ))
+            )
+            submit_btn.click()
+
+            # Wait for the result page — URL pattern ends in "show-details"
+            WebDriverWait(driver, 30).until(
+                lambda d: "show-details" in d.current_url
+            )
+            # Wait for the bin content to render
+            WebDriverWait(driver, 30).until(
+                EC.presence_of_element_located((
+                    By.XPATH,
+                    "//strong[normalize-space()='Next collection']",
+                ))
+            )
+
+            soup = BeautifulSoup(driver.page_source, "html.parser")
+
+            data = {"bins": []}
+
+            # Liberty renders each bin type as a block containing:
+            #   <h*>Cardboard & Paper</h*>
+            #   <table> ... <p><strong>Next collection</strong><br>Thursday 23rd April 2026</p> ...
+            # The bin type heading can be h2/h3/h4/strong depending on theme.
+            # Strategy: find each <strong>Next collection</strong>, walk up to
+            # the enclosing block, look back for the most recent heading text
+            # naming the bin type.
+            bin_type_whitelist = {
+                "Cardboard & Paper",
+                "Cardboard and Paper",
+                "Food Waste",
+                "Non-Recyclable Waste",
+                "Non Recyclable Waste",
+                "Garden Waste",
+                "Mixed Recycling",
+                "Refuse",
+                "Glass",
             }
 
-            bins_with_sort_date.append(bin_entry)
+            # Collect (bin_type, date) pairs by walking the DOM order
+            body_text_nodes = []
+            for el in soup.find_all(["h1", "h2", "h3", "h4", "h5", "strong", "p"]):
+                text = el.get_text(" ", strip=True)
+                if not text:
+                    continue
+                body_text_nodes.append((el, text))
 
-        if not bins_with_sort_date:
-            raise ValueError(
-                "No valid bin collection data could be extracted from the API response"
+            current_type = None
+            for el, text in body_text_nodes:
+                # Match a bin-type heading
+                for candidate in bin_type_whitelist:
+                    if text.lower() == candidate.lower():
+                        current_type = candidate.replace(" and ", " & ")
+                        break
+                # Match a "Next collection" block — the date is either after
+                # the <br> in the same <p>, or the element's trailing text
+                if "Next collection" in text and current_type:
+                    # Pull the date from element text after the "Next collection" label
+                    date_match = re.search(
+                        r"Next collection\s+(?:on\s+)?"
+                        r"([A-Za-z]+\s+\d{1,2}(?:st|nd|rd|th)?\s+[A-Za-z]+\s+\d{4})",
+                        text,
+                    )
+                    if date_match:
+                        raw = _strip_ordinal(date_match.group(1))
+                        try:
+                            parsed = datetime.strptime(raw, "%A %d %B %Y")
+                        except ValueError:
+                            continue
+                        data["bins"].append({
+                            "type": current_type,
+                            "collectionDate": parsed.strftime(date_format),
+                        })
+
+            # Dedupe while preserving order
+            seen = set()
+            unique = []
+            for b in data["bins"]:
+                key = (b["type"], b["collectionDate"])
+                if key in seen:
+                    continue
+                seen.add(key)
+                unique.append(b)
+            data["bins"] = unique
+
+            data["bins"].sort(
+                key=lambda x: datetime.strptime(x["collectionDate"], date_format)
             )
-
-        # Sort the bin collections by _sort_date
-        bins_with_sort_date.sort(key=lambda x: x["_sort_date"])
-
-        # Return the sorted bins, excluding the _sort_date key
-        return {
-            "bins": [
-                {k: v for k, v in b.items() if k != "_sort_date"}
-                for b in bins_with_sort_date
-            ]
-        }
+            return data
+        finally:
+            if driver is not None:
+                driver.quit()


### PR DESCRIPTION
## Problem

The old scraper targeted `https://apps.cloud9technologies.com/northherts/citizenmobile/mobileapi/{UPRN}/` which now returns **HTTP 404**. NHDC has moved its bin-collection lookup to a Netcall Liberty Create portal at:

```
https://waste.nc.north-herts.gov.uk/w/webpage/find-bin-collection-day-input-address
```

There is no public UPRN shortcut on the new portal — submit URLs carry an `auth` signature bound to the session-issued `webpage_token` (direct GET with `?id=<record_id>` returns **403 Forbidden**). The form is also entirely client-rendered (initial HTML contains no `<form>`), so a pure-requests implementation would have to replay ~30 Liberty presenter params per call and is extremely fragile. Selenium is the pragmatic path — the old fixture already declared `web_driver: http://selenium:4444` anyway.

## Fix

Selenium-driven typeahead flow:

1. `driver.get` the input form page.
2. Type postcode into `input.relation_path_type_ahead_search`.
3. Wait for `div.relation_path_type_ahead_results_holder ul.result_list li[data-id]` to render.
4. Pick the `<li>` whose text contains the `paon` (case-insensitive substring match; falls back to the first result if the caller doesn't provide a house-number match).
5. Click `input[type=submit][aria-label='Select address and continue']`.
6. Wait for the `show-details` result URL, then parse bin-type headings (`Cardboard & Paper` / `Food Waste` / `Non-Recyclable Waste` / `Mixed Recycling` / `Garden Waste` / `Refuse` / `Glass`) paired with the following `Next collection` date. Strip ordinal suffixes and parse `%A %d %B %Y`.

## Fixture change

Required — the old fixture was UPRN-only and the new portal doesn't accept UPRN input. Updated to:

```json
"NorthHertfordshireDistrictCouncil": {
    "house_number": "Stewards Flat",
    "postcode": "SG5 1PZ",
    "skip_get_url": true,
    "url": "https://waste.nc.north-herts.gov.uk/w/webpage/find-bin-collection-day-input-address",
    "web_driver": "http://selenium:4444",
    "wiki_name": "North Hertfordshire",
    "wiki_note": "Pass a postcode (with space) and house_number/name. The scraper performs the Liberty Create typeahead lookup and matches house_number as a case-insensitive substring.",
    "LAD24CD": "E07000099"
}
```

## Verification

Live run against the fixture returns 4 bins:

```
Cardboard & Paper      23/04/2026
Food Waste             23/04/2026
Non-Recyclable Waste   30/04/2026
Mixed Recycling        08/05/2026
```