### PR TITLE
fix(WyreForestDistrictCouncil): rewrite to scrape actual council site

### DIFF
--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -2863,11 +2863,12 @@
         "LAD24CD": "E07000128"
     },
     "WyreForestDistrictCouncil": {
-        "house_number": "Monday",
+        "house_number": "Lea Street",
+        "postcode": "DY10 1SN",
         "skip_get_url": true,
-        "url": "https://www.wyreforestdc.gov.uk",
+        "url": "http://www.wyreforest.gov.uk/querybin.asp",
         "wiki_name": "Wyre Forest",
-        "wiki_note": "Use the House Number field to pass the DAY of the week for your collections. [Monday/Tuesday/Wednesday/Thursday/Friday/Saturday/Sunday].",
+        "wiki_note": "Use the House Number field to pass the STREET NAME (e.g. Lea Street). Postcode is also required.",
         "LAD24CD": "E07000239"
     },
     "YorkCouncil": {

--- a/uk_bin_collection/uk_bin_collection/councils/WyreForestDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/WyreForestDistrictCouncil.py
@@ -1,62 +1,138 @@
+import re
+import urllib.parse
+from datetime import datetime, timedelta
+
+import requests
+from bs4 import BeautifulSoup
+
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
+QUERY_URL = "http://www.wyreforest.gov.uk/querybin.asp"
 
-# import the wonderful Beautiful Soup and the URL grabber
+DAYS_OF_WEEK = [
+    "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"
+]
+
+
+def _next_weekday(day_name: str, from_date: datetime = None) -> datetime:
+    if from_date is None:
+        from_date = datetime.now()
+    target = next(i for i, d in enumerate(DAYS_OF_WEEK) if d.upper() == day_name.upper())
+    current = from_date.weekday()
+    days_ahead = (target - current) % 7
+    if days_ahead == 0:
+        return from_date
+    return from_date + timedelta(days=days_ahead)
+
+
+def _parse_result_page(soup) -> dict | None:
+    text = soup.get_text(" ", strip=True)
+
+    day_match = re.search(
+        r"collected on a\s+(\w+)\s+on alternate weeks", text, re.I
+    )
+    if not day_match:
+        return None
+
+    collection_day = day_match.group(1).capitalize()
+    if collection_day not in DAYS_OF_WEEK:
+        return None
+
+    green_vals = soup.find_all("font", color="#539253")
+    vals = [v.get_text(strip=True) for v in green_vals]
+
+    rubbish_next = None
+    recycling_next = None
+    if len(vals) >= 3:
+        rubbish_next = vals[1]
+        recycling_next = vals[2]
+
+    today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+    next_day = _next_weekday(collection_day, today)
+
+    if rubbish_next and "today" in rubbish_next.lower():
+        rubbish_start = today
+        recycling_start = today + timedelta(days=7)
+    elif rubbish_next and "next" in rubbish_next.lower():
+        rubbish_start = next_day + timedelta(days=7) if next_day == today else next_day
+        recycling_start = today if next_day == today else next_day - timedelta(days=7)
+        if recycling_start < today:
+            recycling_start = next_day
+            rubbish_start = next_day + timedelta(days=7)
+    elif recycling_next and "today" in recycling_next.lower():
+        recycling_start = today
+        rubbish_start = today + timedelta(days=7)
+    elif recycling_next and "next" in recycling_next.lower():
+        recycling_start = next_day + timedelta(days=7) if next_day == today else next_day
+        rubbish_start = today if next_day == today else next_day - timedelta(days=7)
+        if rubbish_start < today:
+            rubbish_start = next_day
+            recycling_start = next_day + timedelta(days=7)
+    else:
+        rubbish_start = next_day
+        recycling_start = next_day + timedelta(days=7)
+
+    return {
+        "day": collection_day,
+        "rubbish_start": rubbish_start,
+        "recycling_start": recycling_start,
+    }
+
+
 class CouncilClass(AbstractGetBinDataClass):
-    """
-    Concrete classes have to implement all abstract operations of the
-    base class. They can also override some operations with a default
-    implementation.
-    """
-
     def parse_data(self, page: str, **kwargs) -> dict:
+        street_name = (kwargs.get("paon") or "").strip()
+        if not street_name:
+            raise ValueError("Street name required in house_number/paon field")
 
-        collection_day = kwargs.get("paon")
         bindata = {"bins": []}
 
-        days_of_week = [
-            "Monday",
-            "Tuesday",
-            "Wednesday",
-            "Thursday",
-            "Friday",
-            "Saturday",
-            "Sunday",
-        ]
+        params = {
+            "txtStreetName": street_name.upper(),
+            "locality": " ",
+            "town": "",
+            "select": "",
+        }
+        resp = requests.get(QUERY_URL, params=params, timeout=30)
+        resp.raise_for_status()
+        soup = BeautifulSoup(resp.text, "html.parser")
 
-        refusestartDate = datetime(2026, 1, 5)
-        recyclingstartDate = datetime(2026, 1, 12)
+        result = _parse_result_page(soup)
+        if result is None:
+            links = soup.find_all("a", href=re.compile(r"querybin\.asp.*select=yes", re.I))
+            if not links:
+                raise ValueError(f"No collection data found for street: {street_name}")
 
-        offset_days = days_of_week.index(collection_day)
+            for link in links:
+                href = link.get("href", "")
+                full_url = urllib.parse.urljoin(QUERY_URL, href)
+                resp2 = requests.get(full_url, timeout=30)
+                resp2.raise_for_status()
+                soup2 = BeautifulSoup(resp2.text, "html.parser")
+                result = _parse_result_page(soup2)
+                if result is not None:
+                    break
 
-        refuse_dates = get_dates_every_x_days(refusestartDate, 14, 28)
-        recycling_dates = get_dates_every_x_days(recyclingstartDate, 14, 28)
+            if result is None:
+                raise ValueError(f"Could not parse collection data for: {street_name}")
 
-        for refuseDate in refuse_dates:
+        today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
 
-            collection_date = (
-                datetime.strptime(refuseDate, "%d/%m/%Y") + timedelta(days=offset_days)
-            ).strftime("%d/%m/%Y")
+        for i in range(28):
+            rubbish_date = result["rubbish_start"] + timedelta(weeks=i * 2)
+            if rubbish_date >= today:
+                bindata["bins"].append({
+                    "type": "Black/Grey Rubbish Bin",
+                    "collectionDate": rubbish_date.strftime("%d/%m/%Y"),
+                })
 
-            dict_data = {
-                "type": "Black/Grey Rubbish Bin",
-                "collectionDate": collection_date,
-            }
-            bindata["bins"].append(dict_data)
-
-        for recyclingDate in recycling_dates:
-
-            collection_date = (
-                datetime.strptime(recyclingDate, "%d/%m/%Y")
-                + timedelta(days=offset_days)
-            ).strftime("%d/%m/%Y")
-
-            dict_data = {
-                "type": "Green Recycling Bin",
-                "collectionDate": collection_date,
-            }
-            bindata["bins"].append(dict_data)
+            recycling_date = result["recycling_start"] + timedelta(weeks=i * 2)
+            if recycling_date >= today:
+                bindata["bins"].append({
+                    "type": "Green Recycling Bin",
+                    "collectionDate": recycling_date.strftime("%d/%m/%Y"),
+                })
 
         bindata["bins"].sort(
             key=lambda x: datetime.strptime(x.get("collectionDate"), "%d/%m/%Y")


### PR DESCRIPTION
## Summary
- Rewrites scraper to query the actual council site at `wyreforest.gov.uk/querybin.asp` instead of using hardcoded 2026 start dates
- Old scraper required a day-of-week string in the `house_number` field, which broke when real addresses were passed (`ValueError: '74' is not in list`)
- New scraper accepts a **street name** in the `house_number` field and a postcode, queries the council, parses collection day and next-collection indicators, then computes fortnightly dates from today
- Handles disambiguation when multiple streets match (e.g. "High Street" in Kidderminster vs Bewdley)
- Updated `input.json` with street name + postcode test address

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WyreForest District Council now fetches live bin collection schedules from the council website for accurate, up-to-date information.

* **Bug Fixes**
  * Updated input requirements for WyreForest District Council: users now provide street name and postcode instead of the day of week.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robbrad/UKBinCollectionData/pull/2031)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->