### PR TITLE
feat(BassetlawDistrictCouncil): add new scraper using ReCollect API

### DIFF
--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -1754,14 +1754,14 @@
         "LAD24CD": "E06000012"
     },
     "NorthHertfordshireDistrictCouncil": {
-            "house_number": "Stewards Flat",
-            "postcode": "SG5 1PZ",
-            "skip_get_url": true,
-            "url": "https://waste.nc.north-herts.gov.uk/w/webpage/find-bin-collection-day-input-address",
-            "web_driver": "http://selenium:4444",
-            "wiki_name": "North Hertfordshire",
-            "wiki_note": "Pass a postcode (with space) and house_number/name. The scraper performs the Liberty Create typeahead lookup and matches house_number as a case-insensitive substring.",
-            "LAD24CD": "E07000099"
+        "house_number": "Stewards Flat",
+        "postcode": "SG5 1PZ",
+        "skip_get_url": true,
+        "url": "https://waste.nc.north-herts.gov.uk/w/webpage/find-bin-collection-day-input-address",
+        "web_driver": "http://selenium:4444",
+        "wiki_name": "North Hertfordshire",
+        "wiki_note": "Pass a postcode (with space) and house_number/name. The scraper performs the Liberty Create typeahead lookup and matches house_number as a case-insensitive substring.",
+        "LAD24CD": "E07000099"
     },
     "NorthKestevenDistrictCouncil": {
         "skip_get_url": true,
@@ -2877,5 +2877,14 @@
         "wiki_name": "York",
         "wiki_note": "Provide your UPRN.",
         "LAD24CD": "E06000014"
+    },
+    "BassetlawDistrictCouncil": {
+        "LAD24CD": "E07000171",
+        "house_number": "2 Albert Road",
+        "postcode": "DN22 6JD",
+        "skip_get_url": true,
+        "uprn": "",
+        "url": "https://www.bassetlaw.gov.uk",
+        "wiki_name": "Bassetlaw"
     }
 }

--- a/uk_bin_collection/uk_bin_collection/councils/BassetlawDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/BassetlawDistrictCouncil.py
@@ -1,0 +1,151 @@
+import re
+from datetime import datetime, timedelta
+
+import requests
+
+from uk_bin_collection.uk_bin_collection.common import *
+from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
+
+HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36"
+}
+
+AREA = "BassetlawUK"
+SERVICE = "50015"
+
+
+class CouncilClass(AbstractGetBinDataClass):
+    def parse_data(self, page: str, **kwargs) -> dict:
+        data = {"bins": []}
+
+        user_paon = kwargs.get("paon")
+        postcode = kwargs.get("postcode")
+
+        suggest_url = f"https://api.eu.recollect.net/api/areas/{AREA}/services/{SERVICE}/address-suggest"
+
+        place_id = None
+
+        # Strategy 1: Try paon as full address text (works if user passes "2 Albert Road")
+        if user_paon and not user_paon.strip().isdigit():
+            params = {"q": user_paon, "locale": "en-GB"}
+            response = requests.get(suggest_url, headers=HEADERS, params=params, timeout=30)
+            response.raise_for_status()
+            for result in response.json():
+                if result.get("type") == "parcel" and result.get("place_id"):
+                    place_id = result["place_id"]
+                    break
+
+        # Strategy 2: Search postcode to get qualifier, then search house number within it
+        if not place_id and postcode:
+            params = {"q": postcode, "locale": "en-GB"}
+            response = requests.get(suggest_url, headers=HEADERS, params=params, timeout=30)
+            response.raise_for_status()
+            results = response.json()
+
+            # If postcode returns parcels directly, match by house number
+            parcels = [r for r in results if r.get("type") == "parcel" and r.get("place_id")]
+            if parcels:
+                if user_paon:
+                    for p in parcels:
+                        name = p.get("name", "")
+                        if name.lower().startswith(user_paon.lower()):
+                            place_id = p["place_id"]
+                            break
+                if not place_id and parcels:
+                    place_id = parcels[0]["place_id"]
+
+            # If postcode returns qualifiers, get all addresses for that postcode
+            if not place_id:
+                qualifiers = [r for r in results if r.get("type") == "place_qualifier"]
+                if qualifiers:
+                    qual = qualifiers[0]
+                    # Fetch all addresses in this postcode area
+                    params2 = {"q": "", "locale": "en-GB", "place_qualifier_id": qual["qualifier_id"]}
+                    response2 = requests.get(suggest_url, headers=HEADERS, params=params2, timeout=30)
+                    response2.raise_for_status()
+                    addresses = [r for r in response2.json() if r.get("type") == "parcel" and r.get("place_id")]
+
+                    if not addresses:
+                        # Qualifier empty search fails — try with postcode text inside qualifier
+                        params3 = {"q": postcode, "locale": "en-GB", "place_qualifier_id": qual["qualifier_id"]}
+                        response3 = requests.get(suggest_url, headers=HEADERS, params=params3, timeout=30)
+                        response3.raise_for_status()
+                        addresses = [r for r in response3.json() if r.get("type") == "parcel" and r.get("place_id")]
+
+                    if addresses and user_paon:
+                        for addr in addresses:
+                            name = addr.get("name", "")
+                            if name.lower().startswith(user_paon.lower()):
+                                place_id = addr["place_id"]
+                                break
+                            # Match house number at start of address
+                            num_match = re.match(r"^(\d+[a-zA-Z]?)\b", user_paon.strip())
+                            if num_match and name.startswith(num_match.group(1) + " "):
+                                place_id = addr["place_id"]
+                                break
+
+                    if not place_id and addresses:
+                        place_id = addresses[0]["place_id"]
+
+        # Strategy 3: Try combining paon + postcode as search
+        if not place_id and user_paon and postcode:
+            for q in [f"{user_paon} {postcode}", f"{user_paon}"]:
+                params = {"q": q, "locale": "en-GB"}
+                response = requests.get(suggest_url, headers=HEADERS, params=params, timeout=30)
+                response.raise_for_status()
+                for result in response.json():
+                    if result.get("type") == "parcel" and result.get("place_id"):
+                        place_id = result["place_id"]
+                        break
+                if place_id:
+                    break
+
+        if not place_id:
+            raise ValueError(
+                f"No address found for: {user_paon or postcode}"
+            )
+
+        now = datetime.now()
+        after = now.strftime("%Y-%m-%d")
+        before = (now + timedelta(days=60)).strftime("%Y-%m-%d")
+
+        events_url = f"https://api.eu.recollect.net/api/places/{place_id}/services/{SERVICE}/events"
+        params = {
+            "nomerge": "1",
+            "hide": "reminder_only",
+            "after": after,
+            "before": before,
+            "locale": "en-GB",
+        }
+        response = requests.get(events_url, headers=HEADERS, params=params, timeout=60)
+        response.raise_for_status()
+        events_data = response.json()
+
+        seen = set()
+        for event in events_data.get("events", []):
+            day = event.get("day")
+            if not day:
+                continue
+
+            for flag in event.get("flags", []):
+                if flag.get("event_type") != "pickup":
+                    continue
+
+                bin_type = flag.get("subject") or flag.get("name", "Unknown")
+                collection_date = datetime.strptime(day, "%Y-%m-%d").strftime(date_format)
+
+                key = (bin_type, collection_date)
+                if key not in seen:
+                    seen.add(key)
+                    data["bins"].append(
+                        {
+                            "type": bin_type,
+                            "collectionDate": collection_date,
+                        }
+                    )
+
+        data["bins"].sort(
+            key=lambda x: datetime.strptime(x.get("collectionDate"), date_format)
+        )
+
+        return data

