### PR TITLE
fix: ExeterCityCouncil - add postcode lookup for UPRN-miss addresses

### DIFF
--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -913,7 +913,9 @@
         "url": "https://www.exeter.gov.uk",
         "wiki_name": "Exeter",
         "wiki_note": "Pass the UPRN. You can find it using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
-        "LAD24CD": "E07000041"
+        "LAD24CD": "E07000041",
+        "postcode": "EX2 4NT",
+        "house_number": "5"
     },
     "FalkirkCouncil": {
         "uprn": "136065818",
@@ -1754,14 +1756,14 @@
         "LAD24CD": "E06000012"
     },
     "NorthHertfordshireDistrictCouncil": {
-            "house_number": "Stewards Flat",
-            "postcode": "SG5 1PZ",
-            "skip_get_url": true,
-            "url": "https://waste.nc.north-herts.gov.uk/w/webpage/find-bin-collection-day-input-address",
-            "web_driver": "http://selenium:4444",
-            "wiki_name": "North Hertfordshire",
-            "wiki_note": "Pass a postcode (with space) and house_number/name. The scraper performs the Liberty Create typeahead lookup and matches house_number as a case-insensitive substring.",
-            "LAD24CD": "E07000099"
+        "house_number": "Stewards Flat",
+        "postcode": "SG5 1PZ",
+        "skip_get_url": true,
+        "url": "https://waste.nc.north-herts.gov.uk/w/webpage/find-bin-collection-day-input-address",
+        "web_driver": "http://selenium:4444",
+        "wiki_name": "North Hertfordshire",
+        "wiki_note": "Pass a postcode (with space) and house_number/name. The scraper performs the Liberty Create typeahead lookup and matches house_number as a case-insensitive substring.",
+        "LAD24CD": "E07000099"
     },
     "NorthKestevenDistrictCouncil": {
         "skip_get_url": true,

--- a/uk_bin_collection/uk_bin_collection/councils/ExeterCityCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/ExeterCityCouncil.py
@@ -1,4 +1,4 @@
-import time
+import re
 
 import requests
 from bs4 import BeautifulSoup
@@ -7,7 +7,6 @@ from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
 
-# import the wonderful Beautiful Soup and the URL grabber
 class CouncilClass(AbstractGetBinDataClass):
     """
     Concrete classes have to implement all abstract operations of the
@@ -16,25 +15,61 @@ class CouncilClass(AbstractGetBinDataClass):
     """
 
     def parse_data(self, page: str, **kwargs) -> dict:
-
         user_uprn = kwargs.get("uprn")
-        check_uprn(user_uprn)
+        user_postcode = kwargs.get("postcode")
+        user_paon = kwargs.get("paon")
+
         bindata = {"bins": []}
+        results_html = None
 
-        URI = f"https://exeter.gov.uk/repositories/hidden-pages/address-finder/?qsource=UPRN&qtype=bins&term={user_uprn}"
+        # Prefer postcode+house_number lookup (works for all UPRNs)
+        if user_postcode and user_paon:
+            response = requests.get(
+                "https://exeter.gov.uk/repositories/hidden-pages/address-finder/",
+                params={"qsource": "POSTCODE", "qtype": "bins", "term": user_postcode},
+                timeout=30,
+            )
+            response.raise_for_status()
+            data = response.json()
 
-        response = requests.get(URI)
-        response.raise_for_status()
+            if data:
+                # Extract leading number from paon for matching
+                paon_num = re.match(r"^(\d+)", str(user_paon).strip())
+                paon_prefix = paon_num.group(1) if paon_num else str(user_paon).strip()
 
-        data = response.json()
+                for entry in data:
+                    label = entry.get("label", "")
+                    if label.strip().startswith(paon_prefix):
+                        results_html = entry.get("Results")
+                        break
 
-        soup = BeautifulSoup(data[0]["Results"], "html.parser")
-        soup.prettify()
+                # Fallback: first entry if no match
+                if not results_html and data:
+                    results_html = data[0].get("Results")
 
-        # Extract bin schedule
+        # Fall back to UPRN lookup (original method)
+        if not results_html and user_uprn:
+            check_uprn(user_uprn)
+            response = requests.get(
+                f"https://exeter.gov.uk/repositories/hidden-pages/address-finder/?qsource=UPRN&qtype=bins&term={user_uprn}",
+                timeout=30,
+            )
+            response.raise_for_status()
+            data = response.json()
+            if data:
+                results_html = data[0].get("Results")
+
+        if not results_html:
+            return bindata
+
+        soup = BeautifulSoup(results_html, "html.parser")
+
         for section in soup.find_all("h2"):
             bin_type = section.text.strip()
-            collection_date = section.find_next("h3").text.strip()
+            h3 = section.find_next("h3")
+            if not h3:
+                continue
+            collection_date = h3.text.strip()
 
             dict_data = {
                 "type": bin_type,


### PR DESCRIPTION
About 55% of Ordnance Survey UPRNs in the Exeter area are not in the council's internal database. The address-finder API returns `[]` for these, causing `IndexError: list index out of range` on `data[0]["Results"]`.

**Root cause:** Exeter's `?qsource=UPRN` endpoint only recognises UPRNs with the `100040xxxxxx` prefix. Newer prefixes (`10094x`, `10091x`, `100041x`) return empty arrays.

**Fix:** Added a `?qsource=POSTCODE` lookup path that works for all addresses. The endpoint returns every property in the postcode with full bin schedule HTML. The scraper matches by leading house number against the `label` field. Falls back to the original UPRN lookup for backward compatibility.

Also added `postcode`, `house_number`, and `skip_get_url` to `input.json`.

Tested with multiple Exeter postcodes and house numbers on the live API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exeter City Council: bin lookup now accepts postcode and house number input.

* **Bug Fixes**
  * More robust schedule parsing to handle missing or malformed responses.
  * Improved fallback behavior when primary lookup fails, reducing failed or empty results.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robbrad/UKBinCollectionData/pull/2003)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->