### PR TITLE
fix(SheffieldCityCouncil): rewrite for new Veolia JSON API

### DIFF
--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -2128,10 +2128,12 @@
         "LAD24CD": "E07000111"
     },
     "SheffieldCityCouncil": {
-        "url": "https://wasteservices.sheffield.gov.uk/property/100050931898",
-        "wiki_command_url_override": "https://wasteservices.sheffield.gov.uk/property/XXXXXXXXXXX",
+        "postcode": "S7 1RY",
+        "skip_get_url": true,
+        "uprn": "100050931898",
+        "url": "https://wasteservices.sheffield.gov.uk",
         "wiki_name": "Sheffield",
-        "wiki_note": "Follow the instructions [here](https://wasteservices.sheffield.gov.uk/) until you get the 'Your bin collection dates and services' page, then copy the URL and replace the URL in the command.",
+        "wiki_note": "Provide your UPRN and postcode. You can find your UPRN using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E08000019"
     },
     "ShropshireCouncil": {

--- a/uk_bin_collection/uk_bin_collection/councils/SheffieldCityCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/SheffieldCityCouncil.py
@@ -1,54 +1,99 @@
-from bs4 import BeautifulSoup
+import requests
+from datetime import datetime
+
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
+API_BASE = "https://wasteservices.sheffield.gov.uk/api"
+COUNCIL_ID = "1"
 
-# import the wonderful Beautiful Soup and the URL grabber
+
 class CouncilClass(AbstractGetBinDataClass):
-    """
-    Concrete classes have to implement all abstract operations of the
-    base class. They can also override some operations with a default
-    implementation.
-    """
-
     def parse_data(self, page: str, **kwargs) -> dict:
-        # Make a BS4 object
-        soup = BeautifulSoup(page.text, features="html.parser")
-        soup.prettify()
+        uprn = kwargs.get("uprn")
+        postcode = kwargs.get("postcode")
 
-        # Form a JSON wrapper
-        data = {"bins": []}
+        if not uprn:
+            raise ValueError("UPRN is required for Sheffield")
 
-        # Search for the specific table using BS4
-        rows = soup.find("table", {"class": re.compile("table")}).find_all("tr")
+        headers = {
+            "Content-Type": "application/json",
+            "Origin": "https://wasteservices.sheffield.gov.uk",
+        }
 
-        # Loops the Rows
-        for row in rows:
-            cells = row.find_all(
-                "td", {"class": lambda L: L and L.startswith("service-name")}
+        point_id = None
+
+        if postcode:
+            search_resp = requests.post(
+                f"{API_BASE}/getPropertySearch",
+                json={"councilId": COUNCIL_ID, "searchQuery": postcode},
+                headers=headers,
+                timeout=30,
             )
+            search_resp.raise_for_status()
+            search_data = search_resp.json()
 
-            if len(cells) > 0:
-                collectionDatesRawData = row.find_all(
-                    "td", {"class": lambda L: L and L.startswith("next-service")}
-                )[0].get_text(strip=True)
-                collectionDate = collectionDatesRawData[
-                    16 : len(collectionDatesRawData)
-                ].split(",")
-                bin_type = row.find_all(
-                    "td", {"class": lambda L: L and L.startswith("service-name")}
-                )[0].h4.get_text(strip=True)
+            for prop in search_data.get("data", []):
+                if str(prop.get("uprn")) == str(uprn):
+                    point_id = prop["id"]
+                    break
 
-                for collectDate in collectionDate:
-                    # Make each Bin element in the JSON
-                    dict_data = {
-                        "type": bin_type,
-                        "collectionDate": datetime.strptime(
-                            collectDate.strip(), "%d %b %Y"
-                        ).strftime(date_format),
-                    }
+        if not point_id:
+            search_resp = requests.post(
+                f"{API_BASE}/getPropertySearch",
+                json={"councilId": COUNCIL_ID, "searchQuery": str(uprn)},
+                headers=headers,
+                timeout=30,
+            )
+            search_resp.raise_for_status()
+            search_data = search_resp.json()
 
-                    # Add data to the main JSON Wrapper
-                    data["bins"].append(dict_data)
+            for prop in search_data.get("data", []):
+                if str(prop.get("uprn")) == str(uprn):
+                    point_id = prop["id"]
+                    break
 
-        return data
+        if not point_id:
+            raise ValueError(f"Could not find property for UPRN {uprn}")
+
+        collection_resp = requests.post(
+            f"{API_BASE}/getCollectionDays",
+            json={
+                "pointId": point_id,
+                "pointType": "PointAddress",
+                "councilId": COUNCIL_ID,
+            },
+            headers=headers,
+            timeout=30,
+        )
+        collection_resp.raise_for_status()
+        collection_data = collection_resp.json()
+
+        bindata = {"bins": []}
+
+        for service in collection_data.get("activeServices", []):
+            bin_type = service.get("serviceName", "Unknown")
+            for schedule in service.get("serviceSchedules", []):
+                if schedule.get("state") == "Complete":
+                    continue
+                date_str = schedule.get("currentScheduledDate") or schedule.get(
+                    "originalScheduledDate"
+                )
+                if not date_str:
+                    continue
+                try:
+                    dt = datetime.fromisoformat(date_str)
+                    bindata["bins"].append(
+                        {
+                            "type": bin_type,
+                            "collectionDate": dt.strftime(date_format),
+                        }
+                    )
+                except (ValueError, TypeError):
+                    continue
+
+        bindata["bins"].sort(
+            key=lambda x: datetime.strptime(x.get("collectionDate"), date_format)
+        )
+
+        return bindata


### PR DESCRIPTION
## Summary
- Sheffield migrated to a Next.js SPA with a JSON API — old HTML table scraper no longer works
- New scraper calls `/api/getPropertySearch` (postcode search, UPRN match) then `/api/getCollectionDays` (internal ID) to get bin schedules
- Pure `requests`-based — no Selenium needed
- Updated `input.json` to use UPRN + postcode instead of embedded URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Sheffield City Council's bin collection data now retrieves information through a direct API connection for enhanced reliability.
  * Updated property lookup method to use UPRN and postcode for more accurate address matching.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robbrad/UKBinCollectionData/pull/2032)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->