### PR TITLE
fix: EastRidingCouncil - replace Selenium with direct JSON API

### DIFF
--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -806,10 +806,10 @@
     },
     "EastRidingCouncil": {
         "LAD24CD": "E06000011",
-        "house_number": "14 THE LEASES BEVERLEY HU17 8LG",
+        "house_number": "14",
         "postcode": "HU17 8LG",
         "skip_get_url": true,
-        "url": "https://wasterecyclingapi.eastriding.gov.uk",
+        "url": "https://www.eastriding.gov.uk",
         "web_driver": "http://selenium:4444",
         "wiki_name": "East Riding of Yorkshire",
         "wiki_note": "Put the full address as it displays on the council website dropdown when you do the check manually."

--- a/uk_bin_collection/uk_bin_collection/councils/EastRidingCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/EastRidingCouncil.py
@@ -1,141 +1,119 @@
-import urllib.request
+import requests
 from datetime import datetime
-
-import pandas as pd
-from bs4 import BeautifulSoup
-from selenium.webdriver.common.by import By
-from selenium.webdriver.common.keys import Keys
-from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.support.ui import Select
-from selenium.webdriver.support.wait import WebDriverWait
 
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
 
+# East Riding API returns BlueDate, GreenDate, BrownDate fields.
+# Map to human-readable bin type names.
+BIN_DATE_FIELDS = {
+    "BlueDate": "Blue Bin (Recycling)",
+    "GreenDate": "Green Bin (General Waste)",
+    "BrownDate": "Brown Bin (Garden Waste)",
+}
+
+API_URL = "https://wasterecyclingapi.eastriding.gov.uk/api/RecyclingData/CollectionsData"
+API_KEY = "ekBWR8tSiv6qwMo31REEeTZ5FAiMNB"
+API_LICENSEE = "BinCollectionWebTeam"
+
+
 class CouncilClass(AbstractGetBinDataClass):
-    """
-    Concrete classes have to implement all abstract operations of the base
-    class. They can also override some operations with a default
-    implementation.
-    """
 
     def parse_data(self, page: str, **kwargs) -> dict:
-        driver = None
-        try:
-            user_paon = kwargs.get("paon")
-            user_postcode = kwargs.get("postcode")
-            web_driver = kwargs.get("web_driver")
-            headless = kwargs.get("headless")
+        data = {"bins": []}
 
-            # Create Selenium webdriver
-            page = "https://www.eastriding.gov.uk/environment/bins-rubbish-recycling/bins-and-collections/bin-collection-dates/#"
+        user_postcode = kwargs.get("postcode")
+        user_paon = kwargs.get("paon")
+        check_postcode(user_postcode)
 
-            driver = create_webdriver(web_driver, headless, None, __name__)
-            driver.get(page)
+        # API expects postcode without spaces
+        postcode_clean = user_postcode.replace(" ", "")
 
-            wait = WebDriverWait(driver, 60)
+        params = {
+            "APIKey": API_KEY,
+            "Licensee": API_LICENSEE,
+            "Postcode": postcode_clean,
+        }
 
+        response = requests.get(API_URL, params=params, timeout=30)
+        response.raise_for_status()
+        result = response.json()
+
+        if not result.get("dataRetrieved"):
+            raise ValueError(
+                f"No data returned for postcode {user_postcode}: "
+                f"{result.get('dataMessage', 'unknown error')}"
+            )
+
+        entries = result.get("dataReturned", [])
+        if not entries:
+            raise ValueError(f"No addresses found for postcode {user_postcode}")
+
+        # Match the house number/name against the Address field.
+        # The API provides HouseNameOrder (string, e.g. "14" or a house name)
+        # and Address (full address string like "14 THE LEASES BEVERLEY HU17 8LG").
+        matched = None
+        if user_paon:
+            paon_upper = user_paon.strip().upper()
+            # Try exact match on HouseNameOrder first (most reliable)
+            for entry in entries:
+                house_name = (entry.get("HouseNameOrder") or "").strip().upper()
+                if house_name == paon_upper:
+                    matched = entry
+                    break
+            # Fall back to Address startswith
+            if not matched:
+                for entry in entries:
+                    address = (entry.get("Address") or "").upper()
+                    if address.startswith(paon_upper):
+                        matched = entry
+                        break
+            # Fall back to Address contains
+            if not matched:
+                for entry in entries:
+                    address = (entry.get("Address") or "").upper()
+                    if paon_upper in address:
+                        matched = entry
+                        break
+        else:
+            # No paon provided — if only one result, use it; otherwise fail
+            if len(entries) == 1:
+                matched = entries[0]
+            else:
+                raise ValueError(
+                    f"Multiple addresses found for postcode {user_postcode} "
+                    f"but no house number (paon) provided to disambiguate. "
+                    f"Found {len(entries)} entries."
+                )
+
+        if not matched:
+            available = [e.get("Address", "?") for e in entries]
+            raise ValueError(
+                f"No address matched '{user_paon}' at postcode {user_postcode}. "
+                f"Available: {available}"
+            )
+
+        # Extract bin collection dates from the matched entry
+        for field, bin_type in BIN_DATE_FIELDS.items():
+            date_str = matched.get(field)
+            if not date_str:
+                continue
             try:
-                accept_cookies = wait.until(
-                    EC.element_to_be_clickable(
-                        (By.XPATH, '//*[@id="er-cookie-placeholder-settings"]/div/a[1]')
-                    )
+                collection_date = datetime.strptime(
+                    date_str, "%Y-%m-%dT%H:%M:%S"
                 )
-
-                accept_cookies.click()
-            except:
-                print(
-                    "Cookies acceptance element not found or clickable within the specified time."
+                data["bins"].append(
+                    {
+                        "type": bin_type,
+                        "collectionDate": collection_date.strftime(date_format),
+                    }
                 )
-                pass
+            except (ValueError, TypeError):
+                continue
 
-            expand_postcode_box = wait.until(
-                EC.element_to_be_clickable(
-                    (By.XPATH, '//a[contains(text(), "Open all")]')
-                )
-            )
+        data["bins"].sort(
+            key=lambda x: datetime.strptime(x.get("collectionDate"), date_format)
+        )
 
-            expand_postcode_box.click()
-
-            postcode_box = wait.until(
-                EC.element_to_be_clickable(
-                    (By.XPATH, "//input[@placeholder='Enter your postcode']")
-                )
-            )
-            postcode_box.send_keys(user_postcode)
-
-            postcode_search_btn = wait.until(
-                EC.element_to_be_clickable((By.XPATH, "//button[text()='Search']"))
-            )
-            postcode_search_btn.send_keys(Keys.ENTER)
-
-            dropdown = wait.until(
-                EC.presence_of_element_located(
-                    (
-                        By.XPATH,
-                        "//div[@class='er-select-wrapper']/select[@class='dropdown']",
-                    )
-                )
-            )
-
-            options_present = wait.until(
-                EC.presence_of_all_elements_located(
-                    (By.CSS_SELECTOR, "select.dropdown option")
-                )
-            )
-            drop = Select(dropdown)
-            drop.select_by_visible_text(str(user_paon))
-
-            results_present = wait.until(
-                EC.presence_of_element_located(
-                    (
-                        By.CLASS_NAME,
-                        "results",
-                    )
-                )
-            )
-
-            data = {"bins": []}  # dictionary for data
-            soup = BeautifulSoup(driver.page_source, "html.parser")
-
-            bin_types = {}  # Dictionary to store bin types
-
-            # Extract bin types from header elements
-            header_elements = soup.find_all(
-                "li", class_=lambda x: x and x.startswith("header")
-            )
-            for header_element in header_elements:
-                bin_type = header_element.get_text(strip=True)
-                bin_class = [
-                    cls for cls in header_element.get("class") if cls != "header"
-                ]
-                if bin_class:
-                    bin_types[bin_class[0]] = bin_type
-
-            # Extract collection dates and associate them with respective bin types
-            date_elements = soup.find_all(
-                "li", class_=lambda x: x and x.startswith("date")
-            )
-            for date_element in date_elements:
-                bin_class = [cls for cls in date_element.get("class") if cls != "date"]
-                if bin_class:
-                    bin_type = bin_types.get(bin_class[0])
-                    span_text = date_element.find("span").get_text(strip=True)
-                    collection_date = datetime.strptime(span_text, "%a, %d %b %Y")
-                    data["bins"].append(
-                        {
-                            "type": bin_type,
-                            "collectionDate": collection_date.strftime(date_format),
-                        }
-                    )
-        except Exception as e:
-            # Here you can log the exception if needed
-            print(f"An error occurred: {e}")
-            # Optionally, re-raise the exception if you want it to propagate
-            raise
-        finally:
-            # This block ensures that the driver is closed regardless of an exception
-            if driver:
-                driver.quit()
         return data


### PR DESCRIPTION
Replaces the Selenium-based dropdown scraper with a direct call to the council's public JSON API.

**Problem:** The old scraper required the exact full address string (e.g. `14 THE LEASES BEVERLEY HU17 8LG`) in the `paon` parameter for `select_by_visible_text()`. Any mismatch in formatting caused failures.

**Fix:** Calls `wasterecyclingapi.eastriding.gov.uk/api/RecyclingData/CollectionsData` directly with the postcode, then matches by house number against the `HouseNameOrder` field. Three-tier matching: exact HouseNameOrder, Address startswith, Address contains.

**Changes:**
- `EastRidingCouncil.py` — full rewrite, requests-only (no Selenium)
- `input.json` — updated to use `house_number` + `postcode` (was `paon` with full address)

**Testing:** Verified with HU17 8LG (14 The Leases) — returns 3 bins (Blue, Green, Brown).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Bin collection schedule retrieval system has been completely reimplemented to use direct API integration instead of web scraping, delivering improvements in reliability, data retrieval speed, error handling, and overall system stability.

* **Tests**
  * Test configuration updated to align with new API endpoint specifications and revised address field format requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->