### PR TITLE
fix: EdinburghCityCouncil - accept real postcode + house number

### DIFF
--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -850,8 +850,8 @@
     },
     "EdinburghCityCouncil": {
         "LAD24CD": "S12000036",
-        "house_number": "Tuesday",
-        "postcode": "Week 1",
+        "house_number": "157",
+        "postcode": "EH10 4AX",
         "skip_get_url": true,
         "url": "https://www.edinburgh.gov.uk",
         "wiki_name": "City of Edinburgh",

--- a/uk_bin_collection/uk_bin_collection/councils/EdinburghCityCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/EdinburghCityCouncil.py
@@ -1,112 +1,193 @@
 import re
-import time
-
 import requests
 from bs4 import BeautifulSoup
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.support.ui import Select
-from selenium.webdriver.support.wait import WebDriverWait
 
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
+DIRECTORY_SEARCH = "https://www.edinburgh.gov.uk/directory/search"
+DIRECTORY_RECORD = "https://www.edinburgh.gov.uk/directory-record"
+NOMINATIM_URL = "https://nominatim.openstreetmap.org/search"
 
-# import the wonderful Beautiful Soup and the URL grabber
+HEADERS = {
+    "User-Agent": "UKBinCollectionData/1.0 (+https://github.com/robbrad/UKBinCollectionData)"
+}
+
+CALENDAR_CODES = {
+    "Mon": "Monday", "Tue": "Tuesday", "Wed": "Wednesday",
+    "Thu": "Thursday", "Fri": "Friday", "Sat": "Saturday", "Sun": "Sunday",
+}
+
+
+def _extract_street_from_paon(paon):
+    """Extract street name from paon if it contains more than just a number.
+    Handles formats like '157 Morningside Road' or 'Morningside Road'."""
+    if not paon:
+        return None
+    stripped = re.sub(r"^\d+[a-zA-Z]?\s+", "", paon.strip())
+    if stripped and stripped != paon.strip():
+        return stripped
+    if not paon.strip()[0].isdigit():
+        return paon.strip()
+    return None
+
+
+def _resolve_street(postcode, paon):
+    """Get street name from paon string or via postcode geocode + Nominatim reverse."""
+    street = _extract_street_from_paon(paon)
+    if street:
+        return street
+    # Use postcodes.io to get lat/lng, then Nominatim reverse to get street
+    try:
+        pc_clean = postcode.replace(" ", "")
+        pc_resp = requests.get(
+            f"https://api.postcodes.io/postcodes/{pc_clean}",
+            headers=HEADERS, timeout=10,
+        )
+        if pc_resp.status_code == 200:
+            pc_data = pc_resp.json()
+            if pc_data.get("status") == 200 and pc_data.get("result"):
+                lat = pc_data["result"]["latitude"]
+                lng = pc_data["result"]["longitude"]
+                rev_resp = requests.get(
+                    NOMINATIM_URL.replace("/search", "/reverse"),
+                    params={"lat": lat, "lon": lng, "format": "json", "addressdetails": 1},
+                    headers=HEADERS, timeout=10,
+                )
+                if rev_resp.status_code == 200:
+                    addr = rev_resp.json().get("address", {})
+                    road = addr.get("road") or addr.get("street")
+                    if road:
+                        return road
+    except Exception:
+        pass
+    return None
+
+
+def _search_directory(street_name):
+    """Search Edinburgh's waste collection directory for a street name.
+    Returns list of (record_url, record_title) tuples."""
+    params = {"directoryID": "10251", "keywords": street_name}
+    resp = requests.get(DIRECTORY_SEARCH, params=params, headers=HEADERS, timeout=15)
+    resp.raise_for_status()
+    soup = BeautifulSoup(resp.text, "html.parser")
+    results = []
+    for link in soup.select("a.list__link"):
+        href = link.get("href", "")
+        if "/directory-record/" in href:
+            title = link.get_text(strip=True)
+            if not href.startswith("http"):
+                href = "https://www.edinburgh.gov.uk" + href
+            results.append((href, title))
+    return results
+
+
+def _get_calendar_code(record_url):
+    """Fetch a directory record page and extract the calendar code."""
+    resp = requests.get(record_url, headers=HEADERS, timeout=15)
+    resp.raise_for_status()
+    soup = BeautifulSoup(resp.text, "html.parser")
+    dts = soup.find_all("dt")
+    for dt in dts:
+        if "calendar code" in dt.get_text(strip=True).lower():
+            dd = dt.find_next_sibling("dd")
+            if dd:
+                return dd.get_text(strip=True)
+    return None
+
+
+def _parse_calendar_code(code):
+    """Parse a calendar code like 'Tue_2' into (day_name, week_index).
+    Returns (day_name, week_index) where week_index is 0-based."""
+    m = re.match(r"(Mon|Tue|Wed|Thu|Fri|Sat|Sun)_(\d)", code)
+    if not m:
+        return None, None
+    day_abbr = m.group(1)
+    week_num = int(m.group(2))
+    day_name = CALENDAR_CODES.get(day_abbr)
+    return day_name, week_num - 1
+
+
 class CouncilClass(AbstractGetBinDataClass):
-    """
-    Concrete classes have to implement all abstract operations of the
-    base class. They can also override some operations with a default
-    implementation.
-    """
 
     def parse_data(self, page: str, **kwargs) -> dict:
+        user_postcode = kwargs.get("postcode")
+        user_paon = kwargs.get("paon")
+        check_postcode(user_postcode)
 
-        """
-        Produce scheduled bin collection entries for a property based on a reference weekday and fortnightly rota.
-        
-        Parameters:
-            page (str): The page content passed to the parser (not used for scheduling).
-            paon (str, in kwargs): The reference weekday name (e.g., "Monday") representing the property's collection day.
-            postcode (str, in kwargs): The collection week label, either "Week 1" or "Week 2", used to select rota start dates.
-        
-        Returns:
-            dict: A mapping with a single key "bins" whose value is a list of collection entries.
-                Each entry is a dict with:
-                    - "type" (str): Bin type name ("Grey Bin", "Green Bin", or "Glass Box").
-                    - "collectionDate" (str): Collection date in "DD/MM/YYYY" format.
-        """
-        collection_day = kwargs.get("paon")
-        collection_week = kwargs.get("postcode")
-        bindata = {"bins": []}
+        street_name = _resolve_street(user_postcode, user_paon)
+        if not street_name:
+            raise ValueError(
+                f"Could not resolve street name for {user_paon}, {user_postcode}"
+            )
+
+        records = _search_directory(street_name)
+        if not records:
+            raise ValueError(
+                f"No Edinburgh collection records found for street '{street_name}'"
+            )
+
+        # If multiple results, prefer exact match on street name
+        best_url = records[0][0]
+        street_upper = street_name.upper()
+        for url, title in records:
+            if title.upper() == street_upper:
+                best_url = url
+                break
+
+        calendar_code = _get_calendar_code(best_url)
+        if not calendar_code:
+            raise ValueError(
+                f"No calendar code found for '{street_name}' at {best_url}"
+            )
+
+        day_name, week_index = _parse_calendar_code(calendar_code)
+        if not day_name:
+            raise ValueError(f"Could not parse calendar code '{calendar_code}'")
 
         days_of_week = [
-            "Monday",
-            "Tuesday",
-            "Wednesday",
-            "Thursday",
-            "Friday",
-            "Saturday",
-            "Sunday",
+            "Monday", "Tuesday", "Wednesday", "Thursday",
+            "Friday", "Saturday", "Sunday",
         ]
+        offset_days = days_of_week.index(day_name)
 
-        collection_weeks = ["Week 1", "Week 2"]
-        collection_week = collection_weeks.index(collection_week)
+        if week_index == 0:
+            recycling_start = datetime(2025, 11, 3)
+            glass_start = datetime(2025, 11, 3)
+            refuse_start = datetime(2025, 11, 10)
+        else:
+            recycling_start = datetime(2025, 11, 10)
+            glass_start = datetime(2025, 11, 10)
+            refuse_start = datetime(2025, 11, 3)
 
-        offset_days = days_of_week.index(collection_day)
+        bindata = {"bins": []}
 
-        if collection_week == 0:
-            recyclingstartDate = datetime(2025, 11, 3)
-            glassstartDate = datetime(2025, 11, 3)
-            refusestartDate = datetime(2025, 11, 10)
-        elif collection_week == 1:
-            recyclingstartDate = datetime(2025, 11, 10)
-            glassstartDate = datetime(2025, 11, 10)
-            refusestartDate = datetime(2025, 11, 3)
-
-        refuse_dates = get_dates_every_x_days(refusestartDate, 14, 28)
-        glass_dates = get_dates_every_x_days(glassstartDate, 14, 28)
-        recycling_dates = get_dates_every_x_days(recyclingstartDate, 14, 28)
-
-        for refuseDate in refuse_dates:
-
+        for base_date in get_dates_every_x_days(refuse_start, 14, 28):
             collection_date = (
-                datetime.strptime(refuseDate, "%d/%m/%Y") + timedelta(days=offset_days)
-            ).strftime("%d/%m/%Y")
+                datetime.strptime(base_date, "%d/%m/%Y") + timedelta(days=offset_days)
+            ).strftime(date_format)
+            bindata["bins"].append(
+                {"type": "Grey Bin", "collectionDate": collection_date}
+            )
 
