### PR TITLE
May 2026 Release

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/BroxtoweBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/BroxtoweBoroughCouncil.py
@@ -48,15 +48,37 @@ class CouncilClass(AbstractGetBinDataClass):
                 "ctl00_ContentPlaceHolder1_FF5683BTN",
             ).click()
 
-            # Wait for the 'Select address' dropdown to appear and select option matching UPRN
+            # Wait for the 'Select address' dropdown to appear
             dropdown = WebDriverWait(driver, 10).until(
                 EC.presence_of_element_located(
                     (By.ID, "ctl00_ContentPlaceHolder1_FF5683DDL")
                 )
             )
-            # Create a 'Select' for it, then select the matching URPN option
             dropdownSelect = Select(dropdown)
-            dropdownSelect.select_by_value("U" + user_uprn)
+
+            # Try UPRN value match first, fall back to house number text match
+            matched = False
+            if user_uprn:
+                try:
+                    dropdownSelect.select_by_value("U" + user_uprn)
+                    matched = True
+                except Exception:
+                    pass
+
+            if not matched:
+                user_paon = kwargs.get("paon") or ""
+                paon_lower = user_paon.strip().lower()
+                for option in dropdownSelect.options:
+                    text = option.text.strip().lower()
+                    if text and paon_lower and (text.startswith(paon_lower + " ") or text.startswith(paon_lower + ",")):
+                        option.click()
+                        matched = True
+                        break
+
+            if not matched:
+                raise ValueError(
+                    f"Address not found for UPRN '{user_uprn}' or house number in dropdown"
+                )
 
             # Wait for the submit button to appear, then click it to get the collection dates
             submit = WebDriverWait(driver, 10).until(

--- a/uk_bin_collection/uk_bin_collection/councils/StirlingCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/StirlingCouncil.py
@@ -1,8 +1,75 @@
+import re
 import requests
 from datetime import datetime, timedelta
 
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
+
+NOMINATIM_URL = "https://nominatim.openstreetmap.org"
+HEADERS = {
+    "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+}
+
+
+def _extract_street_from_paon(paon):
+    if not paon:
+        return None
+    stripped = re.sub(r"^\d+[a-zA-Z]?\s+", "", paon.strip())
+    if stripped and stripped != paon.strip():
+        return stripped
+    if not paon.strip()[0].isdigit():
+        return paon.strip()
+    return None
+
+
+def _build_queries(paon, postcode):
+    """Build search queries from most specific to least."""
+    queries = []
+    if paon:
+        street = _extract_street_from_paon(paon)
+        if street:
+            num_match = re.match(r"^(\d+[a-zA-Z]?)\b", paon.strip())
+            if num_match:
+                queries.append(f"{num_match.group(1)} {street}")
+        queries.append(paon)
+        parts = [p.strip() for p in paon.split(",")]
+        if len(parts) >= 2:
+            queries.append(f"{parts[0]} {parts[1]}")
+        if len(parts) >= 1:
+            queries.append(parts[0])
+
+    if postcode:
+        try:
+            pc_clean = postcode.replace(" ", "")
+            pc_resp = requests.get(
+                f"https://api.postcodes.io/postcodes/{pc_clean}",
+                headers=HEADERS, timeout=10,
+            )
+            if pc_resp.status_code == 200:
+                pc_data = pc_resp.json()
+                if pc_data.get("status") == 200 and pc_data.get("result"):
+                    lat = pc_data["result"]["latitude"]
+                    lng = pc_data["result"]["longitude"]
+                    rev_resp = requests.get(
+                        f"{NOMINATIM_URL}/reverse",
+                        params={"lat": lat, "lon": lng, "format": "json", "addressdetails": 1},
+                        headers=HEADERS, timeout=10,
+                    )
+                    if rev_resp.status_code == 200:
+                        addr = rev_resp.json().get("address", {})
+                        road = addr.get("road") or addr.get("street")
+                        if road and paon:
+                            num = re.match(r"^(\d+[a-zA-Z]?)\b", paon.strip())
+                            if num:
+                                queries.append(f"{num.group(1)} {road}")
+                        if road:
+                            queries.append(road)
+        except Exception:
+            pass
+
+        queries.append(postcode)
+
+    return queries
 
 
 class CouncilClass(AbstractGetBinDataClass):
@@ -13,33 +80,16 @@ class CouncilClass(AbstractGetBinDataClass):
         user_paon = kwargs.get("paon")
         postcode = kwargs.get("postcode")
 
-        headers = {
-            "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
-        }
-
         suggest_url = (
             "https://api.eu.recollect.net/api/areas/StirlingUK/services/waste/address-suggest"
         )
 
-        # Build search queries to try, from most specific to least
-        queries = []
-        if user_paon:
-            # Full address like "5, SUNNYLAW ROAD, BRIDGE OF ALLAN, STIRLING, FK9 4QA"
-            # Try the full thing first
-            queries.append(user_paon)
-            # Then try just number + street (first two comma parts)
-            parts = [p.strip() for p in user_paon.split(",")]
-            if len(parts) >= 2:
-                queries.append(f"{parts[0]} {parts[1]}")
-            if len(parts) >= 1:
-                queries.append(parts[0])
-        if postcode:
-            queries.append(postcode)
+        queries = _build_queries(user_paon, postcode)
 
         place_id = None
         for query in queries:
             params = {"q": query, "locale": "en-GB"}
-            response = requests.get(suggest_url, headers=headers, params=params, timeout=30)
+            response = requests.get(suggest_url, headers=HEADERS, params=params, timeout=30)
             response.raise_for_status()
             results = response.json()
 
@@ -56,7 +106,6 @@ class CouncilClass(AbstractGetBinDataClass):
                 f"Tried queries: {queries}"
             )
 
-        # Get collection events from the Recollect API
         now = datetime.now()
         after = now.strftime("%Y-%m-%d")
         before = (now + timedelta(days=60)).strftime("%Y-%m-%d")
@@ -71,7 +120,7 @@ class CouncilClass(AbstractGetBinDataClass):
             "locale": "en-GB",
             "place_id": place_id,
         }
