### PR TITLE
fix: EnvironmentFirst/Eastbourne/Lewes - handle restructured page

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/EastbourneBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/EastbourneBoroughCouncil.py
@@ -1,12 +1,13 @@
 # Lewes Borough Council uses the same script.
 
+import re
+
 from bs4 import BeautifulSoup
 
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
 
-# import the wonderful Beautiful Soup and the URL grabber
 class CouncilClass(AbstractGetBinDataClass):
     """
     Concrete classes have to implement all abstract operations of the
@@ -21,56 +22,60 @@ class CouncilClass(AbstractGetBinDataClass):
             check_uprn(user_uprn)
             url = f"https://environmentfirst.co.uk/house.php?uprn={user_uprn}"
             if not user_uprn:
-                # This is a fallback for if the user stored a URL in old system. Ensures backwards compatibility.
+                # Backwards compatibility for users who stored a URL.
                 url = kwargs.get("url")
         except Exception as e:
             raise ValueError(f"Error getting identifier: {str(e)}")
 
-        # Make a BS4 object
         page = requests.get(url)
         soup = BeautifulSoup(page.text, features="html.parser")
         soup.prettify()
 
-        # Get the paragraph lines from the page
         data = {"bins": []}
-        page_text = soup.find("div", {"class": "collect"}).find_all("p")
+        collect_div = soup.find("div", {"class": "collect"})
+        if collect_div is None:
+            return data
 
-        # Parse the correct lines (find them, remove the ordinal indicator and make them the correct format date) and
-        # then add them to the dictionary
-        rubbish_day = datetime.strptime(
-            remove_ordinal_indicator_from_date_string(
-                page_text[2].find_next("strong").text
-            ),
-            "%d %B %Y",
-        ).strftime(date_format)
-        dict_data = {
-            "type": "Rubbish",
-            "collectionDate": rubbish_day,
-        }
-        data["bins"].append(dict_data)
-        recycling_day = datetime.strptime(
-            remove_ordinal_indicator_from_date_string(
-                page_text[4].find_next("strong").text
-            ),
-            "%d %B %Y",
-        ).strftime(date_format)
-        dict_data = {
-            "type": "Recycling",
-            "collectionDate": recycling_day,
-        }
-        data["bins"].append(dict_data)
+        # Site format (April 2026):
+        #   <p class="address-line">...</p>
+        #   <p>Your next rubbish collection day is: <strong>Tuesday 5th May 2026</strong></p>
+        #   <p>Your next recycling collection day is: <strong>Tuesday 28th April 2026</strong></p>
+        #   <p>Your next garden waste collection day is: <strong>Wednesday 6th May 2026</strong></p>
+        # Some properties also have an introductory paragraph between the address
+        # and the dates. Identify each row by the surrounding label rather than by
+        # a fixed index — paragraph counts have shifted twice in 12 months.
+        date_pattern = re.compile(
+            r"(\d{1,2}(?:st|nd|rd|th)?\s+[A-Za-z]+\s+\d{4})"
+        )
 
-        if len(page_text) > 5:
-            garden_day = datetime.strptime(
-                remove_ordinal_indicator_from_date_string(
-                    page_text[6].find_next("strong").text
-                ),
-                "%d %B %Y",
-            ).strftime(date_format)
-            dict_data = {
-                "type": "Garden",
-                "collectionDate": garden_day,
-            }
-            data["bins"].append(dict_data)
+        for p in collect_div.find_all("p"):
+            strong = p.find("strong")
+            if not strong:
+                continue
+            label = p.get_text(" ", strip=True).lower()
+            if "rubbish" in label:
+                bin_type = "Rubbish"
+            elif "recycling" in label:
+                bin_type = "Recycling"
+            elif "garden" in label:
+                bin_type = "Garden"
+            else:
+                continue
+            match = date_pattern.search(strong.get_text(" ", strip=True))
+            if not match:
+                continue
+            cleaned = remove_ordinal_indicator_from_date_string(match.group(1))
+            try:
+                collection_date = datetime.strptime(
+                    cleaned, "%d %B %Y"
+                ).strftime(date_format)
+            except ValueError:
+                continue
+            data["bins"].append(
+                {
+                    "type": bin_type,
+                    "collectionDate": collection_date,
+                }
+            )
 
         return data

--- a/uk_bin_collection/uk_bin_collection/councils/EnvironmentFirst.py
+++ b/uk_bin_collection/uk_bin_collection/councils/EnvironmentFirst.py
@@ -1,12 +1,13 @@
 # Legacy script. Copied to Lewes and Eastbourne.
 
+import re
+
 from bs4 import BeautifulSoup
 
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
 
-# import the wonderful Beautiful Soup and the URL grabber
 class CouncilClass(AbstractGetBinDataClass):
     """
     Concrete classes have to implement all abstract operations of the
