### PR TITLE
fix: MoleValleyDistrictCouncil HTML parsing broken by nested strong tags

### DIFF
--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -1636,9 +1636,9 @@
         "LAD24CD": "E06000042"
     },
     "MoleValleyDistrictCouncil": {
-        "postcode": "RH4 1SJ",
+        "postcode": "RH5 6QE",
         "skip_get_url": true,
-        "uprn": "200000171235",
+        "uprn": "100062496342",
         "url": "https://myproperty.molevalley.gov.uk/molevalley/",
         "wiki_name": "Mole Valley",
         "wiki_note": "UPRN can only be parsed with a valid postcode.",

--- a/uk_bin_collection/uk_bin_collection/councils/MoleValleyDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/MoleValleyDistrictCouncil.py
@@ -10,11 +10,9 @@ from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataC
 
 class CouncilClass(AbstractGetBinDataClass):
     def parse_data(self, page: str, **kwargs) -> dict:
-
         user_postcode = kwargs.get("postcode")
         check_postcode(user_postcode)
 
-        # Fetch the page content
         root_url = "https://myproperty.molevalley.gov.uk/molevalley/api/live_addresses/{}?format=json".format(
             user_postcode
         )
@@ -23,12 +21,12 @@ class CouncilClass(AbstractGetBinDataClass):
         if not response.ok:
             raise ValueError("Invalid server response code retrieving data.")
 
-        jsonData = response.json()
+        json_data = response.json()
 
-        if len(jsonData["results"]["features"]) == 0:
+        if len(json_data["results"]["features"]) == 0:
             raise ValueError("No collection data found for postcode provided.")
 
-        properties_found = jsonData["results"]["features"]
+        properties_found = json_data["results"]["features"]
 
         html_data = None
         uprn = kwargs.get("uprn")
@@ -43,93 +41,64 @@ class CouncilClass(AbstractGetBinDataClass):
         else:
             html_data = properties_found[0]["properties"]["three_column_layout_html"]
 
-        # Conditionally replace the commented-out sections (<!-- ... -->)
         if "<!--" in html_data and "-->" in html_data:
-            print("Commented-out section found, replacing comments...")
             html_data = html_data.replace("<!--", "").replace("-->", "")
-        else:
-            print("No commented-out section found, processing as is.")
 
-        # Process the updated HTML data with BeautifulSoup
         soup = BeautifulSoup(html_data, "html.parser")
 
         data = {"bins": []}
-        all_collection_dates = []
-        regex_date = re.compile(r"(\d{2}/\d{2}/\d{4})")  # Adjusted date regex
-        regex_additional_collection = re.compile(r"We also collect (.*) on (.*) -")
+        regex_date = re.compile(r"(\d{2}/\d{2}/\d{4})")
 
-        # Debugging to verify the HTML content is parsed correctly
-        print("HTML content parsed successfully.")
-
-        # Search for the 'Bins and Recycling' panel
         bins_panel = soup.find("h2", string="Bins and Recycling")
-        if bins_panel:
-            panel = bins_panel.find_parent("div", class_="panel")
-            print("Found 'Bins and Recycling' panel.")
-
-            # Extract bin collection info from the un-commented HTML
-            for strong_tag in panel.find_all("strong"):
-                bin_type = strong_tag.text.strip()
-                collection_string = strong_tag.find_next("p").text.strip()
-
-                # Debugging output
-                print(f"Processing bin type: {bin_type}")
-                print(f"Collection string: {collection_string}")
-
-                match = regex_date.search(collection_string)
-                if match:
-                    collection_date = datetime.strptime(
-                        match.group(1), "%d/%m/%Y"
-                    ).date()
-                    data["bins"].append(
-                        {
-                            "type": bin_type,
-                            "collectionDate": collection_date.strftime("%d/%m/%Y"),
-                        }
-                    )
-                    all_collection_dates.append(collection_date)
-                else:
-                    # Add a debug line to show which collections are missing dates
-                    print(f"No valid date found for bin type: {bin_type}")
-
-            # Search for additional collections like electrical and textiles
-            for p in panel.find_all("p"):
-                additional_match = regex_additional_collection.match(p.text.strip())
-
-                # Debugging output for additional collections
-                if additional_match:
-                    bin_type = additional_match.group(1)
-                    print(f"Found additional collection: {bin_type}")
-                    if "each collection day" in additional_match.group(2):
-                        if all_collection_dates:
-                            collection_date = min(all_collection_dates)
-                            data["bins"].append(
-                                {
-                                    "type": bin_type,
-                                    "collectionDate": collection_date.strftime(
-                                        "%d/%m/%Y"
-                                    ),
-                                }
-                            )
-                        else:
-                            print(
-                                "No collection dates available for additional collection."
-                            )
-                            raise ValueError("No valid bin collection dates found.")
-                else:
-                    print(
-                        f"No additional collection found in paragraph: {p.text.strip()}"
-                    )
-        else:
+        if not bins_panel:
             raise ValueError(
                 "Unable to find 'Bins and Recycling' panel in the HTML data."
             )
 
-        # Debugging to check collected data
-        print(f"Collected bin data: {data}")
+        panel = bins_panel.find_parent("div", class_="panel")
 
-        # Handle the case where no collection dates were found
-        if not all_collection_dates:
+        for strong_tag in panel.find_all("strong"):
+            if strong_tag.parent != panel:
+                continue
+
+            bin_type = strong_tag.text.strip()
+            next_p = strong_tag.find_next_sibling("p")
+            if not next_p:
+                continue
+
+            collection_text = next_p.get_text()
+            match = regex_date.search(collection_text)
+            if match:
+                collection_date = datetime.strptime(
+                    match.group(1), "%d/%m/%Y"
+                ).date()
+                data["bins"].append(
+                    {
+                        "type": bin_type,
+                        "collectionDate": collection_date.strftime("%d/%m/%Y"),
+                    }
+                )
+
+        regex_additional = re.compile(r"We also collect (.*?) on (.*?) -")
+        for p in panel.find_all("p"):
+            additional_match = regex_additional.match(p.get_text().strip())
+            if (
+                additional_match
+                and "each collection day" in additional_match.group(2)
+                and data["bins"]
+            ):
+                earliest = min(
+                    datetime.strptime(b["collectionDate"], "%d/%m/%Y")
+                    for b in data["bins"]
+                )
+                data["bins"].append(
+                    {
+                        "type": additional_match.group(1),
+                        "collectionDate": earliest.strftime("%d/%m/%Y"),
+                    }
+                )
+
+        if not data["bins"]:
             raise ValueError("No valid collection dates were found in the data.")
 
         return data

--- a/uk_bin_collection/uk_bin_collection/councils/MoleValleyDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/MoleValleyDistrictCouncil.py
@@ -23,10 +23,15 @@ class CouncilClass(AbstractGetBinDataClass):
 
         json_data = response.json()
 
-        if len(json_data["results"]["features"]) == 0:
+        try:
+            features = json_data["results"]["features"]
+        except (TypeError, KeyError):
+            raise ValueError("Unexpected response format from Mole Valley API")
+
+        if len(features) == 0:
             raise ValueError("No collection data found for postcode provided.")
 
-        properties_found = json_data["results"]["features"]
+        properties_found = features
 
         html_data = None
         uprn = kwargs.get("uprn")
@@ -56,6 +61,8 @@ class CouncilClass(AbstractGetBinDataClass):
             )
 
         panel = bins_panel.find_parent("div", class_="panel")
+        if panel is None:
+            raise ValueError("Could not find collection panel on page")
 
         for strong_tag in panel.find_all("strong"):
             if strong_tag.parent != panel:


### PR DESCRIPTION
The scraper used `panel.find_all("strong")` which caught nested `<strong>` tags inside `<p>` (collection dates) and `<a>` (links like "Read more", "Missed Bin"). This caused bin types to be parsed incorrectly — dates and link text appeared as bin names.

**Fix:** Only match `<strong>` tags that are direct children of the panel div (`strong_tag.parent == panel`). Also cleaned up debug print statements and unnecessary variables.

Also updated the test address from the council office (RH4 1SJ / 200000171235, which returns "No collection dates available" for Refuse and Food Waste) to a residential property (RH5 6QE / 100062496342) that returns all 4 collection types.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved and more reliable parsing/validation of Mole Valley bin collection pages, including better detection of additional collection entries and removal of noisy diagnostic output.

* **Tests**
  * Updated test input data for Mole Valley to reflect the new parsing behavior and sample response format.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robbrad/UKBinCollectionData/pull/2043?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->