-            dict_data = {
-                "type": "Grey Bin",
-                "collectionDate": collection_date,
-            }
-            bindata["bins"].append(dict_data)
-
-        for recyclingDate in recycling_dates:
-
+        for base_date in get_dates_every_x_days(recycling_start, 14, 28):
             collection_date = (
-                datetime.strptime(recyclingDate, "%d/%m/%Y")
-                + timedelta(days=offset_days)
-            ).strftime("%d/%m/%Y")
+                datetime.strptime(base_date, "%d/%m/%Y") + timedelta(days=offset_days)
+            ).strftime(date_format)
+            bindata["bins"].append(
+                {"type": "Green Bin", "collectionDate": collection_date}
+            )
 
-            dict_data = {
-                "type": "Green Bin",
-                "collectionDate": collection_date,
-            }
-            bindata["bins"].append(dict_data)
-
-        for glassDate in glass_dates:
-
+        for base_date in get_dates_every_x_days(glass_start, 14, 28):
             collection_date = (
-                datetime.strptime(glassDate, "%d/%m/%Y") + timedelta(days=offset_days)
-            ).strftime("%d/%m/%Y")
-
-            dict_data = {
-                "type": "Glass Box",
-                "collectionDate": collection_date,
-            }
-            bindata["bins"].append(dict_data)
+                datetime.strptime(base_date, "%d/%m/%Y") + timedelta(days=offset_days)
+            ).strftime(date_format)
+            bindata["bins"].append(
+                {"type": "Glass Box", "collectionDate": collection_date}
+            )
 
         bindata["bins"].sort(
-            key=lambda x: datetime.strptime(x.get("collectionDate"), "%d/%m/%Y")
+            key=lambda x: datetime.strptime(x.get("collectionDate"), date_format)
         )
 
         return bindata


### PR DESCRIPTION
Replaces the magic-token date calculator with a real address-based lookup.

**Problem:** The old scraper required `paon="Tuesday"` and `postcode="Week 1"` — users had to already know their collection schedule code. Unusable for any system that passes real addresses.

**Fix:** Resolves the street name from postcode via postcodes.io + Nominatim reverse geocoding, then searches Edinburgh's waste collection directory at `/directory/10251/` for the street, extracts the calendar code (e.g. `Tue_2`), and calculates dates using the same fortnightly rota logic.

**Changes:**
- `EdinburghCityCouncil.py` — full rewrite with street lookup
- `input.json` — updated to use real `postcode` + `house_number` (was magic tokens)

**Testing:** Verified with EH10 4AX / 157 (Morningside Road) — returns 84 bins (Grey, Green, Glass across 28 weeks).