### PR TITLE
fix: NorthKestevenDistrictCouncil - make own HTTP request instead of using page param

### DIFF
--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -1763,10 +1763,12 @@
         "LAD24CD": "E07000099"
     },
     "NorthKestevenDistrictCouncil": {
-        "url": "https://www.n-kesteven.org.uk/bins/display?uprn=100030869513",
-        "wiki_command_url_override": "https://www.n-kesteven.org.uk/bins/display?uprn=XXXXXXXX",
+        "skip_get_url": true,
+        "uprn": "10006545854",
+        "url": "https://www.n-kesteven.org.uk/bins/display",
+        "wiki_command_url_override": "https://www.n-kesteven.org.uk/bins/display",
         "wiki_name": "North Kesteven",
-        "wiki_note": "Replace XXXXXXXX with your UPRN.",
+        "wiki_note": "Pass the UPRN in the uprn parameter.",
         "LAD24CD": "E07000139"
     },
     "NorthLanarkshireCouncil": {

--- a/uk_bin_collection/uk_bin_collection/councils/NorthKestevenDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/NorthKestevenDistrictCouncil.py
@@ -1,58 +1,53 @@
+import re
+import requests
 from bs4 import BeautifulSoup
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
 
-# import the wonderful Beautiful Soup and the URL grabber
 class CouncilClass(AbstractGetBinDataClass):
-    """
-    Concrete classes have to implement all abstract operations of the
-    base class. They can also override some operations with a default
-    implementation.
-    """
-
     def parse_data(self, page: str, **kwargs) -> dict:
-        # Make a BS4 object
-        soup = BeautifulSoup(page.text, features="html.parser")
-        soup.prettify()
+        uprn = kwargs.get("uprn")
+        check_uprn(uprn)
+
+        url = f"https://www.n-kesteven.org.uk/bins/display?uprn={uprn}"
+        headers = {
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36"
+        }
+        response = requests.get(url, headers=headers, timeout=30)
+        response.raise_for_status()
+
+        soup = BeautifulSoup(response.text, features="html.parser")
 
         data = {"bins": []}
 
-        # Find the bin-dates div
         bin_dates_div = soup.find("div", {"class": "bin-dates"})
         if not bin_dates_div:
             return data
 
-        # Find all list items with bin collection information
         for li in bin_dates_div.find_all("li", {"class": "text-large"}):
-            # Extract bin type from the span tag
             bin_type_span = li.find("span", {"class": "font-weight-bold"})
             if not bin_type_span:
                 continue
-            
+
             bin_type = bin_type_span.get_text(strip=True)
-            
-            # Extract collection date from the strong tag
+
             date_strong = li.find("strong")
             if not date_strong:
                 continue
-            
+
             date_text = date_strong.get_text(strip=True)
-            
+
             try:
-                # Parse date in format "Monday, 2 February 2026"
                 collection_date = datetime.strptime(date_text, "%A, %d %B %Y")
-                
-                # Get the full bin description (e.g., "Black (Residual waste)")
-                # Extract text between bin type and " bin on"
+
                 full_text = li.get_text(strip=True)
-                # Pattern: "Black (Residual waste) bin on Monday, 2 February 2026"
                 match = re.search(rf"{re.escape(bin_type)}\s+(.*?)\s+bin on", full_text)
                 if match:
                     bin_description = match.group(1).strip()
                     if bin_description:
                         bin_type = f"{bin_type} {bin_description}"
-                
+
                 data["bins"].append(
                     {
                         "type": bin_type,
@@ -60,7 +55,6 @@ class CouncilClass(AbstractGetBinDataClass):
                     }
                 )
             except ValueError:
-                # Skip if date parsing fails
                 continue
 
         data["bins"].sort(


### PR DESCRIPTION
The scraper calls page.text but page is a string, not a Response object, so it throws an AttributeError. Switched to making a direct requests.get() with the UPRN embedded in the URL and added skip_get_url + uprn to input.json.

Tested against UPRN 10006545854 (Sleaford area) on 2026-04-30.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated NorthKestevenDistrictCouncil configuration to use a shared endpoint for retrieving bin collection data.
  * Modified data retrieval method to fetch live information directly using UPRN parameter instead of pre-embedded URLs.
  * Updated user documentation to clarify UPRN parameter entry method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->