### PR TITLE
fix: MidSussexDistrictCouncil - migrate to council-branded Whitespace portal

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/MidSussexDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/MidSussexDistrictCouncil.py
@@ -5,7 +5,6 @@ from bs4 import BeautifulSoup
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
-# Set up logging
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
 )
@@ -17,23 +16,6 @@ class CouncilClass(AbstractGetBinDataClass):
     """
 
     def parse_data(self, page: str, **kwargs) -> dict:
-        """
-        Retrieve scheduled bin collection dates for a given address from Mid-Sussex District Council.
-        
-        Parameters:
-            page (str): Unused by this implementation (kept for compatibility).
-            paon (str, in kwargs): Address name or number (passed as `paon`).
-            postcode (str, in kwargs): Address postcode (passed as `postcode`); must be valid.
-        
-        Returns:
-            dict: A dictionary with a "bins" key containing a list of collection entries. Each entry is a dict with:
-                - "type": bin type as shown on the council page.
-                - "collectionDate": collection date string formatted using the module's `date_format`.
-        
-        Raises:
-            Exception: If the initial council page link is missing, the address cannot be found, or there are no scheduled services for the address.
-            requests.HTTPError: Propagated when HTTP requests return error status codes.
-        """
         try:
             data = {"bins": []}
             bindata = {"bins": []}
@@ -41,26 +23,40 @@ class CouncilClass(AbstractGetBinDataClass):
             user_postcode = kwargs.get("postcode")
             check_postcode(user_postcode)
 
-            URI = "https://sms-wrp.whitespacews.com/"
+            # The council previously used the shared Whitespace portal at
+            # sms-wrp.whitespacews.com. That subdomain now returns
+            # "Access denied!" — the council moved to a self-branded
+            # Whitespace deployment at waste.services.midsussex.gov.uk
+            # but the underlying flow (seq=1 -> seq=2 with paon/postcode)
+            # is identical.
+            URI = "https://waste.services.midsussex.gov.uk/"
 
             session = requests.Session()
+            session.headers.update(
+                {
+                    "User-Agent": (
+                        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                        "AppleWebKit/537.36 (KHTML, like Gecko) "
+                        "Chrome/132.0.0.0 Safari/537.36"
+                    )
+                }
+            )
 
             # get link from first page as has some kind of unique hash
-            r = session.get(
-                URI,
-            )
+            r = session.get(URI, timeout=30)
             r.raise_for_status()
             soup = BeautifulSoup(r.text, features="html.parser")
 
             alink = soup.find(
                 "a",
-                text="View my collections for refuse, gardening, food and recycling",
+                string=lambda s: s
+                and "View my collections" in s,
             )
 
             if alink is None:
                 raise Exception("Initial page did not load correctly")
 
-            # greplace 'seq' query string to skip next step
+            # replace 'seq' query string to skip next step
             nextpageurl = alink["href"].replace("seq=1", "seq=2")
 
             data = {
@@ -68,24 +64,24 @@ class CouncilClass(AbstractGetBinDataClass):
                 "address_postcode": user_postcode,
             }
 
-            # get list of addresses
             r = session.post(nextpageurl, data=data, timeout=30)
             r.raise_for_status()
 
             soup = BeautifulSoup(r.text, features="html.parser")
 
-            # get first address (if you don't enter enough argument values this won't find the right address)
             alink = soup.find("div", id="property_list").find("a")
 
             if alink is None:
                 raise Exception("Address not found")
 
-            nextpageurl = URI + alink["href"]
+            # property_list href may already be absolute on the rebranded portal
+            href = alink["href"]
+            if href.startswith("http"):
+                nextpageurl = href
+            else:
+                nextpageurl = URI + href.lstrip("/")
 
-            # get collection page
-            r = session.get(
-                nextpageurl,
-            )
+            r = session.get(nextpageurl, timeout=30)
             r.raise_for_status()
             soup = BeautifulSoup(r.text, features="html.parser")
 


### PR DESCRIPTION
Mid-Sussex moved off the shared `sms-wrp.whitespacews.com` host (which now returns `Access denied!` for every request — 14 bytes, no body) onto a self-branded Whitespace deployment at `waste.services.midsussex.gov.uk`. The underlying flow — find the "View my collections..." link, replace `seq=1` with `seq=2`, POST `address_name_number` + `address_postcode`, follow the `property_list` anchor, parse `section#scheduled-collections` — is identical.

Changes:

* URI swapped to `https://waste.services.midsussex.gov.uk/`.
* Send a realistic Chrome User-Agent (host returns 403 without one).
* Use a callable for the `find()` text match instead of the deprecated `text=` kwarg (BeautifulSoup 4.12 wants `string=`).
* Handle `property_list` `href` being either absolute or relative on the new branded host.

Verified against postcode `RH16 1SS` — returns the full collection schedule (food / recycling / refuse over the next four weeks).