### PR TITLE
feat: add Westminster City Council scraper

### DIFF
--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -2715,6 +2715,14 @@
         "wiki_note": "Provide your house name/number in the `house_number` parameter (wrapped in double quotes) and your postcode in the `postcode` parameter.",
         "LAD24CD": "S12000040"
     },
+    "WestminsterCityCouncil": {
+        "skip_get_url": true,
+        "url": "https://transact.westminster.gov.uk/env/streetsearch.aspx",
+        "usrn": "8401095",
+        "wiki_name": "Westminster City Council",
+        "wiki_note": "Provide your street's USRN (Unique Street Reference Number) in the `usrn` parameter. Westminster's lookup is street-based rather than property-based; the USRN is the numeric value behind the street name in the dropdown at https://transact.westminster.gov.uk/env/streetsearch.aspx (e.g. `8401095` for Acacia Road).",
+        "LAD24CD": "E09000033"
+    },
     "WestMorlandAndFurness": {
         "uprn": "100110353478",
         "url": "https://www.westmorlandandfurness.gov.uk/",

--- a/uk_bin_collection/uk_bin_collection/collect_data.py
+++ b/uk_bin_collection/uk_bin_collection/collect_data.py
@@ -56,6 +56,9 @@ class UKBinCollectionApp:
             "-u", "--uprn", type=str, help="UPRN to parse", required=False
         )
         self.parser.add_argument(
+            "-us", "--usrn", type=str, help="USRN to parse", required=False
+        )
+        self.parser.add_argument(
             "-w",
             "--web_driver",
             type=str,
@@ -104,6 +107,7 @@ class UKBinCollectionApp:
             postcode=self.parsed_args.postcode,
             paon=self.parsed_args.number,
             uprn=self.parsed_args.uprn,
+            usrn=self.parsed_args.usrn,
             skip_get_url=self.parsed_args.skip_get_url,
             web_driver=self.parsed_args.web_driver,
             headless=self.parsed_args.headless,

--- a/uk_bin_collection/uk_bin_collection/councils/WestminsterCityCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/WestminsterCityCouncil.py
@@ -1,0 +1,169 @@
+import logging
+import re
+from datetime import datetime, timedelta
+
+import requests
+from bs4 import BeautifulSoup
+
+from uk_bin_collection.uk_bin_collection.common import check_usrn, date_format
+from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
+
+_LOGGER = logging.getLogger(__name__)
+
+# Westminster's transact subdomain redirects HTTP -> HTTPS via 301; following
+# that redirect on a POST converts it to a GET (RFC 7231) and silently drops
+# the form body. Always hit HTTPS directly.
+LOOKUP_URL = "https://transact.westminster.gov.uk/env/streetsearch.aspx"
+
+DAY_ORDER = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"]
+DAY_INDEX = {abbr: i for i, abbr in enumerate(DAY_ORDER)}
+
+
+class CouncilClass(AbstractGetBinDataClass):
+    """
+    Westminster City Council uses a street-based ASP.NET WebForms lookup at
+    transact.westminster.gov.uk/env/streetsearch.aspx. The dropdown's option
+    values are USRNs (Unique Street Reference Numbers); pass the USRN via the
+    `usrn` kwarg.
+
+    The response renders three tables:
+      1. General bin presentation/collection windows (per-street).
+      2. Service-specific collections (Recycling, Food Recycling, etc).
+      3. Street cleaning schedule -- skipped because it is not a bin service.
+
+    Westminster's data is recurring weekday windows rather than calendar
+    dates, so for each row we report the next occurrence of the listed
+    day(s).
+    """
+
+    def parse_data(self, page: str, **kwargs) -> dict:
+        usrn = kwargs.get("usrn")
+        check_usrn(usrn)
+
+        session = requests.Session()
+        session.headers.update(
+            {
+                "User-Agent": (
+                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) "
+                    "Chrome/120.0 Safari/537.36"
+                )
+            }
+        )
+
+        get_resp = session.get(LOOKUP_URL, timeout=60)
+        get_resp.raise_for_status()
+        form_soup = BeautifulSoup(get_resp.text, "html.parser")
+
+        post_data = {
+            "__VIEWSTATE": _hidden(form_soup, "__VIEWSTATE"),
+            "__VIEWSTATEGENERATOR": _hidden(form_soup, "__VIEWSTATEGENERATOR"),
+            "__EVENTVALIDATION": _hidden(form_soup, "__EVENTVALIDATION"),
+            "dlstreets": str(usrn),
+            "btnsearch": _btn_value(form_soup),
+        }
+
+        post_resp = session.post(
+            LOOKUP_URL,
+            data=post_data,
+            headers={
+                "Referer": LOOKUP_URL,
+                "Origin": "https://transact.westminster.gov.uk",
+            },
+            timeout=60,
+        )
+        post_resp.raise_for_status()
+
+        result_soup = BeautifulSoup(post_resp.text, "html.parser")
+        return _build_bins(result_soup)
+
+
+def _hidden(soup, name):
+    el = soup.find("input", {"name": name})
+    if not el:
+        raise ValueError(f"Westminster page missing hidden field: {name}")
+    return el.get("value", "")
+
+
+def _btn_value(soup):
+    btn = soup.find("input", {"name": "btnsearch"})
+    return btn.get("value", "") if btn else ""
+
+
+def _expand_days(text):
+    """Expand 'Mon - Fri' / 'Sat, Sun' / 'Fri' into a list of 3-letter abbrs."""
+    text = text.strip()
+    if not text:
+        return []
+    if "-" in text:
+        parts = [p.strip()[:3] for p in text.split("-")]
+        if len(parts) == 2 and parts[0] in DAY_INDEX and parts[1] in DAY_INDEX:
+            return DAY_ORDER[DAY_INDEX[parts[0]] : DAY_INDEX[parts[1]] + 1]
+    out = []
+    for token in re.split(r"[,&]", text):
+        token = token.strip()[:3]
+        if token in DAY_INDEX:
+            out.append(token)
+    return out
+
+
+def _next_date_for_day(day_abbr, today):
+    target = DAY_INDEX[day_abbr]
+    days_ahead = (target - today.weekday()) % 7
+    if days_ahead == 0:
+        days_ahead = 7
+    return (today + timedelta(days=days_ahead)).strftime(date_format)
+
+
+def _build_bins(soup):
+    bins = []
+    seen = set()
+    today = datetime.now()
+
+    for table in soup.find_all("table"):
+        headers = [th.get_text(strip=True) for th in table.find_all("th")]
+        if not headers:
+            continue
+        if "swept" in table.get_text(" ", strip=True).lower():
+            continue
+        has_service_column = any("service description" in h.lower() for h in headers)
+
+        for row in table.find_all("tr"):
+            cells = [c.get_text(" ", strip=True) for c in row.find_all("td")]
+            if not cells:
+                continue
+
+            if has_service_column:
+                # [Location, Service, '', Week Days, Week Times, Weekend Days, Weekend Times]
+                if len(cells) < 4:
+                    continue
+                service = cells[1]
+                if not service or "swept" in service.lower():
+                    continue
+                bin_type = service
+                day_cells = cells[2:]
+            else:
+                # [Location, Week Days, Week Times, Weekend Days, Weekend Times]
+                bin_type = "General Waste Collection"
+                day_cells = cells[1:]
+
+            days = []
+            for cell in day_cells:
+                if re.search(r"\b(Mon|Tue|Wed|Thu|Fri|Sat|Sun)\b", cell):
+                    days.extend(_expand_days(cell))
+
+            if not days:
+                continue
+
+            next_dates = sorted({_next_date_for_day(d, today) for d in days})
+            collection_date = next_dates[0]
+
+            key = (bin_type, collection_date)
+            if key in seen:
+                continue
+            seen.add(key)
+
+            bins.append({"type": bin_type, "collectionDate": collection_date})
+
+    bins.sort(key=lambda b: datetime.strptime(b["collectionDate"], date_format))
+    return {"bins": bins}


