### PR TITLE
feat: update Royal Borough of Greenwich collection dates for bank holidays

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/RoyalBoroughofGreenwich.py
+++ b/uk_bin_collection/uk_bin_collection/councils/RoyalBoroughofGreenwich.py
@@ -57,7 +57,8 @@ class CouncilClass(AbstractGetBinDataClass):
         URI = f"https://www.royalgreenwich.gov.uk/site/custom_scripts/apps/waste-collection/new2023/source.php?term={user_postcode}"
 
         # Make the GET request to retrieve the day of the week and black bin week for the address
-        response = requests.get(URI, headers=headers)
+        response = requests.get(URI, headers=headers, timeout=30)
+        response.raise_for_status()
 
         for address in response.json():
             if user_paon in address:
@@ -68,8 +69,8 @@ class CouncilClass(AbstractGetBinDataClass):
 
         data = {"address": collection_address}
 
-        response = requests.post(URI, data=data, headers=headers)
-
+        response = requests.post(URI, data=data, headers=headers, timeout=30)
+        response.raise_for_status()
         response = response.json()
 
         collection_day = response["Day"]

--- a/uk_bin_collection/uk_bin_collection/councils/RoyalBoroughofGreenwich.py
+++ b/uk_bin_collection/uk_bin_collection/councils/RoyalBoroughofGreenwich.py
@@ -1,9 +1,13 @@
+import logging
 import time
 
 import requests
+from bs4 import BeautifulSoup
 
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
+
+logger = logging.getLogger(__name__)
 
 
 # import the wonderful Beautiful Soup and the URL grabber
