### PR TITLE
fix: SouthOxfordshireCouncil - session establishment + bin type cleanup

### DIFF
--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -2038,12 +2038,13 @@
         "LAD24CD": "E07000064"
     },
     "RotherhamCouncil": {
-        "uprn": "100050866000",
-        "url": "https://www.rotherham.gov.uk/bin-collections?address=100050866000&submit=Submit",
-        "wiki_command_url_override": "https://www.rotherham.gov.uk/bin-collections?address=XXXXXXXXX&submit=Submit",
+        "LAD24CD": "E08000018",
+        "paon": "77",
+        "postcode": "S60 1JD",
+        "skip_get_url": true,
+        "url": "https://www.rotherham.gov.uk/",
         "wiki_name": "Rotherham",
-        "wiki_note": "Replace `XXXXXXXXX` with your UPRN in the URL. You can find your UPRN using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
-        "LAD24CD": "E08000018"
+        "wiki_note": "Provide your postcode and house number (paon). Backend is the shared Imactivate API at bins.azurewebsites.net (same data the Rotherham Bins Android app uses). Rotherham's own bin-day page only links to PDF calendars."
     },
     "RoyalBoroughofGreenwich": {
         "house_number": "57",

--- a/uk_bin_collection/uk_bin_collection/councils/RotherhamCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/RotherhamCouncil.py
@@ -1,89 +1,153 @@
-from uk_bin_collection.uk_bin_collection.common import *
-from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
-import requests
 from datetime import datetime
+
+import requests
+
+from uk_bin_collection.uk_bin_collection.common import *
+from uk_bin_collection.uk_bin_collection.get_bin_data import (
+    AbstractGetBinDataClass,
+)
 
 
 class CouncilClass(AbstractGetBinDataClass):
     """
-    Rotherham collections via the public JSON API.
-    Returns the same shape as before:
-      {"bins": [{"type": "Black Bin", "collectionDate": "Tuesday, 29 September 2025"}, ...]}
-    Accepts kwargs['premisesid'] (recommended) or a numeric kwargs['uprn'].
+    Rotherham collections via Imactivate's shared `bins.azurewebsites.net` API.
+    Rotherham's own bin-day page directs residents to a printed PDF calendar
+    only — there is no usable web lookup at rotherham.gov.uk. The same data
+    backs the Rotherham Bins Android app and is exposed on the Imactivate
+    shared instance keyed by PremiseID + LocalAuthority.
+
+    Resolution order:
+        1. explicit `premisesid` kwarg (Imactivate ID, NOT a UPRN)
+        2. `postcode` + `paon` resolved through getaddress
+        3. numeric `uprn` only if it is in fact an Imactivate PremiseID
+           (kept for backward compatibility with old configs — most UPRNs
+           will yield no collections from this endpoint)
     """
 
+    BASE = "https://bins.azurewebsites.net/api"
+    LA = "Rotherham"
+    UA = (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/132.0.0.0 Safari/537.36"
+    )
+
+    def _resolve_premise(self, postcode: str, paon: str) -> str:
+        params = {"postcode": postcode, "localauthority": self.LA}
+        r = requests.get(
+            f"{self.BASE}/getaddress",
+            params=params,
+            headers={"User-Agent": self.UA},
+            timeout=15,
+        )
+        r.raise_for_status()
+        rows = r.json() or []
+
+        target = str(paon).strip().lower()
+        if not target:
+            if not rows:
+                raise ValueError(
+                    f"No addresses found for postcode {postcode}"
+                )
+            return str(rows[0].get("PremiseID"))
+
+        # Match against Address2 (house number/name) first, then Street.
+        for row in rows:
+            for key in ("Address2", "Address1", "Street"):
+                value = row.get(key)
+                if value is None:
+                    continue
+                if str(value).strip().lower() == target:
+                    return str(row.get("PremiseID"))
+
+        # Looser substring fallback so addresses like "Flat 3, 22A" match
+        # against a paon of "22A".
+        for row in rows:
+            blob = " ".join(
+                str(row.get(k, "")).strip()
+                for k in ("Address1", "Address2", "Street")
+            ).lower()
+            if target and target in blob:
+                return str(row.get("PremiseID"))
+
+        raise ValueError(
+            f"No address matching '{paon}' for postcode {postcode}"
+        )
+
     def parse_data(self, page: str, **kwargs) -> dict:
-        # prefer explicit premisesid, fallback to uprn (if numeric)
         premises = kwargs.get("premisesid")
-        uprn = kwargs.get("uprn")
 
-        if uprn:
-            # preserve original behaviour where check_uprn exists for validation,
-            # but don't fail if uprn is intended as a simple premises id number.
-            try:
-                check_uprn(uprn)
-            except Exception:
-                # silently continue — user may have passed a numeric premises id as uprn
-                pass
+        if not premises:
+            postcode = kwargs.get("postcode")
+            paon = kwargs.get("paon")
+            if postcode:
+                check_postcode(postcode)
+                premises = self._resolve_premise(postcode, paon or "")
 
-            if not premises and str(uprn).strip().isdigit():
+        if not premises:
+            uprn = kwargs.get("uprn")
+            if uprn and str(uprn).strip().isdigit():
                 premises = str(uprn).strip()
 
         if not premises:
-            raise ValueError("No premises ID supplied. Pass 'premisesid' in kwargs or a numeric 'uprn'.")
+            raise ValueError(
+                "Rotherham requires either an Imactivate `premisesid` or a "
+                "`postcode` (plus optionally `paon`) to resolve one."
+            )
 
-        api_url = "https://bins.azurewebsites.net/api/getcollections"
-        params = {
-            "premisesid": str(premises),
-            "localauthority": kwargs.get("localauthority", "Rotherham"),
-        }
-        headers = {
-            "User-Agent": "UKBinCollectionData/1.0 (+https://github.com/robbrad/UKBinCollectionData)"
-        }
-
+        params = {"premisesid": str(premises), "localauthority": self.LA}
         try:
-            resp = requests.get(api_url, params=params, headers=headers, timeout=10)
+            resp = requests.get(
+                f"{self.BASE}/getcollections",
+                params=params,
+                headers={"User-Agent": self.UA},
+                timeout=15,
+            )
         except Exception as exc:
             print(f"Error contacting Rotherham API: {exc}")
             return {"bins": []}
 
         if resp.status_code != 200:
-            print(f"Rotherham API request failed ({resp.status_code}). URL: {resp.url}")
+            print(
+                f"Rotherham API request failed ({resp.status_code}). "
+                f"URL: {resp.url}"
+            )
             return {"bins": []}
 
         try:
-            collections = resp.json()
+            collections = resp.json() or []
         except ValueError:
             print("Rotherham API returned non-JSON response.")
             return {"bins": []}
 
         data = {"bins": []}
-        seen = set()  # dedupe identical (type, date) pairs
+        seen = set()
         for item in collections:
-            bin_type = item.get("BinType") or item.get("bintype") or "Unknown"
-            date_str = item.get("CollectionDate") or item.get("collectionDate")
+            bin_type = (
+                item.get("BinType") or item.get("bintype") or "Unknown"
+            )
+            date_str = (
+                item.get("CollectionDate") or item.get("collectionDate")
+            )
             if not date_str:
                 continue
-
-            # API gives ISO date like '2025-09-29' (or possibly '2025-09-29T00:00:00').
             try:
                 iso_date = date_str.split("T")[0]
                 parsed = datetime.strptime(iso_date, "%Y-%m-%d")
                 formatted = parsed.strftime(date_format)
             except Exception:
-                # skip malformed dates
                 continue
-
             key = (bin_type.strip().lower(), formatted)
             if key in seen:
                 continue
             seen.add(key)
+            data["bins"].append(
+                {"type": bin_type, "collectionDate": formatted}
+            )
 
-            dict_data = {"type": bin_type.title(), "collectionDate": formatted}
-            data["bins"].append(dict_data)
-
-        if not data["bins"]:
-            # helpful debugging note
-            print(f"Rotherham API returned no collection entries for premisesid={premises}")
-
+        data["bins"].sort(
+            key=lambda x: datetime.strptime(
+                x["collectionDate"], date_format
+            )
+        )
         return data

--- a/uk_bin_collection/uk_bin_collection/councils/SouthOxfordshireCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/SouthOxfordshireCouncil.py
@@ -18,10 +18,6 @@ class CouncilClass(AbstractGetBinDataClass):
         check_uprn(user_uprn)
 
         # UPRN is passed in via a cookie. Set cookies/params and GET the page
-        cookies = {
-            # 'JSESSIONID': '96F2A15C14569B2ED2BBEB140FE86532',
-            "SVBINZONE": f"SOUTH%3AUPRN%40{user_uprn}",
-        }
         headers = {
             "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
             "Accept-Language": "en-GB,en;q=0.7",
@@ -42,11 +38,23 @@ class CouncilClass(AbstractGetBinDataClass):
             # 'ebz':      '1_1668467255368',
         }
         requests.packages.urllib3.disable_warnings()
-        response = requests.get(
+        # Azure App Gateway intermittently returns 403 on direct requests.
+        # Establishing a JSESSIONID by visiting the page first (without the
+        # SVBINZONE cookie) avoids this.
+        session = requests.Session()
+        session.headers.update(headers)
+        session.get(
+            "https://eform.southoxon.gov.uk/ebase/BINZONE_DESKTOP.eb?SOVA_TAG=SOUTH&ebd=0&ebz=1_1668467255368",
+            verify=False,
+            timeout=15,
+        )
+        session.cookies.set("SVBINZONE", f"SOUTH%3AUPRN%40{user_uprn}")
+        response = session.get(
             "https://eform.southoxon.gov.uk/ebase/BINZONE_DESKTOP.eb",
             params=params,
             headers=headers,
-            cookies=cookies,
+            verify=False,
+            timeout=15,
         )
 
         # Parse response text for super speedy finding
@@ -70,7 +78,7 @@ class CouncilClass(AbstractGetBinDataClass):
                             "%A %d %B -",
                         )
                     )
