### PR TITLE
fix(BlackpoolCouncil): handle null jobsField from Bartec API

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/BlackpoolCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/BlackpoolCouncil.py
@@ -87,6 +87,8 @@ class CouncilClass(AbstractGetBinDataClass):
         bin_collection = response.json()
 
         # Loop through each collection in bin_collection
+        if not bin_collection.get("jobsField"):
+            return bindata
         for collection in bin_collection["jobsField"]:
 
             job = collection["jobField"]


### PR DESCRIPTION
When a UPRN isn't recognised by Blackpool's Bartec system, the PremiseJobs endpoint returns `jobsField` as `null` instead of an empty list. This causes a `TypeError: 'NoneType' object is not iterable` when the scraper tries to iterate.

Added a guard to return empty bins gracefully instead of crashing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved handling of incomplete API responses from Blackpool Council to prevent service disruptions and enhance reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->