### PR TITLE
fix: SouthDerbyshireDistrictCouncil — add SSL bypass and User-Agent

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/SouthDerbyshireDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/SouthDerbyshireDistrictCouncil.py
@@ -4,16 +4,8 @@ from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
 
-# import the wonderful Beautiful Soup and the URL grabber
 class CouncilClass(AbstractGetBinDataClass):
-    """
-    Concrete classes have to implement all abstract operations of the
-    base class. They can also override some operations with a default
-    implementation.
-    """
-
     def parse_data(self, page: str, **kwargs) -> dict:
-
         user_uprn = kwargs.get("uprn")
         check_uprn(user_uprn)
         data = {"bins": []}
@@ -21,40 +13,31 @@ class CouncilClass(AbstractGetBinDataClass):
         baseurl = "https://maps.southderbyshire.gov.uk/iShareLIVE.web//getdata.aspx?RequestType=LocalInfo&ms=mapsources/MyHouse&format=JSONP&group=Recycling%20Bins%20and%20Waste|Next%20Bin%20Collections&uid="
         url = baseurl + user_uprn
 
-        # Make the web request
-        response = requests.get(url).text
+        requests.packages.urllib3.disable_warnings()
+        headers = {"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"}
+        response = requests.get(url, verify=False, headers=headers).text
 
-        # Remove the JSONP wrapper using a regular expression
-        jsonp_pattern = r"\{.*\}"
-        json_match = re.search(jsonp_pattern, response)
+        jsonp_pattern = r"import\((\{.*\})\)"
+        json_match = re.search(jsonp_pattern, response, re.S)
 
         if json_match:
-            # Extract the JSON part
-            json_data = json_match.group(0)
-
-            # Parse the JSON
+            json_data = json_match.group(1)
             parsed_data = json.loads(json_data)
-
-            # Extract the embedded HTML string
             html_content = parsed_data["Results"]["Next_Bin_Collections"]["_"]
 
-            # Parse the HTML to extract dates and bin types using regex
             matches = re.findall(
                 r"<span.*?>(\d{2} \w+ \d{4})</span>.*?<span.*?>(.*?)</span>",
                 html_content,
                 re.S,
             )
 
-            # Output the parsed bin collection details
             for match in matches:
                 dict_data = {
                     "type": match[1],
-                    "collectionDate": datetime.strptime(match[0], "%d %B %Y").strftime(
-                        "%d/%m/%Y"
-                    ),
+                    "collectionDate": datetime.strptime(
+                        match[0], "%d %B %Y"
+                    ).strftime("%d/%m/%Y"),
                 }
                 data["bins"].append(dict_data)
-        else:
-            print("No valid JSON found in the response.")
 
         return data

--- a/uk_bin_collection/uk_bin_collection/councils/SouthDerbyshireDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/SouthDerbyshireDistrictCouncil.py
@@ -15,29 +15,33 @@ class CouncilClass(AbstractGetBinDataClass):
 
         requests.packages.urllib3.disable_warnings()
         headers = {"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"}
-        response = requests.get(url, verify=False, headers=headers).text
+        response = requests.get(url, verify=False, headers=headers, timeout=30).text
 
         jsonp_pattern = r"import\((\{.*\})\)"
         json_match = re.search(jsonp_pattern, response, re.S)
 
-        if json_match:
-            json_data = json_match.group(1)
-            parsed_data = json.loads(json_data)
-            html_content = parsed_data["Results"]["Next_Bin_Collections"]["_"]
-
-            matches = re.findall(
-                r"<span.*?>(\d{2} \w+ \d{4})</span>.*?<span.*?>(.*?)</span>",
-                html_content,
-                re.S,
+        if not json_match:
+            raise ValueError(
+                "Could not extract JSONP data from South Derbyshire API response"
             )
 
-            for match in matches:
-                dict_data = {
-                    "type": match[1],
-                    "collectionDate": datetime.strptime(
-                        match[0], "%d %B %Y"
-                    ).strftime("%d/%m/%Y"),
-                }
-                data["bins"].append(dict_data)
+        json_data = json_match.group(1)
+        parsed_data = json.loads(json_data)
+        html_content = parsed_data["Results"]["Next_Bin_Collections"]["_"]
+
+        matches = re.findall(
+            r"<span.*?>(\d{2} \w+ \d{4})</span>.*?<span.*?>(.*?)</span>",
+            html_content,
+            re.S,
+        )
+
+        for match in matches:
+            dict_data = {
+                "type": match[1],
+                "collectionDate": datetime.strptime(
+                    match[0], "%d %B %Y"
+                ).strftime("%d/%m/%Y"),
+            }
+            data["bins"].append(dict_data)
 
         return data


### PR DESCRIPTION
The iShare API at `maps.southderbyshire.gov.uk` returns an error page (HTML) when:
1. SSL verification is enabled (certificate issue)
2. No User-Agent header is set (server rejects default python-requests UA)

Both caused the JSONP regex to match CSS braces instead of the actual JSON data, resulting in a JSON parse error.

Fixes:
- Added `verify=False` with urllib3 warning suppression
- Added a browser User-Agent header
- Improved JSONP extraction regex to match `import({...})` wrapper specifically instead of any `{...}` pattern

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed South Derbyshire bin collection retrieval to restore consistent access to schedules, improve reliability of response parsing, and reduce extraneous warning output for a cleaner user experience.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robbrad/UKBinCollectionData/pull/2045)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->