### PR TITLE
feat: add ClackmannanshireCouncil scraper

### DIFF
--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -879,7 +879,7 @@
         "url": "https://environmentfirst.co.uk/house.php?uprn=100060055444",
         "wiki_command_url_override": "https://environmentfirst.co.uk/house.php?uprn=XXXXXXXXXX",
         "wiki_name": "Environment First",
-        "wiki_note": "For properties with collections managed by Environment First, such as Lewes and Eastbourne. Replace the XXXXXXXXXX with the UPRN of your property\u2014you can use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find this."
+        "wiki_note": "For properties with collections managed by Environment First, such as Lewes and Eastbourne. Replace the XXXXXXXXXX with the UPRN of your property—you can use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find this."
     },
     "EppingForestDistrictCouncil": {
         "postcode": "IG9 6EP",
@@ -1754,14 +1754,14 @@
         "LAD24CD": "E06000012"
     },
     "NorthHertfordshireDistrictCouncil": {
-            "house_number": "Stewards Flat",
-            "postcode": "SG5 1PZ",
-            "skip_get_url": true,
-            "url": "https://waste.nc.north-herts.gov.uk/w/webpage/find-bin-collection-day-input-address",
-            "web_driver": "http://selenium:4444",
-            "wiki_name": "North Hertfordshire",
-            "wiki_note": "Pass a postcode (with space) and house_number/name. The scraper performs the Liberty Create typeahead lookup and matches house_number as a case-insensitive substring.",
-            "LAD24CD": "E07000099"
+        "house_number": "Stewards Flat",
+        "postcode": "SG5 1PZ",
+        "skip_get_url": true,
+        "url": "https://waste.nc.north-herts.gov.uk/w/webpage/find-bin-collection-day-input-address",
+        "web_driver": "http://selenium:4444",
+        "wiki_name": "North Hertfordshire",
+        "wiki_note": "Pass a postcode (with space) and house_number/name. The scraper performs the Liberty Create typeahead lookup and matches house_number as a case-insensitive substring.",
+        "LAD24CD": "E07000099"
     },
     "NorthKestevenDistrictCouncil": {
         "skip_get_url": true,
@@ -2877,5 +2877,11 @@
         "wiki_name": "York",
         "wiki_note": "Provide your UPRN.",
         "LAD24CD": "E06000014"
+    },
+    "ClackmannanshireCouncil": {
+        "postcode": "FK10 1EB",
+        "skip_get_url": true,
+        "url": "https://www.clacks.gov.uk",
+        "wiki_name": "Clackmannanshire"
     }
 }

--- a/uk_bin_collection/uk_bin_collection/councils/ClackmannanshireCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/ClackmannanshireCouncil.py
@@ -1,0 +1,93 @@
+import re
+from datetime import datetime, timedelta
+
+import requests
+from bs4 import BeautifulSoup
+from icalevents.icalevents import events
+
+from uk_bin_collection.uk_bin_collection.common import *
+from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
+
+
+class CouncilClass(AbstractGetBinDataClass):
+    def parse_data(self, page: str, **kwargs) -> dict:
+        data = {"bins": []}
+
+        user_postcode = kwargs.get("postcode")
+        user_paon = kwargs.get("paon")
+        check_postcode(user_postcode)
+
+        base_url = "https://www.clacks.gov.uk"
+        headers = {
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
+        }
+
+        # Step 1: Search by postcode to get address list
+        search_url = f"{base_url}/environment/wastecollection/?pc={user_postcode.replace(chr(32), chr(43))}"
+        response = requests.get(search_url, headers=headers, timeout=30)
+        response.raise_for_status()
+
+        soup = BeautifulSoup(response.text, "html.parser")
+        links = soup.find_all("a", href=re.compile(r"/environment/wastecollection/id/\d+/"))
+
+        if not links:
+            raise ValueError("No addresses found for postcode")
+
+        # Step 2: Find matching address
+        address_url = None
+        if user_paon:
+            for link in links:
+                text = link.get_text(strip=True)
+                if text.lower().startswith(user_paon.lower()):
+                    address_url = base_url + link["href"]
+                    break
+            if not address_url:
+                for link in links:
+                    text = link.get_text(strip=True)
+                    if user_paon.lower() in text.lower():
+                        address_url = base_url + link["href"]
+                        break
+
+        if not address_url:
+            address_url = base_url + links[0]["href"]
+
+        # Step 3: Get property page and extract iCal URLs
+        response = requests.get(address_url, headers=headers, timeout=30)
+        response.raise_for_status()
+
+        soup = BeautifulSoup(response.text, "html.parser")
+        ics_links = soup.find_all("a", href=re.compile(r"\.ics$"))
+
+        if not ics_links:
+            raise ValueError("No iCal files found on property page")
+
+        # Step 4: Parse each iCal file for upcoming events
+        now = datetime.now()
+        future = now + timedelta(days=60)
+        seen = set()
+
+        for ics_link in ics_links:
+            ics_url = base_url + ics_link["href"]
+            try:
+                upcoming = events(ics_url, start=now, end=future)
+                for event in sorted(upcoming, key=lambda e: e.start):
+                    if event.summary and event.start:
+                        bin_type = event.summary.strip()
+                        collection_date = event.start.date().strftime(date_format)
+                        key = (bin_type, collection_date)
+                        if key not in seen:
+                            seen.add(key)
+                            data["bins"].append(
+                                {
+                                    "type": bin_type,
+                                    "collectionDate": collection_date,
+                                }
+                            )
+            except Exception:
+                continue
+
+        data["bins"].sort(
+            key=lambda x: datetime.strptime(x.get("collectionDate"), date_format)
+        )
+
+        return data


### PR DESCRIPTION
Adds support for Clackmannanshire Council bin collections.

**How it works:**
- Plain HTTP GET requests (no Selenium required)
- Searches by postcode at `clacks.gov.uk/environment/wastecollection/`
- Resolves address to property page containing iCal download links
- Parses iCal files using `icalevents` for RRULE expansion (60-day window)

**Bin types returned:** Grey bin, Blue bin, Green bin, Food caddy, Brown bin

**Test address:** FK10 1EB

**Dependencies:** `icalevents` (already in requirements)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clackmannanshire Council is now supported. Users can enter their postcode and optionally their property number to retrieve upcoming waste and recycling collection dates, bin types, and schedules.

* **Tests**
  * Test data expanded to include Clackmannanshire Council entry with configuration details. Minor adjustments made to existing test data.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robbrad/UKBinCollectionData/pull/2026)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->