@@ -15,50 +16,46 @@ class CouncilClass(AbstractGetBinDataClass):
     """
 
     def parse_data(self, page: str, **kwargs) -> dict:
-        # Make a BS4 object
         soup = BeautifulSoup(page.text, features="html.parser")
         soup.prettify()
 
-        # Get the paragraph lines from the page
         data = {"bins": []}
-        page_text = soup.find("div", {"class": "collect"}).find_all("p")
+        collect_div = soup.find("div", {"class": "collect"})
+        if collect_div is None:
+            return data
 
-        # Parse the correct lines (find them, remove the ordinal indicator and make them the correct format date) and
-        # then add them to the dictionary
-        rubbish_day = datetime.strptime(
-            remove_ordinal_indicator_from_date_string(
-                page_text[2].find_next("strong").text
-            ),
-            "%d %B %Y",
-        ).strftime(date_format)
-        dict_data = {
-            "type": "Rubbish",
-            "collectionDate": rubbish_day,
-        }
-        data["bins"].append(dict_data)
-        recycling_day = datetime.strptime(
-            remove_ordinal_indicator_from_date_string(
-                page_text[4].find_next("strong").text
-            ),
-            "%d %B %Y",
-        ).strftime(date_format)
-        dict_data = {
-            "type": "Recycling",
-            "collectionDate": recycling_day,
-        }
-        data["bins"].append(dict_data)
+        date_pattern = re.compile(
+            r"(\d{1,2}(?:st|nd|rd|th)?\s+[A-Za-z]+\s+\d{4})"
+        )
 
-        if len(page_text) > 5:
-            garden_day = datetime.strptime(
-                remove_ordinal_indicator_from_date_string(
-                    page_text[6].find_next("strong").text
-                ),
-                "%d %B %Y",
-            ).strftime(date_format)
-            dict_data = {
-                "type": "Garden",
-                "collectionDate": garden_day,
-            }
-            data["bins"].append(dict_data)
+        for p in collect_div.find_all("p"):
+            strong = p.find("strong")
+            if not strong:
+                continue
+            label = p.get_text(" ", strip=True).lower()
+            if "rubbish" in label:
+                bin_type = "Rubbish"
+            elif "recycling" in label:
+                bin_type = "Recycling"
+            elif "garden" in label:
+                bin_type = "Garden"
+            else:
+                continue
+            match = date_pattern.search(strong.get_text(" ", strip=True))
+            if not match:
+                continue
+            cleaned = remove_ordinal_indicator_from_date_string(match.group(1))
+            try:
+                collection_date = datetime.strptime(
+                    cleaned, "%d %B %Y"
+                ).strftime(date_format)
+            except ValueError:
+                continue
+            data["bins"].append(
+                {
+                    "type": bin_type,
+                    "collectionDate": collection_date,
+                }
+            )
 
         return data

--- a/uk_bin_collection/uk_bin_collection/councils/LewesDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/LewesDistrictCouncil.py
@@ -1,12 +1,13 @@
 # Eastbourne uses the same script.
 
+import re
+
 from bs4 import BeautifulSoup
 
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
 
-# import the wonderful Beautiful Soup and the URL grabber
 class CouncilClass(AbstractGetBinDataClass):
     """
     Concrete classes have to implement all abstract operations of the
@@ -21,56 +22,52 @@ class CouncilClass(AbstractGetBinDataClass):
             check_uprn(user_uprn)
             url = f"https://environmentfirst.co.uk/house.php?uprn={user_uprn}"
             if not user_uprn:
