### PR TITLE
fix(EastDevonDC): zero-pad UPRN to 12 digits

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/EastDevonDC.py
+++ b/uk_bin_collection/uk_bin_collection/councils/EastDevonDC.py
@@ -1,7 +1,7 @@
 import re
 from datetime import datetime
 
-import pandas as pd
+import requests
 from bs4 import BeautifulSoup
 
 from uk_bin_collection.uk_bin_collection.common import *
@@ -20,6 +20,8 @@ class CouncilClass(AbstractGetBinDataClass):
         try:
             user_uprn = kwargs.get("uprn")
             check_uprn(user_uprn)
+            # East Devon requires 12-digit zero-padded UPRNs
+            user_uprn = user_uprn.zfill(12)
             url = f"https://eastdevon.gov.uk/recycling-and-waste/recycling-waste-information/when-is-my-bin-collected/future-collections-calendar/?UPRN={user_uprn}"
             if not user_uprn:
                 # This is a fallback for if the user stored a URL in old system. Ensures backwards compatibility.


### PR DESCRIPTION
## Summary
- East Devon's website requires 12-digit zero-padded UPRNs
- Unpadded UPRNs (e.g. from PostGIS/UPRN database lookups) return empty pages with no error
- Added `.zfill(12)` to pad the UPRN before building the URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed UPRN (property reference) formatting for East Devon District Council lookups to ensure proper data retrieval for bin collection schedules.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robbrad/UKBinCollectionData/pull/2050)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->