### PR TITLE
fix: DurhamCouncil — switch to Selenium for JS-rendered bin data

### DIFF
--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -717,8 +717,9 @@
         "skip_get_url": true,
         "uprn": "200003218818",
         "url": "https://www.durham.gov.uk/bincollections?uprn=",
+        "web_driver": "http://selenium:4444",
         "wiki_name": "County Durham",
-        "wiki_note": "Pass the UPRN. You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search)."
+        "wiki_note": "Pass the UPRN. Uses Selenium to render JS-populated bin data."
     },
     "EalingCouncil": {
         "skip_get_url": true,

--- a/uk_bin_collection/uk_bin_collection/councils/DurhamCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/DurhamCouncil.py
@@ -1,30 +1,37 @@
 import re
 from datetime import datetime
 
-import requests
 from bs4 import BeautifulSoup
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.ui import WebDriverWait
+
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
 
-# import the wonderful Beautiful Soup and the URL grabber
 class CouncilClass(AbstractGetBinDataClass):
-    """
-    Concrete classes have to implement all abstract operations of the
-    base class. They can also override some operations with a default
-    implementation.
-    """
-
     def parse_data(self, page: str, **kwargs) -> dict:
-        url = "https://www.durham.gov.uk/bincollections?uprn="
         uprn = kwargs.get("uprn")
         check_uprn(uprn)
-        url += uprn
-        requests.packages.urllib3.disable_warnings()
-        page = requests.get(url)
+        headless = kwargs.get("headless")
+        web_driver = kwargs.get("web_driver")
 
-        # Make a BS4 object
-        soup = BeautifulSoup(page.text, features="html.parser")
+        url = f"https://www.durham.gov.uk/bincollections?uprn={uprn}"
+
+        driver = create_webdriver(web_driver, headless, None, __name__)
+        try:
+            driver.get(url)
+
+            WebDriverWait(driver, 30).until(
+                EC.presence_of_element_located(
+                    (By.CSS_SELECTOR, ".binsrubbish, .binsrecycling")
+                )
+            )
+
+            soup = BeautifulSoup(driver.page_source, features="html.parser")
+        finally:
+            driver.quit()
 
         data = {"bins": []}
 
@@ -35,15 +42,14 @@ class CouncilClass(AbstractGetBinDataClass):
                 collection_text = bin_info.get_text(strip=True)
 
                 if collection_text:
-                    results = re.search("\\d\\d? [A-Za-z]+ \\d{4}", collection_text)
+                    results = re.search(r"\d\d? [A-Za-z]+ \d{4}", collection_text)
                     if results:
                         date = datetime.strptime(results[0], "%d %B %Y")
-                        if date:
-                            data["bins"].append(
-                                {
-                                    "type": bin_type,
-                                    "collectionDate": date.strftime(date_format),
-                                }
-                            )
+                        data["bins"].append(
+                            {
+                                "type": bin_type,
+                                "collectionDate": date.strftime(date_format),
+                            }
+                        )
 
         return data

--- a/uk_bin_collection/uk_bin_collection/councils/DurhamCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/DurhamCouncil.py
@@ -24,8 +24,11 @@ class CouncilClass(AbstractGetBinDataClass):
             driver.get(url)
 
             WebDriverWait(driver, 30).until(
-                EC.presence_of_element_located(
-                    (By.CSS_SELECTOR, ".binsrubbish, .binsrecycling")
+                lambda d: any(
+                    el.text.strip()
+                    for el in d.find_elements(
+                        By.CSS_SELECTOR, ".binsrubbish, .binsrecycling"
+                    )
                 )
             )
 
@@ -51,5 +54,10 @@ class CouncilClass(AbstractGetBinDataClass):
                                 "collectionDate": date.strftime(date_format),
                             }
                         )
+
+        if not data["bins"]:
+            raise ValueError(
+                "No bin collection data found after parsing Durham page"
+            )
 
         return data


### PR DESCRIPTION
The bin collection page at `durham.gov.uk/bincollections?uprn=` renders data client-side via JavaScript. The existing scraper used `requests.get()` which only returned the empty HTML shell — the `binsrubbish`/`binsrecycling`/`binsgardenwaste` divs were present but unpopulated.

Switched to Selenium with `create_webdriver()` to render the JS. Waits for the bin data divs to appear, then parses with BeautifulSoup as before. The CSS class selectors and date parsing are unchanged.

Added `web_driver` to input.json config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Durham Council bin collection retrieval updated to use a JavaScript-rendering workflow for more reliable schedule and date extraction.
* **Documentation**
  * Test configuration and council note updated to reflect the new rendering approach used for Durham's data.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robbrad/UKBinCollectionData/pull/2047)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->