### PR DESCRIPTION
## Summary

- Adds a `WestminsterCityCouncil` scraper for Westminster City Council (London).
- Adds the `--usrn` / `-us` CLI flag that the kwargs table in `CONTRIBUTING.md` already documents and `tests/step_defs/test_validate_council.py` already passes when input.json supplies a `usrn` key — Westminster is the first scraper to actually use it.

## Context

Westminster's bin-day lookup at https://transact.westminster.gov.uk/env/streetsearch.aspx is street-based rather than property- or postcode-based. The dropdown's option values are USRNs (Unique Street Reference Numbers), so the natural input parameter is `usrn`. Once selected, the page renders three tables:
- General collection window (per street segment)
- Service-specific collections (Recycling, Food Recycling, etc.)
- Street cleaning schedule

The scraper extracts the first two and converts the day strings (\"Mon - Fri\", \"Sat, Sun\", \"Fri\") into next-occurrence dates using the existing `date_format` helper. Street cleaning is filtered out as it is not a bin service.

## Notable gotchas

- **HTTP→HTTPS 301 + POST**: the transact subdomain redirects HTTP to HTTPS, but following the redirect on a POST converts it to a GET (RFC 7231) so the form body is silently dropped. The scraper always hits HTTPS directly.
- **btnsearch value**: the button's value attribute contains literal whitespace and `> >` characters that ASP.NET checks during EventValidation. The scraper re-reads it from the GET response rather than hard-coding it.

## Test plan

- [x] Scraped Acacia Road (USRN 8401095, residential, single Friday collection) — output validates against `tests/output.schema`
- [x] Scraped Baker Street (USRN 8401123, BOS multi-window) — produces sensible next-occurrence dates per service
- [x] Verified `--usrn` flag flows through `collect_data` → council class kwargs
- [ ] CI integration tests on this branch

## Notes for reviewers

- I'm opening this as a draft so you can flag anything before it's marked ready. The scraper sits in unfamiliar territory (first USRN-based scraper, and Westminster's collection model is unusual for the UK), so I'd particularly welcome feedback on:
  - Whether reporting "next occurrence" of recurring weekly windows is the right contract for ukbcd, vs a different representation
  - Whether to include the BOS bag-presentation windows or leave them out (currently included as "General Waste Collection")
  - Naming: `WestminsterCityCouncil` to match `WestminsterCityCouncil` in `LAD24CD: E09000033` — open to alternatives