### PR TITLE
fix(BroxtoweBoroughCouncil): update test address to residential

### DIFF
--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -372,13 +372,14 @@
         "LAD24CD": "E07000095"
     },
     "BroxtoweBoroughCouncil": {
-        "postcode": "NG16 2LY",
+        "house_number": "2",
+        "postcode": "NG16 2LS",
         "skip_get_url": true,
-        "uprn": "100031325997",
+        "uprn": "100031320105",
         "url": "https://www.broxtowe.gov.uk/",
         "web_driver": "http://selenium:4444",
         "wiki_name": "Broxtowe",
-        "wiki_note": "Pass the UPRN and postcode. To get the UPRN, you can use [FindMyAddress](https://www.findmyaddress.co.uk/search).",
+        "wiki_note": "Pass the UPRN and postcode. House number used as fallback if UPRN doesn't match dropdown.",
         "LAD24CD": "E07000172"
     },
     "BuckinghamshireCouncil": {


### PR DESCRIPTION
## Summary
- Old test postcode NG16 2LY is a commercial street (shops only) — no simple house numbers for UPRN matching
- Changed to 2 High Street, NG16 2LS (residential, UPRN `100031320105` matches dropdown)
- Added `house_number` param for text-match fallback

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test configuration for address validation with revised property identifiers and postcode values.
  * Enhanced fallback handling to use house number when standard property identifiers don't match available options.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robbrad/UKBinCollectionData/pull/2038)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->