### PR TITLE
fix: StirlingCouncil - resolve street from postcode for Recollect lookup

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/StirlingCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/StirlingCouncil.py
@@ -1,8 +1,75 @@
+import re
 import requests
 from datetime import datetime, timedelta
 
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
+
+NOMINATIM_URL = "https://nominatim.openstreetmap.org"
+HEADERS = {
+    "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+}
+
+
+def _extract_street_from_paon(paon):
+    if not paon:
+        return None
+    stripped = re.sub(r"^\d+[a-zA-Z]?\s+", "", paon.strip())
+    if stripped and stripped != paon.strip():
+        return stripped
+    if not paon.strip()[0].isdigit():
+        return paon.strip()
+    return None
+
+
+def _build_queries(paon, postcode):
+    """Build search queries from most specific to least."""
+    queries = []
+    if paon:
+        street = _extract_street_from_paon(paon)
+        if street:
+            num_match = re.match(r"^(\d+[a-zA-Z]?)\b", paon.strip())
+            if num_match:
+                queries.append(f"{num_match.group(1)} {street}")
+        queries.append(paon)
+        parts = [p.strip() for p in paon.split(",")]
+        if len(parts) >= 2:
+            queries.append(f"{parts[0]} {parts[1]}")
+        if len(parts) >= 1:
+            queries.append(parts[0])
+
+    if postcode:
+        try:
+            pc_clean = postcode.replace(" ", "")
+            pc_resp = requests.get(
+                f"https://api.postcodes.io/postcodes/{pc_clean}",
+                headers=HEADERS, timeout=10,
+            )
+            if pc_resp.status_code == 200:
+                pc_data = pc_resp.json()
+                if pc_data.get("status") == 200 and pc_data.get("result"):
+                    lat = pc_data["result"]["latitude"]
+                    lng = pc_data["result"]["longitude"]
+                    rev_resp = requests.get(
+                        f"{NOMINATIM_URL}/reverse",
+                        params={"lat": lat, "lon": lng, "format": "json", "addressdetails": 1},
+                        headers=HEADERS, timeout=10,
+                    )
+                    if rev_resp.status_code == 200:
+                        addr = rev_resp.json().get("address", {})
+                        road = addr.get("road") or addr.get("street")
+                        if road and paon:
+                            num = re.match(r"^(\d+[a-zA-Z]?)\b", paon.strip())
+                            if num:
+                                queries.append(f"{num.group(1)} {road}")
+                        if road:
+                            queries.append(road)
+        except Exception:
+            pass
+
+        queries.append(postcode)
+
+    return queries
 
 
 class CouncilClass(AbstractGetBinDataClass):
@@ -13,33 +80,16 @@ class CouncilClass(AbstractGetBinDataClass):
         user_paon = kwargs.get("paon")
         postcode = kwargs.get("postcode")
 
-        headers = {
-            "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
-        }
-
         suggest_url = (
             "https://api.eu.recollect.net/api/areas/StirlingUK/services/waste/address-suggest"
         )
 
-        # Build search queries to try, from most specific to least
-        queries = []
-        if user_paon:
-            # Full address like "5, SUNNYLAW ROAD, BRIDGE OF ALLAN, STIRLING, FK9 4QA"
-            # Try the full thing first
-            queries.append(user_paon)
-            # Then try just number + street (first two comma parts)
-            parts = [p.strip() for p in user_paon.split(",")]
-            if len(parts) >= 2:
-                queries.append(f"{parts[0]} {parts[1]}")
-            if len(parts) >= 1:
-                queries.append(parts[0])
-        if postcode:
-            queries.append(postcode)
+        queries = _build_queries(user_paon, postcode)
 
         place_id = None
         for query in queries:
             params = {"q": query, "locale": "en-GB"}
-            response = requests.get(suggest_url, headers=headers, params=params, timeout=30)
+            response = requests.get(suggest_url, headers=HEADERS, params=params, timeout=30)
             response.raise_for_status()
             results = response.json()
 
@@ -56,7 +106,6 @@ class CouncilClass(AbstractGetBinDataClass):
                 f"Tried queries: {queries}"
             )
 
-        # Get collection events from the Recollect API
         now = datetime.now()
         after = now.strftime("%Y-%m-%d")
         before = (now + timedelta(days=60)).strftime("%Y-%m-%d")
@@ -71,7 +120,7 @@ class CouncilClass(AbstractGetBinDataClass):
             "locale": "en-GB",
             "place_id": place_id,
         }
-        response = requests.get(events_url, headers=headers, params=params, timeout=30)
+        response = requests.get(events_url, headers=HEADERS, params=params, timeout=30)
         response.raise_for_status()
         events_data = response.json()
 


### PR DESCRIPTION
The Recollect address-suggest API needs a street name to find a specific property, but callers often only have a house number + postcode. The scraper now resolves the street name via postcodes.io + Nominatim reverse geocoding when paon contains only a house number, then builds search queries combining the number with the resolved street.

**Testing:** Verified with FK9 4QA / 5 (Sunnylaw Road) — returns 168 bins.