--- a/uk_bin_collection/uk_bin_collection/councils/BassetlawDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/BassetlawDistrictCouncil.py
@@ -18,7 +18,7 @@ class CouncilClass(AbstractGetBinDataClass):
     def parse_data(self, page: str, **kwargs) -> dict:
         data = {"bins": []}
 
-        user_paon = kwargs.get("paon")
+        user_paon = kwargs.get("paon") or kwargs.get("house_number")
         postcode = kwargs.get("postcode")
 
         suggest_url = f"https://api.eu.recollect.net/api/areas/{AREA}/services/{SERVICE}/address-suggest"
@@ -51,8 +51,13 @@ class CouncilClass(AbstractGetBinDataClass):
                         if name.lower().startswith(user_paon.lower()):
                             place_id = p["place_id"]
                             break
-                if not place_id and parcels:
-                    place_id = parcels[0]["place_id"]
+                if not place_id:
+                    if len(parcels) == 1:
+                        place_id = parcels[0]["place_id"]
+                    elif user_paon:
+                        raise ValueError(
+                            f"Address '{user_paon}' not found among {len(parcels)} results for {postcode}"
+                        )
 
             # If postcode returns qualifiers, get all addresses for that postcode
             if not place_id:
@@ -84,8 +89,13 @@ class CouncilClass(AbstractGetBinDataClass):
                                 place_id = addr["place_id"]
                                 break
 
-                    if not place_id and addresses:
-                        place_id = addresses[0]["place_id"]
+                    if not place_id:
+                        if len(addresses) == 1:
+                            place_id = addresses[0]["place_id"]
+                        elif user_paon and addresses:
+                            raise ValueError(
+                                f"Address '{user_paon}' not found among {len(addresses)} results for {postcode}"
+                            )
 
         # Strategy 3: Try combining paon + postcode as search
         if not place_id and user_paon and postcode:
@@ -120,6 +130,9 @@ class CouncilClass(AbstractGetBinDataClass):
         response = requests.get(events_url, headers=HEADERS, params=params, timeout=60)
         response.raise_for_status()
         events_data = response.json()
+
+        if "events" not in events_data or not isinstance(events_data["events"], list):
+            raise ValueError("Unexpected events format from Bassetlaw API")
 
         seen = set()
         for event in events_data.get("events", []):


### PR DESCRIPTION
## Summary
- New scraper for Bassetlaw District Council using the ReCollect API (area `BassetlawUK`, service `50015`)
- Multi-strategy address resolution: full address text search, postcode qualifier expansion, and combined paon+postcode fallback
- Test address: 2 Albert Road, DN22 6JD (verified returning Green Waste, Blue Recycling, and Glass bins)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Bassetlaw District Council bin collection schedules.

* **Tests**
  * Updated test configuration to include Bassetlaw District Council and refined North Hertfordshire District Council test data.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robbrad/UKBinCollectionData/pull/2049)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->