### PR TITLE
fix(FolkestoneandHytheDistrictCouncil): strip leading zeros from UPRN

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/FolkestoneandHytheDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/FolkestoneandHytheDistrictCouncil.py
@@ -17,6 +17,7 @@ class CouncilClass(AbstractGetBinDataClass):
 
         user_uprn = kwargs.get("uprn")
         check_uprn(user_uprn)
+        user_uprn = str(int(user_uprn))  # Strip leading zeros — council API rejects zero-padded UPRNs
         bindata = {"bins": []}
 
         URI1 = f"https://service.folkestone-hythe.gov.uk/webapp/myarea/?uprn={user_uprn}&tab=collections"


### PR DESCRIPTION
The council's `api_collections.php` endpoint returns `400 Bad Request` when the UPRN is zero-padded (e.g. `000050031226` instead of `50031226`).

**Fix:** `str(int(user_uprn))` before building the request URLs, stripping any leading zeros while preserving the numeric value.

Discovered via automated smoke testing — UPRNs are commonly stored zero-padded in databases but this council rejects that format.