-        response = requests.get(events_url, headers=headers, params=params, timeout=30)
+        response = requests.get(events_url, headers=HEADERS, params=params, timeout=30)
         response.raise_for_status()
         events_data = response.json()
 

--- a/uk_bin_collection/uk_bin_collection/councils/UttlesfordDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/UttlesfordDistrictCouncil.py
@@ -63,7 +63,24 @@ class CouncilClass(AbstractGetBinDataClass):
             logging.info("Selecting address")
             drop_down_values = Select(input_element_postcode_dd)
 
-            drop_down_values.select_by_visible_text(str(user_paon))
+            # Try exact match first, fall back to house number prefix match
+            matched = False
+            try:
+                drop_down_values.select_by_visible_text(str(user_paon))
+                matched = True
+            except Exception:
+                paon_lower = str(user_paon).strip().lower()
+                for option in drop_down_values.options:
+                    text = option.text.strip().lower()
+                    if text and paon_lower and (text.startswith(paon_lower + " ") or text.startswith(paon_lower + ",") or text == paon_lower):
+                        option.click()
+                        matched = True
+                        break
+
+            if not matched:
+                raise ValueError(
+                    f"Address '{user_paon}' not found in dropdown"
+                )
 
             input_element_address_btn = wait.until(
                 EC.element_to_be_clickable(


### PR DESCRIPTION
## May 2026 Release — 63 PRs Consolidated

All open PRs merged into a single release branch with merge conflicts resolved.

### Council Fixes (56 PRs)

| PR | Council(s) | Change |
|----|-----------|--------|
| #1899 | Babergh, MidSuffolk, Rother, Wirral | Date parsing, null handling, input.json |
| #1909 | EastSuffolk | Fix collection parsing |
| #1916 | Southampton | Include food waste collections |
| #1918 | Blaby | Add User-Agent header (403 fix) |
| #1919 | Brent | Add User-Agent header |
| #1920 | Swale | Add user_agent to webdriver |
| #1921 | SouthHams | Init fcc_session_token before try |
| #1922 | Oxford | Handle multiple editor divs |
| #1923 | ReigateAndBanstead | Select populated span |
| #1924 | Shropshire | Use full link text for bin type |
| #1925 | Salford | Use lxml parser for malformed HTML |
| #1926 | Rushmoor | Handle raw JSON response |
| #1927 | Plymouth | Fix garden collection |
| #1929 | Crawley | Add XML response parsing fallback |
| #1930 | Newham | Updated card selectors, date format fallback |
| #1932 | Torridge | Parse new relative-date SOAP format |
| #1933 | Peterborough | user_agent and container selector |
| #1934 | Horsham | user_agent and postcode ID selector |
| #1935 | API server | Fix double-encoded JSON string |
| #1936 | NeathPortTalbot | user_agent and JS click for overlay |
| #1937 | Bexley | Replace Selenium with requests |
| #1938 | Stirling | Replace Selenium with Recollect API |
| #1939 | WindsorAndMaidenhead | Replace Selenium with requests |
| #1940 | EppingForest | Replace Selenium with ArcGIS REST API |
| #1941 | Moray | Rewrite for annual calendar |
| #1942 | EastLothian | Rewrite for Drupal migration |
| #1943 | Barnet | Rewrite for Jadu migration |
| #1944 | NorthNorfolk | Rewrite for X-Forms |
| #1947 | 63 councils | Add realistic user_agent to all Selenium scrapers |
| #1948 | Richmond | Rewrite for My Richmond page |
| #1949 | NorthYorkshire | Find HTML data dynamically in AJAX |
| #1950 | GreatYarmouth | Use current year instead of hardcoded 2025 |
| #1952 | Wyre | Skip non-bin divs, harden date parsing |
| #1953 | Chichester | Rewrite for AchieveForms V7 |
| #1954 | StocktonOnTees | Update form IDs to V2, dismiss cookie banner |
| #1955 | WestSuffolk | Send User-Agent header |
| #1956 | Midlothian | Rewrite for MyMidlothian Granicus |
| #1957 | SouthStaffordshire | Use objectId query param |
| #1958 | Chorley, Islington, Medway, Hastings, Conwy | Reliability sweep |
| #1971 | Tewkesbury | Handle new API response format |
| #1972 | Boston | Drive chosen.js widget |
| #1973 | Chelmsford | Dismiss email-signup modal |
| #1974 | ArmaghBanbridgeCraigavon | Full browser User-Agent for WAF |
| #1975 | NorthHertfordshire | Migrate to Netcall Liberty Create |
| #1978 | WestSuffolk | User-Agent and renamed h4 heading |
| #1979 | EnvironmentFirst, Eastbourne, Lewes | Handle restructured page |
| #1980 | MidSussex | Migrate to Whitespace portal |
| #1981 | Rotherham | Rewrite for Imactivate API |
| #1983 | SouthOxfordshire | Session establishment and bin type cleanup |
| #1984 | Chelmsford | Replace Selenium with requests |
| #1985 | MidSuffolk | Replace sleep with WebDriverWait |
| #1987 | NorthKesteven | Make own HTTP request |
| #1988 | Fareham | Switch to calendar page |
| #1989 | EastRiding | Replace Selenium with JSON API |
| #1990 | Edinburgh | Accept real postcode and house number |
| #1991 | Thurrock | Accept real postcode and house number |
| #1993 | Broxtowe | Fall back to house number text match |
| #1994 | Uttlesford | House number prefix match in dropdown |
| #1995 | Stirling | Resolve street from postcode for Recollect |

### Bug Fixes

- Fixed server.py indentation bug from PR #1935 merge
- Fixed ThanetDistrictCouncil and StaffordshireMoorlandsDistrictCouncil indentation errors from PR #1947 merge

### Dependencies (4 PRs)

| PR | Change |
|----|--------|
| #1963 | Bump pillow 12.1.1 to 12.2.0 |
| #1967 | Bump mako 1.3.10 to 1.3.11 |
| #1976 | Bump python-dotenv 1.1.0 to 1.2.2 |
| #1977 | Bump lxml 5.3.2 to 6.1.0 |

### Issues Resolved (23)

Closes #1555, #1616, #1725, #1768, #1804, #1806, #1889, #1890, #1893, #1902, #1904, #1906, #1908, #1910, #1911, #1914, #1931, #1946, #1951, #1962, #1966, #1970, #1982

### Code Review Notes

- No malicious code found
- No eval/exec/subprocess/os.system calls added
- No hardcoded credentials or API keys
- All 334 council files compile cleanly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved address selection logic with enhanced fallback matching for more reliable lookups
  * Strengthened address search capabilities using smarter query generation and reverse-geocoding
  * Implemented case-insensitive address matching to handle formatting variations
  * Enhanced error handling with clearer feedback when addresses cannot be located

<!-- end of auto-generated comment: release notes by coderabbit.ai -->