### PR TITLE
fix(LondonBoroughCamdenCouncil): rewrite for new waste portal API

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/LondonBoroughCamdenCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/LondonBoroughCamdenCouncil.py
@@ -1,7 +1,9 @@
 import requests
-from bs4 import BeautifulSoup
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
+
+BASE_URL = "https://recyclingandrubbishcollections.camden.gov.uk/api"
+COUNCIL_ID = "27"
 
 
 class CouncilClass(AbstractGetBinDataClass):
@@ -15,51 +17,69 @@ class CouncilClass(AbstractGetBinDataClass):
         check_uprn(user_uprn)
         check_postcode(user_postcode)
 
-        # Build the property URL
-        property_url = f"https://environmentservices.camden.gov.uk/property/{user_uprn}"
+        headers = {"Content-Type": "application/json"}
 
-        # Make the request
-        response = requests.get(property_url)
-        response.raise_for_status()
+        # Step 1: Search by postcode to resolve property ID
+        search_resp = requests.post(
+            f"{BASE_URL}/getPropertySearch",
+            json={"councilId": COUNCIL_ID, "searchQuery": user_postcode},
+            headers=headers,
+            timeout=30,
+        )
+        search_resp.raise_for_status()
+        search_data = search_resp.json()
 
-        # Parse the HTML
-        soup = BeautifulSoup(response.content, "html.parser")
+        properties = search_data.get("data", [])
+        if not properties:
+            raise ValueError(f"No properties found for postcode: {user_postcode}")
+
+        # Match by UPRN
+        point_id = None
+        for prop in properties:
+            if str(prop.get("uprn", "")) == str(user_uprn):
+                point_id = prop["id"]
+                break
+
+        # Fallback: first property if UPRN not matched
+        if not point_id:
+            point_id = properties[0]["id"]
+
+        # Step 2: Get collection days
+        collection_resp = requests.post(
+            f"{BASE_URL}/getCollectionDays",
+            json={
+                "pointId": str(point_id),
+                "pointType": "PointAddress",
+                "councilId": COUNCIL_ID,
+            },
+            headers=headers,
+            timeout=30,
+        )
+        collection_resp.raise_for_status()
+        collection_data = collection_resp.json()
 
         data = {"bins": []}
+        now = datetime.now()
 
-        # Find all service wrappers
-        service_wrappers = soup.find_all("div", class_="service-wrapper")
+        for service in collection_data.get("activeServices", []):
+            bin_type = service.get("serviceName", "Unknown")
 
-        for service in service_wrappers:
-            # Get the service name (bin type)
-            service_name_elem = service.find("h3", class_="service-name")
-            if not service_name_elem:
-                continue
+            for schedule in service.get("serviceSchedules", []):
+                date_str = schedule.get("currentScheduledDate")
+                if not date_str:
+                    continue
 
-            bin_type = service_name_elem.get_text(strip=True)
-            # Remove "Add to my calendar" text if present
-            bin_type = bin_type.replace("Add to my calendar", "").strip()
+                collection_date = datetime.fromisoformat(date_str)
+                if collection_date.date() >= now.date():
+                    data["bins"].append(
+                        {
+                            "type": bin_type,
+                            "collectionDate": collection_date.strftime(date_format),
+                        }
+                    )
 
-            # Find the next collection date
-            next_collection_elem = service.find("td", class_="next-service")
-            if not next_collection_elem:
-                continue
-
-            next_collection_date = next_collection_elem.get_text(strip=True)
-
-            # Parse the date (format: dd/mm/yyyy)
-            try:
-                collection_date = datetime.strptime(
-                    next_collection_date, "%d/%m/%Y"
-                )
-                data["bins"].append(
-                    {
-                        "type": bin_type,
-                        "collectionDate": collection_date.strftime(date_format),
-                    }
-                )
-            except ValueError:
-                # Skip if date parsing fails
-                continue
+        data["bins"].sort(
+            key=lambda x: datetime.strptime(x.get("collectionDate"), date_format)
+        )
 
         return data

--- a/uk_bin_collection/uk_bin_collection/councils/LondonBoroughCamdenCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/LondonBoroughCamdenCouncil.py
@@ -40,9 +40,10 @@ class CouncilClass(AbstractGetBinDataClass):
                 point_id = prop["id"]
                 break
 
-        # Fallback: first property if UPRN not matched
         if not point_id:
-            point_id = properties[0]["id"]
+            raise ValueError(
+                f"UPRN {user_uprn} not found in properties for postcode {user_postcode}"
+            )
 
         # Step 2: Get collection days
         collection_resp = requests.post(
@@ -58,10 +59,14 @@ class CouncilClass(AbstractGetBinDataClass):
         collection_resp.raise_for_status()
         collection_data = collection_resp.json()
 
+        active_services = collection_data.get("activeServices")
+        if not isinstance(active_services, list):
+            raise ValueError("Unexpected API response format")
+
         data = {"bins": []}
         now = datetime.now()
 
-        for service in collection_data.get("activeServices", []):
+        for service in active_services:
             bin_type = service.get("serviceName", "Unknown")
 
             for schedule in service.get("serviceSchedules", []):


### PR DESCRIPTION
## Summary
- Camden migrated from `environmentservices.camden.gov.uk` (server-rendered HTML) to `recyclingandrubbishcollections.camden.gov.uk` (Next.js SPA with JSON API)
- Old scraper parsed HTML `service-wrapper` divs which no longer exist
- Rewrote as pure requests hitting the new JSON API:
  1. `POST /api/getPropertySearch` with postcode to resolve property ID from UPRN
  2. `POST /api/getCollectionDays` with pointId/pointType/councilId to get schedules
- No Selenium needed, no reCAPTCHA token required
- Verified returning Rubbish, Food, and Recycling collection dates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Camden Council bin collection data retrieval to use official API endpoints for improved reliability and accuracy.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robbrad/UKBinCollectionData/pull/2052)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->