### PR TITLE
fix: UttlesfordDistrictCouncil - house number prefix match in dropdown

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/UttlesfordDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/UttlesfordDistrictCouncil.py
@@ -63,7 +63,24 @@ class CouncilClass(AbstractGetBinDataClass):
             logging.info("Selecting address")
             drop_down_values = Select(input_element_postcode_dd)
 
-            drop_down_values.select_by_visible_text(str(user_paon))
+            # Try exact match first, fall back to house number prefix match
+            matched = False
+            try:
+                drop_down_values.select_by_visible_text(str(user_paon))
+                matched = True
+            except Exception:
+                paon_lower = str(user_paon).strip().lower()
+                for option in drop_down_values.options:
+                    text = option.text.strip().lower()
+                    if text and paon_lower and (text.startswith(paon_lower + " ") or text.startswith(paon_lower + ",") or text == paon_lower):
+                        option.click()
+                        matched = True
+                        break
+
+            if not matched:
+                raise ValueError(
+                    f"Address '{user_paon}' not found in dropdown"
+                )
 
             input_element_address_btn = wait.until(
                 EC.element_to_be_clickable(


### PR DESCRIPTION
`select_by_visible_text` fails when the dropdown text includes the street name (e.g. "72, Birchanger Lane") but only the house number is provided as paon.

Now tries exact match first, then iterates options matching by house number prefix (handles "72," and "72 " patterns).

**Testing:** Verified with CM23 5QF / 72 — returns 12 bins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved address selection matching to support case-insensitive searches and prefix-style matching
  * Enhanced error handling with clearer feedback when addresses cannot be found in available options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->