### PR TITLE
fix: LondonBoroughOfRichmondUponThames — support UPRN directly as PID

### DIFF
--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -1467,12 +1467,12 @@
         "LAD24CD": "E09000023"
     },
     "LondonBoroughOfRichmondUponThames": {
-        "house_number": "March Road",
+        "postcode": "TW1 3LD",
+        "uprn": "100022350670",
         "skip_get_url": true,
-        "url": "https://www.richmond.gov.uk/services/waste_and_recycling/collection_days/",
-        "web_driver": "http://selenium:4444",
+        "url": "https://www.richmond.gov.uk/my_richmond",
         "wiki_name": "Richmond upon Thames",
-        "wiki_note": "Pass the name of the street ONLY in the house number parameter, unfortunately post code's are not allowed. ",
+        "wiki_note": "Pass UPRN (used as PID) or postcode + house number. Street search is automatic.",
         "LAD24CD": "E09000027"
     },
     "LondonBoroughRedbridge": {

--- a/uk_bin_collection/uk_bin_collection/councils/LondonBoroughOfRichmondUponThames.py
+++ b/uk_bin_collection/uk_bin_collection/councils/LondonBoroughOfRichmondUponThames.py
@@ -1,70 +1,164 @@
 import re
 import html as html_unescape
 from datetime import datetime
-from urllib.parse import urlparse, parse_qs
 
 import requests
+from bs4 import BeautifulSoup
 
-from uk_bin_collection.uk_bin_collection.common import date_format
+from uk_bin_collection.uk_bin_collection.common import (
+    check_postcode,
+    check_uprn,
+    date_format,
+)
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
+
+BASE_URL = "https://www.richmond.gov.uk"
+MY_RICHMOND_URL = f"{BASE_URL}/myrichmond"
+MY_RICHMOND_PROPERTY_URL = f"{BASE_URL}/my_richmond"
+HEADERS = {"User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36"}
 
 
 class CouncilClass(AbstractGetBinDataClass):
-    """Richmond upon Thames – parse My Richmond property page."""
+    """Richmond upon Thames bin collection scraper.
+
+    Accepts UPRN directly (used as PID), or postcode + house number
+    for a 3-step lookup: postcode -> street -> property -> waste page.
+    """
 
     def parse_data(self, page: str, **kwargs) -> dict:
-        base_url = kwargs.get("url") or page
-        paon = kwargs.get("paon")
+        uprn = kwargs.get("uprn")
+        postcode = kwargs.get("postcode")
+        paon = kwargs.get("paon") or kwargs.get("number")
 
-        pid = self._pid_from_url(base_url) or self._pid_from_paon(paon)
-        if not pid:
+        if uprn:
+            check_uprn(uprn)
+            pid = uprn
+        elif postcode and paon:
+            check_postcode(postcode)
+            pid = self._lookup_pid(postcode, paon)
+        else:
             raise ValueError(
-                "Richmond: supply a URL with ?pid=... OR put PID in the House Number field."
+                "Richmond: provide UPRN, or postcode + house number/name."
             )
 
-        if "pid=" not in (base_url or ""):
-            sep = "&" if "?" in (base_url or "") else "?"
-            target_url = f"{base_url}{sep}pid={pid}"
-        else:
-            target_url = base_url
-
-        html = self._fetch_html(target_url)
-        bindata = self._parse_html_for_waste(html)
+        target_url = f"{MY_RICHMOND_PROPERTY_URL}?pid={pid}"
+        html = self._fetch(target_url)
+        bindata = self._parse_waste(html)
         if not bindata["bins"]:
             raise RuntimeError("Richmond: no bins found in page HTML.")
         return bindata
 
-    def _fetch_html(self, url):
-        headers = {"User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36"}
-        resp = requests.get(url, headers=headers, timeout=30)
+    def _fetch(self, url):
+        resp = requests.get(url, headers=HEADERS, timeout=30)
         resp.raise_for_status()
         return resp.text
 
-    def _parse_html_for_waste(self, html):
+    def _lookup_pid(self, postcode, paon):
+        """Postcode + address -> PID via the My Richmond 3-step form flow."""
+        session = requests.Session()
+
+        # Step 1: Load postcode page to get street list + form tokens
+        resp = session.get(
+            f"{MY_RICHMOND_URL}?postcode={postcode}", headers=HEADERS, timeout=30
+        )
+        resp.raise_for_status()
+        soup = BeautifulSoup(resp.text, "html.parser")
+
+        # Find the street search form (has USRN select)
+        usrn_select = soup.find("select", {"name": "USRN"})
+        if not usrn_select:
+            raise ValueError(f"No streets found for postcode {postcode}")
+
+        # Try to match street name from paon, or use all streets
+        streets = usrn_select.find_all("option")
+        street_usrns = [
+            (s.get("value"), s.text.strip())
+            for s in streets
+            if s.get("value")
+        ]
+
+        if not street_usrns:
+            raise ValueError(f"No streets found for postcode {postcode}")
+
+        paon_lower = paon.strip().lower()
+
+        # Search each street for matching address
+        for usrn, street_name in street_usrns:
+            form = usrn_select.find_parent("form")
+            token = form.find(
+                "input", {"name": "__RequestVerificationToken"}
+            ).get("value")
+            ufprt = form.find("input", {"name": "ufprt"}).get("value")
+
+            data = {
+                "__RequestVerificationToken": token,
+                "ufprt": ufprt,
+                "USRN": usrn,
+                "findproperty": "Go",
+            }
+            resp2 = session.post(
+                f"{MY_RICHMOND_URL}?postcode={postcode}",
+                data=data,
+                headers=HEADERS,
+                timeout=30,
+                allow_redirects=True,
+            )
+            resp2.raise_for_status()
+            soup2 = BeautifulSoup(resp2.text, "html.parser")
+
+            uprn_select = soup2.find("select", {"name": "UPRN"})
+            if not uprn_select:
+                continue
+
+            for opt in uprn_select.find_all("option"):
+                val = opt.get("value", "")
+                text = opt.text.strip().lower()
+                if val and paon_lower in text:
+                    return val
+
+        raise ValueError(
+            f"Could not find address matching '{paon}' in postcode {postcode}"
+        )
+
+    def _parse_waste(self, html):
         waste_block = self._extract_waste_block(html)
         if not waste_block:
             return {"bins": []}
 
         bins = []
-        for h_match in re.finditer(r"<h4>(.*?)</h4>", waste_block, flags=re.I | re.S):
+        for h_match in re.finditer(
+            r"<h4>(.*?)</h4>", waste_block, flags=re.I | re.S
+        ):
             bin_name = self._clean(h_match.group(1))
             if not bin_name:
                 continue
 
             start = h_match.end()
             next_h = re.search(r"<h4>", waste_block[start:], flags=re.I)
-            section = waste_block[start:start + next_h.start()] if next_h else waste_block[start:]
+            section = (
+                waste_block[start : start + next_h.start()]
+                if next_h
+                else waste_block[start:]
+            )
 
             date_lines = []
-            ul_match = re.search(r"<ul[^>]*>(.*?)</ul>", section, flags=re.I | re.S)
+            ul_match = re.search(
+                r"<ul[^>]*>(.*?)</ul>", section, flags=re.I | re.S
+            )
             if ul_match:
-                for li in re.findall(r"<li[^>]*>(.*?)</li>", ul_match.group(1), flags=re.I | re.S):
+                for li in re.findall(
+                    r"<li[^>]*>(.*?)</li>",
+                    ul_match.group(1),
+                    flags=re.I | re.S,
+                ):
                     text = self._clean(li)
                     if text:
                         date_lines.append(text)
 
             if not date_lines:
-                p_match = re.search(r"<p[^>]*>(.*?)</p>", section, flags=re.I | re.S)
+                p_match = re.search(
+                    r"<p[^>]*>(.*?)</p>", section, flags=re.I | re.S
+                )
                 if p_match:
                     text = self._clean(p_match.group(1))
                     if text:
@@ -77,34 +171,20 @@ class CouncilClass(AbstractGetBinDataClass):
         return {"bins": bins}
 
     def _extract_waste_block(self, html):
-        # New format: <div class="my-item my-waste">...</div>
         m = re.search(
             r'<div[^>]+class="[^"]*my-waste[^"]*"[^>]*>(.+?)(?=<div[^>]+class="[^"]*my-item\b|</body>)',
-            html, flags=re.I | re.S,
+            html,
+            flags=re.I | re.S,
         )
         if m:
             return m.group(1)
-        # Old format: <a id="my_waste">
         m2 = re.search(
             r'<a\s+id="my_waste"\s*></a>(.+?)(?=<a\s+id="my_parking"|<a\s+id="my_councillors")',
-            html, flags=re.I | re.S,
+            html,
+            flags=re.I | re.S,
         )
         if m2:
             return m2.group(1)
-        return None
-
-    def _pid_from_url(self, url):
-        if not url:
-            return None
-        try:
-            q = parse_qs(urlparse(url).query)
-            return q.get("pid", [None])[0]
-        except Exception:
-            return None
-
-    def _pid_from_paon(self, paon):
-        if paon and str(paon).isdigit() and 10 <= len(str(paon)) <= 14:
-            return str(paon)
         return None
 
     def _clean(self, s):

--- a/uk_bin_collection/uk_bin_collection/councils/LondonBoroughOfRichmondUponThames.py
+++ b/uk_bin_collection/uk_bin_collection/councils/LondonBoroughOfRichmondUponThames.py
@@ -113,7 +113,7 @@ class CouncilClass(AbstractGetBinDataClass):
             for opt in uprn_select.find_all("option"):
                 val = opt.get("value", "")
                 text = opt.text.strip().lower()
-                if val and paon_lower in text:
+                if val and re.search(rf"\b{re.escape(paon_lower)}\b", text):
                     return val
 
         raise ValueError(


### PR DESCRIPTION
The scraper required a PID parameter passed via URL or house_number field, but the PID is actually the property's UPRN. The old config had no UPRN or postcode, only a street name in house_number.

Rewritten to:
1. Accept UPRN directly (used as PID to construct the My Richmond URL)
2. Accept postcode + house number for a 3-step form lookup: postcode → street (USRN) → property (UPRN/PID)

Removed Selenium dependency — pure requests now. Updated input.json with UPRN and postcode for the test address.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Richmond upon Thames bin collection scraper refactored: property lookup now accepts UPRN or postcode + house number, improving reliability of waste collection retrieval.
* **Documentation**
  * Updated local configuration/instructions to reflect UPRN or postcode+house number usage and new URL handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robbrad/UKBinCollectionData/pull/2044)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->