### PR TITLE
fix(WestMorlandAndFurness): update CSS class for bin type extraction

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/WestMorlandAndFurness.py
+++ b/uk_bin_collection/uk_bin_collection/councils/WestMorlandAndFurness.py
@@ -44,8 +44,8 @@ class CouncilClass(AbstractGetBinDataClass):
                 collectiondate = datetime.strptime(day, "%d")
                 collectiondate = collectiondate.replace(month=collectionmonth)
                 bintype = collectionday.find(
-                    "span", {"class": "waste-collection__day--colour"}
-                ).text
+                    "span", {"class": "waste-collection__day--type"}
+                ).text.strip()
 
                 if (current_month > 9) and (collectiondate.month < 4):
                     collectiondate = collectiondate.replace(year=(current_year + 1))


### PR DESCRIPTION
## Summary

Westmorland and Furness Council redesigned their bin collection page. The bin type name moved from the `waste-collection__day--colour` span (which is now empty) to a new `waste-collection__day--type` span.

Before this fix, the scraper returns dates correctly but every bin type is an empty string.

## Changes

- Changed CSS selector from `waste-collection__day--colour` to `waste-collection__day--type`
- Added `.strip()` to handle whitespace in the new span element

## Testing

Tested against UPRN `10003956644` (LA8 postcode area). Returns `General Waste`, `Recyclable waste`, and `Garden waste` correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated bin type data extraction for Westmorland and Furness waste collection schedules to improve accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->