### PR TITLE
fix(CarmarthenshireCountyCouncil): guard against empty date strings

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/CarmarthenshireCountyCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/CarmarthenshireCountyCouncil.py
@@ -39,12 +39,20 @@ class CouncilClass(AbstractGetBinDataClass):
             else:
                 continue
 
-            dict_data = {
-                "type": bin_type,
-                "collectionDate": datetime.strptime(
+            if not collection_date:
+                continue
+
+            try:
+                parsed_date = datetime.strptime(
                     collection_date,
                     "%A %d/%m/%Y",
-                ).strftime("%d/%m/%Y"),
+                ).strftime("%d/%m/%Y")
+            except ValueError:
+                continue
+
+            dict_data = {
+                "type": bin_type,
+                "collectionDate": parsed_date,
             }
             bindata["bins"].append(dict_data)
 


### PR DESCRIPTION
Some properties return collection rows with empty date fields, causing `strptime` to crash on empty string vs `%A %d/%m/%Y` format.

**Fix:** Skip entries with empty `collection_date` and wrap the `strptime` call in `try/except ValueError` so malformed dates are gracefully skipped rather than crashing the entire lookup.

Discovered via automated smoke testing against real addresses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced bin collection date parsing to gracefully handle edge cases and invalid date formats, improving overall reliability and preventing parsing failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->