### PR TITLE
fix(MorayCouncil): add postcode-based property lookup

### DIFF
--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -1656,7 +1656,9 @@
         "url": "https://bindayfinder.moray.gov.uk/",
         "wiki_name": "Moray",
         "wiki_note": "Find your property ID by going to (https://bindayfinder.moray.gov.uk), search for your property and extracting the ID from the URL. i.e. (https://bindayfinder.moray.gov.uk/disp_bins.php?id=00028841)",
-        "LAD24CD": "S12000020"
+        "LAD24CD": "S12000020",
+        "postcode": "IV30 1NZ",
+        "house_number": "41 Mayne Road"
     },
     "NeathPortTalbotCouncil": {
         "house_number": "2",
@@ -1754,14 +1756,14 @@
         "LAD24CD": "E06000012"
     },
     "NorthHertfordshireDistrictCouncil": {
-            "house_number": "Stewards Flat",
-            "postcode": "SG5 1PZ",
-            "skip_get_url": true,
-            "url": "https://waste.nc.north-herts.gov.uk/w/webpage/find-bin-collection-day-input-address",
-            "web_driver": "http://selenium:4444",
-            "wiki_name": "North Hertfordshire",
-            "wiki_note": "Pass a postcode (with space) and house_number/name. The scraper performs the Liberty Create typeahead lookup and matches house_number as a case-insensitive substring.",
-            "LAD24CD": "E07000099"
+        "house_number": "Stewards Flat",
+        "postcode": "SG5 1PZ",
+        "skip_get_url": true,
+        "url": "https://waste.nc.north-herts.gov.uk/w/webpage/find-bin-collection-day-input-address",
+        "web_driver": "http://selenium:4444",
+        "wiki_name": "North Hertfordshire",
+        "wiki_note": "Pass a postcode (with space) and house_number/name. The scraper performs the Liberty Create typeahead lookup and matches house_number as a case-insensitive substring.",
+        "LAD24CD": "E07000099"
     },
     "NorthKestevenDistrictCouncil": {
         "skip_get_url": true,

--- a/uk_bin_collection/uk_bin_collection/councils/MorayCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/MorayCouncil.py
@@ -15,7 +15,6 @@ class CouncilClass(AbstractGetBinDataClass):
     on day divs within month containers.
     """
 
-    # CSS class -> bin type mapping (from the calendar legend)
     BIN_TYPE_MAP = {
         "B": "Brown Bin",
         "O": "Glass Container",
@@ -24,15 +23,65 @@ class CouncilClass(AbstractGetBinDataClass):
         "C": "Blue Bin",
     }
 
+    def _resolve_property_id(self, postcode: str, paon: str) -> str:
+        """Search Moray's postcode lookup to find the internal property ID."""
+        search_url = "https://bindayfinder.moray.gov.uk/refuse_roads.php"
+        response = requests.get(
+            search_url,
+            params={"pcode": postcode},
+            timeout=30,
+        )
+        response.raise_for_status()
+
+        soup = BeautifulSoup(response.text, "html.parser")
+        links = soup.find_all("a", href=re.compile(r"disp_bins\.php\?id="))
+
+        if not links:
+            raise ValueError(f"No properties found for postcode: {postcode}")
+
+        # Try to match by house number/name
+        if paon:
+            paon_lower = paon.strip().lower()
+            num_match = re.match(r"^(\d+)", paon_lower)
+
+            for link in links:
+                link_text = link.get_text(strip=True).lower()
+                # Exact start match
+                if link_text.startswith(paon_lower):
+                    return re.search(r"id=(\d+)", link["href"]).group(1)
+                # House number match
+                if num_match:
+                    link_num = re.match(r"^(\d+)", link_text)
+                    if link_num and link_num.group(1) == num_match.group(1):
+                        return re.search(r"id=(\d+)", link["href"]).group(1)
+
+        # Fallback: first property
+        return re.search(r"id=(\d+)", links[0]["href"]).group(1)
+
     def parse_data(self, page: str, **kwargs) -> dict:
         user_uprn = kwargs.get("uprn")
+        user_postcode = kwargs.get("postcode")
+        user_paon = kwargs.get("paon")
         bindata = {"bins": []}
 
-        user_uprn = str(user_uprn).zfill(8)
+        property_id = None
+
+        # If postcode is available, resolve via Moray's own search
+        # (Moray uses internal IDs, not real UPRNs)
+        if user_postcode:
+            property_id = self._resolve_property_id(user_postcode, user_paon or "")
+        elif user_uprn:
+            # Legacy: direct property ID passed as UPRN
+            property_id = str(user_uprn).zfill(8)
+
+        if not property_id:
+            raise ValueError("Either postcode or property ID (as UPRN) required")
+
+        property_id = property_id.zfill(8)
         year = datetime.today().year
 
-        url = f"https://bindayfinder.moray.gov.uk/cal_{year}_view.php?id={user_uprn}"
-        response = requests.get(url)
+        url = f"https://bindayfinder.moray.gov.uk/cal_{year}_view.php?id={property_id}"
+        response = requests.get(url, timeout=30)
 
         if response.status_code != 200:
             return bindata
@@ -40,7 +89,6 @@ class CouncilClass(AbstractGetBinDataClass):
         soup = BeautifulSoup(response.text, "html.parser")
         today = datetime.today().date()
 
-        # Month names for parsing
         month_names = [
             "January", "February", "March", "April", "May", "June",
             "July", "August", "September", "October", "November", "December",
@@ -59,26 +107,21 @@ class CouncilClass(AbstractGetBinDataClass):
             if not days_container:
                 continue
 
-            day_num = 0
             for day_div in days_container.find_all("div"):
                 css_classes = day_div.get("class", [])
 
-                # Skip blank days
                 if "blank" in css_classes:
                     continue
 
-                # Get the day number from the text
                 day_text = day_div.text.strip()
                 if not day_text or not day_text.isdigit():
                     continue
                 day_num = int(day_text)
 
-                # Check if this day has bin collection classes
                 for css_class in css_classes:
                     if css_class in ("blank", "day-name", ""):
                         continue
 
-                    # Each character in the CSS class represents a bin type
                     for char in css_class:
                         if char in self.BIN_TYPE_MAP:
                             try:

--- a/uk_bin_collection/uk_bin_collection/councils/MorayCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/MorayCouncil.py
@@ -55,13 +55,17 @@ class CouncilClass(AbstractGetBinDataClass):
                     if link_num and link_num.group(1) == num_match.group(1):
                         return re.search(r"id=(\d+)", link["href"]).group(1)
 
-        # Fallback: first property
+        # Fallback: only use first property when no PAON was specified
+        if paon:
+            raise ValueError(
+                f"Address '{paon}' not found among {len(links)} properties for postcode"
+            )
         return re.search(r"id=(\d+)", links[0]["href"]).group(1)
 
     def parse_data(self, page: str, **kwargs) -> dict:
         user_uprn = kwargs.get("uprn")
         user_postcode = kwargs.get("postcode")
-        user_paon = kwargs.get("paon")
+        user_paon = kwargs.get("paon") or kwargs.get("house_number")
         bindata = {"bins": []}
 
         property_id = None


### PR DESCRIPTION
## Summary
- Moray uses internal property IDs (e.g. `00030500`), not real UPRNs
- When called via APIs that resolve real UPRNs from PostGIS, the scraper gets IDs Moray doesn't recognize → empty results
- Added postcode+address search via `refuse_roads.php` to resolve the internal property ID automatically
- Falls back to direct UPRN-as-ID for backwards compatibility with existing users
- Added postcode and house_number to test config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Moray Council now supports property lookup using postcode and house number for convenient bin schedule access.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robbrad/UKBinCollectionData/pull/2053)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->