### PR TITLE
fix: WestSuffolkCouncil — User-Agent + renamed h4 heading

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/WestSuffolkCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/WestSuffolkCouncil.py
@@ -15,7 +15,15 @@ class CouncilClass(AbstractGetBinDataClass):
 
         api_url = f"https://maps.westsuffolk.gov.uk/MyWestSuffolk.aspx?action=SetAddress&UniqueId={user_uprn}"
 
-        response = requests.get(api_url)
+        # West Suffolk's IIS now returns 404 to requests without a User-Agent,
+        # so send a realistic browser UA to get a valid response.
+        headers = {
+            "User-Agent": (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+                "(KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36"
+            )
+        }
+        response = requests.get(api_url, headers=headers)
 
         soup = BeautifulSoup(response.text, features="html.parser")
         soup.prettify()
@@ -31,8 +39,11 @@ class CouncilClass(AbstractGetBinDataClass):
             if tag_class is None:
                 return False
 
+            # The header was renamed from "Bin collection days" to
+            # "Bin collection days current"; match as a substring so the
+            # scraper survives either label.
             parent_has_header = cur_tag.parent.find_all(
-                "h4", string="Bin collection days"
+                "h4", string=lambda s: s and "Bin collection days" in s
             )
             if len(parent_has_header) < 1:
                 return False


### PR DESCRIPTION
Two upstream changes on the West Suffolk bin-day page had left the scraper silently failing (empty result, no exception):

1. **User-Agent now required.** `maps.westsuffolk.gov.uk`'s IIS returns 404 to requests with no `User-Agent`. Sending a realistic browser UA fixes the 404.
2. **Collection-panel heading renamed.** The `<h4>` that sits above the bin panel was renamed from `Bin collection days` to `Bin collection days current`. The existing scraper used `find_all("h4", string="Bin collection days")` which is an exact match, so the panel filter never matched and the result came back empty. Matching as a substring via a lambda covers either label.

### Verification

Tested live against UPRN `10009739960` (1 The Drift, Culford, IP28 6DR):

```json
{"bins": [
  {"type": "Black Bins", "collectionDate": "29/04/2026"},
  {"type": "Blue Bins",  "collectionDate": "22/04/2026"},
  {"type": "Brown Bins", "collectionDate": "22/04/2026"}
]}
```

Also confirmed via the Kepthouse `/resolve-v2` API (lat/lng → UPRN → council → scraper) — returned `status: ok` with the bin list in ~22 s on cold Selenium grid.

### Supersedes #1955

#1955 only addressed the User-Agent side of this and was based on a branch that accidentally picked up four unrelated stacked council fixes. This PR is a clean standalone against current `master` with both the UA fix and the h4 rename fix in one commit. Happy to close #1955 once this merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bin collection schedule parsing to handle variations in data formatting across different council responses.
  * Enhanced HTTP request handling with improved browser compatibility headers to ensure more reliable data retrieval of your collection information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->