### PR TITLE
fix(WolverhamptonCityCouncil): fix CSS class match and skip non-bin divs

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/WolverhamptonCityCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/WolverhamptonCityCouncil.py
@@ -7,7 +7,6 @@ from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
 
-# import the wonderful Beautiful Soup and the URL grabber
 class CouncilClass(AbstractGetBinDataClass):
     """
     Concrete classes have to implement all abstract operations of the
@@ -27,19 +26,27 @@ class CouncilClass(AbstractGetBinDataClass):
 
         URI = f"https://www.wolverhampton.gov.uk/find-my-nearest/{user_postcode}/{user_uprn}"
 
-        # Make the GET request
         response = requests.get(URI)
 
         soup = BeautifulSoup(response.content, "html.parser")
 
-        jumbotron = soup.find("div", {"class": "jumbotron jumbotron-fluid"})
+        jumbotron = soup.find("div", class_="jumbotron")
+        if not jumbotron:
+            raise ValueError("Could not find bin collection data on page")
 
-        # Find all bin entries in the row
         for bin_div in jumbotron.select("div.col-md-4"):
-            service_name = bin_div.h3.text.strip()
-            next_date = bin_div.find(
+            h3 = bin_div.find("h3")
+            if not h3:
+                continue
+
+            next_date_h4 = bin_div.find(
                 "h4", text=lambda x: x and "Next date" in x
-            ).text.split(": ")[1]
+            )
+            if not next_date_h4:
+                continue
+
+            service_name = h3.text.strip()
+            next_date = next_date_h4.text.split(": ")[1]
 
             dict_data = {
                 "type": service_name,

--- a/uk_bin_collection/uk_bin_collection/councils/WolverhamptonCityCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/WolverhamptonCityCouncil.py
@@ -46,7 +46,9 @@ class CouncilClass(AbstractGetBinDataClass):
                 continue
 
             service_name = h3.text.strip()
-            next_date = next_date_h4.text.split(": ")[1]
+            _, _, next_date = next_date_h4.text.partition(": ")
+            if not next_date:
+                raise ValueError(f"Unexpected date format: {next_date_h4.text!r}")
 
             dict_data = {
                 "type": service_name,


### PR DESCRIPTION
## Summary
- Site dropped `jumbotron-fluid` from CSS classes — scraper was looking for `jumbotron jumbotron-fluid` (exact match), now uses loose `jumbotron` match
- Added null checks for non-bin `col-md-4` divs (councillors, schools share the same class) — previously crashed with AttributeError when iterating them
- Raises ValueError with clear message when jumbotron div is missing entirely

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved reliability of Wolverhampton Council bin schedule lookups with enhanced error handling. The service now gracefully manages incomplete or missing data entries, reducing lookup failures and ensuring more consistent results.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robbrad/UKBinCollectionData/pull/2054)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->