### PR TITLE
fix(LincolnCouncil): zero-pad UPRN to 12 digits

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/LincolnCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/LincolnCouncil.py
@@ -20,6 +20,8 @@ class CouncilClass(AbstractGetBinDataClass):
         user_postcode = kwargs.get("postcode")
         check_uprn(user_uprn)
         check_postcode(user_postcode)
+        # Lincoln's AchieveForms API requires 12-digit zero-padded UPRNs
+        user_uprn = user_uprn.zfill(12)
         bindata = {"bins": []}
 
         SESSION_URL = "https://contact.lincoln.gov.uk/authapi/isauthenticated?uri=https://contact.lincoln.gov.uk/AchieveForms/?mode=fill&consentMessage=yes&form_uri=sandbox-publish://AF-Process-503f9daf-4db9-4dd8-876a-6f2029f11196/AF-Stage-a1c0af0f-fec1-4419-80c0-0dd4e1d965c9/definition.json&process=1&process_uri=sandbox-processes://AF-Process-503f9daf-4db9-4dd8-876a-6f2029f11196&process_id=AF-Process-503f9daf-4db9-4dd8-876a-6f2029f11196&hostname=contact.lincoln.gov.uk&withCredentials=true"


### PR DESCRIPTION
## Summary
- Lincoln's AchieveForms API matches UPRNs exactly against its database rows
- Unpadded UPRNs (e.g. `235024850` from PostGIS lookups) don't match any row, causing empty results
- Added `.zfill(12)` to pad the UPRN (e.g. `000235024850`) before the API call

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Lincoln Council bin collection data retrieval by ensuring the property reference is properly formatted to meet the council's API requirements. This resolves issues where users couldn't look up their collection schedules.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robbrad/UKBinCollectionData/pull/2051)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->