### PR TITLE
fix: SwaleBoroughCouncil - handle relative date strings

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/SwaleBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/SwaleBoroughCouncil.py
@@ -8,9 +8,15 @@ from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataC
 
 
 def parse_collection_date(date_string) -> datetime:
+    from datetime import timedelta
+
     now = datetime.now()
-    if date_string == "is due today":
+    normalised = date_string.strip().lower()
+
+    if "today" in normalised:
         return now
+    if "tomorrow" in normalised:
+        return now + timedelta(days=1)
 
     parsed_date = datetime.strptime(date_string, "%A, %d %B").replace(year=now.year)
 


### PR DESCRIPTION
Swale's bin page shows "is due today" or potentially "is due tomorrow" as the collection date text on collection day. The existing parser had an exact-match check (`== "is due today"`) which failed intermittently on case or whitespace variations.

**Changes:**
- Normalise the date string (strip + lowercase) before checking
- Use substring matching (`"today" in normalised`) instead of exact equality
- Added "tomorrow" handling for the day-before case

The scraper was failing intermittently when the cron ran on collection day for the test address, then self-recovering the next day. This makes it reliable regardless of when it runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bin collection date parsing to recognize relative date labels such as "today" and "tomorrow" for more accurate schedule recognition.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robbrad/UKBinCollectionData/pull/2002)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->