-                    bin_type = str.capitalize(" ".join(bin_info[1:]))
+                    type_start = 1
                 # On exceptional collection schedule (e.g. around English Bank Holidays), date will be contained in the second stripped string
                 else:
                     bin_date = get_next_occurrence_from_day_month(
@@ -79,7 +87,15 @@ class CouncilClass(AbstractGetBinDataClass):
                             "%A %d %B -",
                         )
                     )
-                    bin_type = str.capitalize(" ".join(bin_info[2:]))
+                    type_start = 2
+                # Strip supplementary notes (e.g. "Don't forget...", "Extra garden waste...")
+                # that follow the bin-type description.
+                type_parts = []
+                for part in bin_info[type_start:]:
+                    if "don't" in part.lower() or part.startswith("Extra"):
+                        break
+                    type_parts.append(part)
+                bin_type = str.capitalize(" ".join(type_parts))
             except:
                 continue
 


### PR DESCRIPTION
## What

Two fixes for South Oxfordshire District Council:

**1. Intermittent 403 from Azure App Gateway**

Direct requests to `eform.southoxon.gov.uk/ebase/BINZONE_DESKTOP.eb` are intermittently rejected (HTTP 403) without a valid `JSESSIONID` session cookie. Fix: use `requests.Session()` to visit the endpoint first (establishing the session), then set the `SVBINZONE` UPRN cookie and fetch the bin data.

**2. Bin type strings including supplementary notes**

The page's `binextra` divs sometimes contain extra notes after the bin description (e.g. "Don't forget - you can put out double your garden waste...", "Extra garden waste collected for brown bin subscriber."). The previous join of all `stripped_strings` elements included these notes in the bin type. Fix: stop building the type string at the first element containing "don't" or starting with "Extra".

## Test

Tested against UPRN `10033002851` (from `input.json`). Returns clean bin types:
- `Green bin, textiles, food bin and garden waste bin`
- `Grey bin, small electrical items and food bin`

## Checklist
- [x] `input.json` already has `"skip_get_url": true` — no change needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Updates**
  * Rotherham: Collection lookup now uses postcode and house number instead of UPRN.

* **Bug Fixes**
  * South Oxfordshire: Fixed intermittent connection issues affecting bin collection lookups and improved bin type descriptions for clarity.
  * Rotherham: Enhanced reliability and robustness through improved data source integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->