### PR TITLE
fix: ChelmsfordCityCouncil - replace Selenium with requests (emarsys popup blocks clicks)

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/ChelmsfordCityCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/ChelmsfordCityCouncil.py
@@ -1,13 +1,9 @@
 import re
-import time
 from datetime import datetime, timedelta
 
 import requests
 from bs4 import BeautifulSoup
 from icalevents.icalevents import events
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.support.wait import WebDriverWait
 
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
@@ -16,107 +12,121 @@ from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataC
 class CouncilClass(AbstractGetBinDataClass):
     def parse_data(self, page: str, **kwargs) -> dict:
         """
-        Locate the council collection round for the given address and return upcoming bin collection dates and types within the next 60 days.
-        
+        Locate the council collection round for the given address and return upcoming bin
+        collection dates and types within the next 60 days.
+
+        Uses HTTP requests only — the search form submits via GET querystring
+        (`?<block_id>_keyword=<postcode>`) and renders a results table directly in static
+        HTML. Avoids Selenium entirely so we don't have to dismiss the emarsys popup +
+        Civic cookie banner that intercept clicks on the live page.
+
         Parameters:
-            page (str): Unused parameter retained for API compatibility.
-            postcode (str, in kwargs): Postcode to search on the council site.
-            paon (str, in kwargs): Property/house name or number used to match the address row.
-        
+            page (str): Unused, kept for API compatibility.
+            postcode (str, in kwargs): Postcode to search.
+            paon (str, in kwargs): Property/house name or number used to match the row.
+
         Returns:
-            dict: A dictionary with a "bins" key containing a list of collection entries. Each entry is a dict with:
-                - "type": collection type string (e.g., "General waste")
-                - "collectionDate": collection date formatted according to the module's `date_format`
-        
+            dict: {"bins": [{"type": ..., "collectionDate": ...}, ...]}
+
         Raises:
-            ValueError: If no collection round can be found for the provided `paon`, or if the calendar (.ics) link for the identified round cannot be located.
+            ValueError: If no collection round is found for `paon`, or the .ics calendar
+                link for the identified round can't be located.
         """
-        driver = None
         try:
             data = {"bins": []}
-            user_agent = "Mozilla/5.0 (Windows NT 6.1; Win64; x64)"
-
             postcode = kwargs.get("postcode")
             user_paon = kwargs.get("paon")
-            web_driver = kwargs.get("web_driver")
-            headless = kwargs.get("headless")
 
-            driver = create_webdriver(web_driver, headless, user_agent, __name__)
-            wait = WebDriverWait(driver, 30)
+            headers = {
+                "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
+            }
+            session = requests.Session()
+            base_url = "https://www.chelmsford.gov.uk/bins-and-recycling/check-your-collection-day/"
 
