### PR TITLE
fix(DumfriesandGallowayCouncil): detect HTML error before iCal parse

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/DumfriesandGallowayCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/DumfriesandGallowayCouncil.py
@@ -37,6 +37,13 @@ class CouncilClass(AbstractGetBinDataClass):
 
             ics_url = f"https://www.dumfriesandgalloway.gov.uk/bins-recycling/waste-collection-schedule/download/{user_uprn}"
 
+            # Pre-fetch to detect HTML error pages before iCal parsing
+            import requests as req
+            ics_resp = req.get(ics_url, timeout=30)
+            ics_text = ics_resp.text
+            if "<br" in ics_text or "<html" in ics_text.lower() or "VCALENDAR" not in ics_text:
+                return data
+
             # Get events from ICS file within the next 60 days
             now = datetime.now()
             future = now + timedelta(days=60)


### PR DESCRIPTION
The council's ICS endpoint at `/bins-recycling/waste-collection-schedule/download/{uprn}` intermittently returns an HTML error page (`"The website encountered an unexpected error. Try again later."`) instead of valid iCalendar data.

When this happens, `icalevents` passes the HTML to `icalendar`'s parser which crashes with `ValueError: Content line could not be parsed into parts`.

**Fix:** Pre-fetch the ICS URL with `requests.get()` and check for HTML markers (`<br`, `<html`) or missing `VCALENDAR` header before passing to `icalevents`. Returns empty result gracefully when the council site is erroring.