-                # This is a fallback for if the user stored a URL in old system. Ensures backwards compatibility.
+                # Backwards compatibility for users who stored a URL.
                 url = kwargs.get("url")
         except Exception as e:
             raise ValueError(f"Error getting identifier: {str(e)}")
 
-        # Make a BS4 object
         page = requests.get(url)
         soup = BeautifulSoup(page.text, features="html.parser")
         soup.prettify()
 
-        # Get the paragraph lines from the page
         data = {"bins": []}
-        page_text = soup.find("div", {"class": "collect"}).find_all("p")
+        collect_div = soup.find("div", {"class": "collect"})
+        if collect_div is None:
+            return data
 
-        # Parse the correct lines (find them, remove the ordinal indicator and make them the correct format date) and
-        # then add them to the dictionary
-        rubbish_day = datetime.strptime(
-            remove_ordinal_indicator_from_date_string(
-                page_text[2].find_next("strong").text
-            ),
-            "%d %B %Y",
-        ).strftime(date_format)
-        dict_data = {
-            "type": "Rubbish",
-            "collectionDate": rubbish_day,
-        }
-        data["bins"].append(dict_data)
-        recycling_day = datetime.strptime(
-            remove_ordinal_indicator_from_date_string(
-                page_text[4].find_next("strong").text
-            ),
-            "%d %B %Y",
-        ).strftime(date_format)
-        dict_data = {
-            "type": "Recycling",
-            "collectionDate": recycling_day,
-        }
-        data["bins"].append(dict_data)
+        date_pattern = re.compile(
+            r"(\d{1,2}(?:st|nd|rd|th)?\s+[A-Za-z]+\s+\d{4})"
+        )
 
-        if len(page_text) > 5:
-            garden_day = datetime.strptime(
-                remove_ordinal_indicator_from_date_string(
-                    page_text[6].find_next("strong").text
-                ),
-                "%d %B %Y",
-            ).strftime(date_format)
-            dict_data = {
-                "type": "Garden",
-                "collectionDate": garden_day,
-            }
-            data["bins"].append(dict_data)
+        for p in collect_div.find_all("p"):
+            strong = p.find("strong")
+            if not strong:
+                continue
+            label = p.get_text(" ", strip=True).lower()
+            if "rubbish" in label:
+                bin_type = "Rubbish"
+            elif "recycling" in label:
+                bin_type = "Recycling"
+            elif "garden" in label:
+                bin_type = "Garden"
+            else:
+                continue
+            match = date_pattern.search(strong.get_text(" ", strip=True))
+            if not match:
+                continue
+            cleaned = remove_ordinal_indicator_from_date_string(match.group(1))
+            try:
+                collection_date = datetime.strptime(
+                    cleaned, "%d %B %Y"
+                ).strftime(date_format)
+            except ValueError:
+                continue
+            data["bins"].append(
+                {
+                    "type": bin_type,
+                    "collectionDate": collection_date,
+                }
+            )
 
         return data


### PR DESCRIPTION
The `environmentfirst.co.uk` results page (used directly by `EnvironmentFirst` and via the same parser by `EastbourneBoroughCouncil` + `LewesDistrictCouncil`) was restructured in April 2026:

* The bin dates are now wrapped in a `<strong>` inside the same `<p>` that carries the label. The previous separator paragraphs are gone, so the fixed indices `page_text[2]` / `[4]` / `[6]` no longer line up — they're now `[1]/[2]/[3]`.
* The date string also gained a leading weekday name. Values like `Tuesday 28th April 2026` no longer match `'%d %B %Y'` and the parser raises `ValueError: time data 'Tuesday 28 April 2026' does not match format '%d %B %Y'`.

Rewritten to identify each row by the surrounding label (rubbish / recycling / garden) instead of a fixed paragraph index, and to extract the date with a regex (`\d{1,2}(?:st|nd|rd|th)?\s+\w+\s+\d{4}`) so the weekday prefix is harmlessly skipped.

Verified against UPRN `100060011258` (Eastbourne) and `100061930155` (Lewes) — both return their full schedules including the garden waste line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved bin collection date extraction for Eastbourne Borough Council, Environment First, and Lewes District Council with enhanced handling of HTML structure variations and date formats, including improved error recovery for edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->