@@ -13,6 +17,26 @@ class CouncilClass(AbstractGetBinDataClass):
     base class. They can also override some operations with a default
     implementation.
     """
+
+    # Method used to set the year from the holiday adjustments to avoid issues around the new year
+    def _set_year_from_month(self, date):
+        if date.month < datetime.now().month:
+            return date.replace(year=datetime.now().year + 1)
+        else:
+            return date.replace(year=datetime.now().year)
+
+    def _add_bin_dates(self, dates, bin_type, bindata, holiday_dict, offset_days):
+        for date_str in dates:
+            collection_date = datetime.strptime(date_str, "%d/%m/%Y") + timedelta(
+                days=offset_days
+            )
+            if collection_date in holiday_dict:
+                collection_date = holiday_dict[collection_date]
+            dict_data = {
+                "type": bin_type,
+                "collectionDate": collection_date.strftime("%d/%m/%Y"),
+            }
+            bindata["bins"].append(dict_data)
 
     def parse_data(self, page: str, **kwargs) -> dict:
 
@@ -32,7 +56,7 @@ class CouncilClass(AbstractGetBinDataClass):
 
         URI = f"https://www.royalgreenwich.gov.uk/site/custom_scripts/apps/waste-collection/new2023/source.php?term={user_postcode}"
 
-        # Make the GET request
+        # Make the GET request to retrieve the day of the week and black bin week for the address
         response = requests.get(URI, headers=headers)
 
         for address in response.json():
@@ -65,52 +89,67 @@ class CouncilClass(AbstractGetBinDataClass):
         offset_days = days_of_week.index(collection_day)
         week = collectionweek.index(week)
 
-        greenstartDate = datetime(2024, 11, 25)
-        bluestartDate = datetime(2024, 11, 25)
+        # Retrieve the list of dates amended by bank holidays such that we can adjust accordingly
+        holiday_dict = {}
+        try:
+            holiday_URI = "https://www.royalgreenwich.gov.uk/recycling-and-rubbish/bins-and-collections/bank-holiday-collection-dates"
+            holiday_response = requests.get(holiday_URI, headers=headers, timeout=30)
+            holiday_response.raise_for_status()
+            soup = BeautifulSoup(holiday_response.text, features="html.parser")
+
+            table = soup.select_one("table.tablesaw.tablesaw-stack")
+            if table:
+                rows = table.find("tbody").find_all("tr")
+                for row in rows:
+                    original_collection_date = row.find_all("td")[0].get_text(
+                        strip=True
+                    )
+                    original_collection_date = re.findall(
+                        r"\w+ \d+ \w+", original_collection_date
+                    )[0]
+                    original_collection_date = datetime.strptime(
+                        original_collection_date, "%A %d %B"
+                    )
+
+                    original_collection_date = self._set_year_from_month(original_collection_date)
+
+                    new_collection_date = row.find_all("td")[1].get_text(strip=True)
+                    new_collection_date = new_collection_date.replace(
+                        " (bank holiday)", ""
+                    )
+                    new_collection_date = datetime.strptime(
+                        new_collection_date, "%A %d %B"
+                    )
+                    # Handle the case where the new collection date is in the next year
+                    new_collection_date = self._set_year_from_month(new_collection_date)
+
+                    holiday_dict[original_collection_date] = new_collection_date
+        except (
+            requests.exceptions.RequestException,
+            AttributeError,
+            IndexError,
+            ValueError,
+        ) as e:
+            logger.warning(f"Failed to scrape bank holiday dates: {e}")
+
+        greenstartDate = datetime(2025, 12, 29)
+        bluestartDate = datetime(2025, 12, 29)
         if week == 0:
-            blackstartDate = datetime(2024, 11, 18)
+            blackstartDate = datetime(2025, 12, 29)
         elif week == 1:
-            blackstartDate = datetime(2024, 11, 25)
+            blackstartDate = datetime(2026, 1, 5)
 
         green_dates = get_dates_every_x_days(greenstartDate, 7, 100)
         blue_dates = get_dates_every_x_days(bluestartDate, 7, 100)
         black_dates = get_dates_every_x_days(blackstartDate, 14, 50)
 
-        for greenDate in green_dates:
-
-            collection_date = (
-                datetime.strptime(greenDate, "%d/%m/%Y") + timedelta(days=offset_days)
-            ).strftime("%d/%m/%Y")
-
-            dict_data = {
-                "type": "Green Bin",
-                "collectionDate": collection_date,
-            }
-            bindata["bins"].append(dict_data)
-
-        for blueDate in blue_dates:
-
-            collection_date = (
-                datetime.strptime(blueDate, "%d/%m/%Y") + timedelta(days=offset_days)
-            ).strftime("%d/%m/%Y")
-
-            dict_data = {
-                "type": "Blue Bin",
-                "collectionDate": collection_date,
-            }
-            bindata["bins"].append(dict_data)
-
-        for blackDate in black_dates:
-
-            collection_date = (
-                datetime.strptime(blackDate, "%d/%m/%Y") + timedelta(days=offset_days)
-            ).strftime("%d/%m/%Y")
-
-            dict_data = {
-                "type": "Black Bin",
-                "collectionDate": collection_date,
-            }
-            bindata["bins"].append(dict_data)
+        self._add_bin_dates(
+            green_dates, "Green Bin", bindata, holiday_dict, offset_days
+        )
+        self._add_bin_dates(blue_dates, "Blue Bin", bindata, holiday_dict, offset_days)
+        self._add_bin_dates(
+            black_dates, "Black Bin", bindata, holiday_dict, offset_days
+        )
 
         bindata["bins"].sort(
             key=lambda x: datetime.strptime(x.get("collectionDate"), "%d/%m/%Y")


### PR DESCRIPTION
Additionally grab and parse the bank holiday collection adjustments, and use this to update the relevant bin collection entries to account for the change in schedule

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bin collection dates (Green, Blue, Black) now correctly apply bank-holiday adjustments, handle year rollovers, and are returned in DD/MM/YYYY order-sorted.
  * Start dates for Green/Blue corrected to later intended dates; Black may roll into early 2026 depending on week mapping.

* **Chores**
  * Holiday schedule lookup made more reliable with stricter fetch behavior, timeouts, error handling and added warnings/logging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robbrad/UKBinCollectionData/pull/2024?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->