-            # Navigate to bin collection page
-            driver.get(
-                "https://www.chelmsford.gov.uk/bins-and-recycling/check-your-collection-day/"
-            )
-
-            # Handle cookie overlay
-            try:
-                accept_btn = wait.until(
-                    EC.element_to_be_clickable(
-                        (By.XPATH, "//*[contains(text(), 'ACCEPT')]")
-                    )
+            # Step 1: load the search page to discover the dynamic block ID used
+            # in the form input (e.g. `14532_keyword`). The ID has been stable but
+            # extracting it keeps the scraper resilient if the council republishes
+            # the block.
+            r = session.get(base_url, headers=headers, timeout=30)
+            r.raise_for_status()
+            soup = BeautifulSoup(r.text, "html.parser")
+            input_el = soup.find("input", id=re.compile(r"\d+_keyword"))
+            if not input_el:
+                raise ValueError(
+                    "Could not locate postcode input on the council search page"
                 )
-                accept_btn.click()
-                time.sleep(1)
-            except Exception as e:
-                # Cookie banner not present or already accepted
-                pass
+            form_id = input_el["id"].split("_")[0]
 
-            # Find postcode input field (dynamic ID)
-            postcode_input = wait.until(
-                EC.presence_of_element_located(
-                    (By.XPATH, "//input[contains(@id, '_keyword')]")
-                )
+            # Step 2: submit the search via querystring (mirrors what the form's
+            # JS submit handler does on the live page).
+            search_url = (
+                f"{base_url}?{form_id}_keyword={requests.utils.quote(postcode)}"
+                f"#search-{form_id}"
             )
-            postcode_input.clear()
-            postcode_input.send_keys(postcode)
+            r = session.get(search_url, headers=headers, timeout=30)
+            r.raise_for_status()
+            soup = BeautifulSoup(r.text, "html.parser")
 
-            # Click search button
-            submit_btn = wait.until(
-                EC.element_to_be_clickable((By.CLASS_NAME, "__submitButton"))
-            )
-            submit_btn.click()
+            # Step 3: walk the results table to find the row matching `paon`.
+            # The row format is `<tr><td>full address</td><td><p>This property is
+            # covered by the Tuesday B collection round...</p></td></tr>`.
+            table = soup.find("table", class_="directories-table__table")
+            if table is None:
+                # Fallback: any table on the page
+                table = soup.find("table")
 
-            # Wait for results table
-            wait.until(EC.presence_of_element_located((By.TAG_NAME, "table")))
+            calendar_url = None
+            if table is not None:
+                for row in table.find_all("tr"):
+                    if user_paon in row.get_text():
+                        row_text = row.get_text()
+                        round_match = re.search(
+                            r"(Monday|Tuesday|Wednesday|Thursday|Friday)\s+([AB])",
+                            row_text,
+                        )
+                        if round_match:
+                            day = round_match.group(1).lower()
+                            letter = round_match.group(2).lower()
+                            calendar_url = (
+                                f"https://www.chelmsford.gov.uk/bins-and-recycling/"
+                                f"check-your-collection-day/{day}-{letter}-collection-calendar/"
+                            )
+                            break
 
-            # Get the collection round from the table row
-            soup = BeautifulSoup(driver.page_source, features="html.parser")
-
-            # Find the row containing the address
-            for row in soup.find_all("tr"):
-                if user_paon in row.get_text():
-                    # Extract collection round (e.g., "Tuesday B")
-                    row_text = row.get_text()
-                    round_match = re.search(
-                        r"(Monday|Tuesday|Wednesday|Thursday|Friday)\s+([AB])", row_text
-                    )
-                    if round_match:
-                        day = round_match.group(1).lower()
-                        letter = round_match.group(2).lower()
-                        calendar_url = f"https://www.chelmsford.gov.uk/bins-and-recycling/check-your-collection-day/{day}-{letter}-collection-calendar/"
-                        driver.get(calendar_url)
-                        soup = BeautifulSoup(driver.page_source, features="html.parser")
-                        a = soup.find(
-                            "a", href=lambda h: h and h.lower().endswith(".ics")
+            if calendar_url is None:
+                # Fallback: the search page also exposes per-property cards as
+                # <details> blocks containing a paragraph with the round name and
+                # a calendar link. Use the first card whose summary contains the
+                # paon.
+                for details in soup.find_all("details"):
+                    if user_paon in details.get_text():
+                        a = details.find(
+                            "a",
+                            href=lambda h: h and "collection-calendar" in h,
                         )
                         if a:
-                            ics_url = a["href"]
-                        else:
-                            raise ValueError(
-                                f"Could not find collection ICS file for address: {user_paon}"
-                            )
-                        break
-            else:
+                            calendar_url = a["href"]
+                            break
+
+            if calendar_url is None:
                 raise ValueError(
                     f"Could not find collection round for address: {user_paon}"
                 )
 
-            # Get events from ICS file within the next 60 days
+            # Step 4: fetch the round's calendar page and pull out the .ics link.
+            r = session.get(calendar_url, headers=headers, timeout=30)
+            r.raise_for_status()
+            soup = BeautifulSoup(r.text, "html.parser")
+            a = soup.find("a", href=lambda h: h and h.lower().endswith(".ics"))
+            if not a:
+                raise ValueError(
+                    f"Could not find collection ICS file for address: {user_paon}"
+                )
+            ics_url = a["href"]
+
+            # Step 5: parse the ICS calendar for events in the next 60 days.
             now = datetime.now()
             future = now + timedelta(days=60)
-
-            # Parse ICS calendar
             upcoming_events = events(ics_url, start=now, end=future)
 
             for event in sorted(upcoming_events, key=lambda e: e.start):
@@ -134,8 +144,5 @@ class CouncilClass(AbstractGetBinDataClass):
         except Exception as e:
             print(f"An error occurred: {e}")
             raise
-        finally:
-            if driver:
-                driver.quit()
 
         return data


### PR DESCRIPTION
## What

Replaces the Selenium-based scraper with a pure `requests` + `BeautifulSoup` implementation. Wall time drops from 90s+ (timeout) to ~2.5s.

## Root cause

The council page now displays an **emarsys popup modal** (`z-index: 2147483647`) on first load that covers the entire viewport. Selenium's `element_to_be_clickable` reports the cookie ACCEPT button as clickable (it's in the DOM), but `.click()` raises `ElementClickInterceptedException` which the broad `except` swallows silently. The popup stays up, the postcode input is then uninteractable, and both subsequent `WebDriverWait(30s)` calls time out — blowing past the 90s test limit.

## Fix

The search form submits via GET querystring (`?<block_id>_keyword=<postcode>`) and the address table, collection round text, and calendar page all render in static HTML. No browser interaction needed:

1. GET the search page → extract the dynamic block ID from the `<input id="NNNN_keyword">` element
2. GET `?NNNN_keyword=<postcode>` → parse the results table row matching `paon` → extract collection round (e.g. `Tuesday B`)
3. GET the round's calendar page → find the `.ics` link
4. Parse the ICS file for events in the next 60 days

A fallback `<details>` card path handles any future page structure changes.

## Test

Tested against postcode `CM3 7AE`, paon `1 Celeborn Street, South Woodham Ferrers, Chelmsford, CM3 7AE`. Returns 36 bin entries (food waste, black bin, green box, card sack / brown bin, plastics and cartons, paper sack) spanning ~60 days. 

## Input.json

`house_number` (used as `paon`) and `postcode` fields are unchanged. `web_driver` key is now unused but harmless.