### PR TITLE
fix(MiddlesbroughCouncil): initialise place_id before address loop

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/MiddlesbroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/MiddlesbroughCouncil.py
@@ -50,6 +50,7 @@ class CouncilClass(AbstractGetBinDataClass):
             response = requests.get(url, headers=headers, params=params)
 
             addresses = response.json()
+            place_id = None
             for address in addresses:
                 if "place_id" in address:
                     place_id = address["place_id"]


### PR DESCRIPTION
When the Recollect address-suggest API returns no results containing a `place_id` key, the variable is never assigned, causing an `UnboundLocalError` on the subsequent `if not place_id:` check.

Initialised `place_id = None` before the loop so the guard works correctly and the scraper returns gracefully instead of crashing.