### PR TITLE
fix(WirralCouncil): Rewrite for new LocalGov Drupal site

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/WirralCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/WirralCouncil.py
@@ -1,142 +1,210 @@
+import re
+from datetime import datetime
+
+import requests
 from bs4 import BeautifulSoup
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.support.ui import Select, WebDriverWait
 
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
 
 class CouncilClass(AbstractGetBinDataClass):
-    """
-    Concrete classes have to implement all abstract operations of the
-    base class. They can also override some operations with a default
-    implementation.
-    """
-
     def parse_data(self, page: str, **kwargs) -> dict:
-        driver = None
-        try:
-            page = "https://www.wirral.gov.uk/bins-and-recycling/bin-collection-dates"
-            user_postcode = kwargs.get("postcode")
-            user_paon = kwargs.get("paon")
-            web_driver = kwargs.get("web_driver")
-            headless = kwargs.get("headless")
+        user_postcode = kwargs.get("postcode")
+        user_uprn = kwargs.get("uprn")
+        check_postcode(user_postcode)
 
-            # Create Selenium webdriver
-            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
-            driver = create_webdriver(web_driver, headless, user_agent, __name__)
-            driver.get(page)
+        base = "https://www.wirral.gov.uk"
+        url = f"{base}/bins-and-recycling/bin-collection-dates"
 
-            # Handle cookie consent if present
-            try:
-                cookie_button = WebDriverWait(driver, 5).until(
-                    EC.element_to_be_clickable(
-                        (By.ID, "ccc-recommended-settings")
-                    )
-                )
-                cookie_button.click()
-                time.sleep(1)
-            except:
-                pass  # Cookie banner not present or already accepted
+        s = requests.Session()
+        s.headers.update(
+            {
+                "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+                "(KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            }
+        )
 
-            # Wait for and switch to the iframe
-            iframe = WebDriverWait(driver, 10).until(
-                EC.presence_of_element_located((By.ID, "BinIFrame"))
-            )
-            driver.switch_to.frame(iframe)
+        # Step 1: GET form to obtain form_build_id
+        r1 = s.get(url, verify=False)
+        r1.raise_for_status()
+        soup1 = BeautifulSoup(r1.text, "html.parser")
 
-            # Wait for postcode input and enter postcode
-            postcode_input = WebDriverWait(driver, 10).until(
-                EC.presence_of_element_located((By.ID, "MainContent_Postcode"))
-            )
-            postcode_input.send_keys(user_postcode)
+        form = soup1.find("form", id="localgov-waste-collection-postcode-form")
+        if not form:
+            raise ValueError("Postcode form not found on page")
 
-            # Click the Go button to search for addresses
-            go_button = driver.find_element(By.ID, "MainContent_LookupPostcode")
-            go_button.click()
+        data1 = {}
+        for inp in form.find_all("input"):
+            name = inp.get("name")
+            if name:
+                data1[name] = inp.get("value", "")
+        data1["postcode"] = user_postcode
 
-            # Wait for address dropdown to appear
-            address_dropdown = WebDriverWait(driver, 10).until(
-                EC.presence_of_element_located((By.ID, "MainContent_addressDropDown"))
-            )
+        # Step 2: POST postcode to get address list
+        r2 = s.post(url, data=data1, verify=False)
+        r2.raise_for_status()
+        soup2 = BeautifulSoup(r2.text, "html.parser")
 
-            # Select the address from dropdown
-            select = Select(address_dropdown)
-            found = False
-            for option in select.options:
-                if user_paon.lower() in option.text.lower():
-                    option.click()
-                    found = True
+        form2 = soup2.find("form", id="localgov-waste-collection-address-select-form")
+        if not form2:
+            raise ValueError(f"No addresses found for postcode {user_postcode}")
+
+        # If UPRN provided, use it directly; otherwise pick first address
+        select = form2.find("select", id="edit-uprn")
+        if not select:
+            raise ValueError("Address dropdown not found")
+
+        options = select.find_all("option")
+        valid_options = [o for o in options if o.get("value")]
+
+        if not valid_options:
+            raise ValueError(f"No addresses returned for {user_postcode}")
+
+        selected_uprn = None
+        if user_uprn:
+            for o in valid_options:
+                if str(o["value"]) == str(user_uprn):
+                    selected_uprn = o["value"]
                     break
-
-            if not found:
+            if not selected_uprn:
                 raise ValueError(
-                    f"Address with house number '{user_paon}' not found in dropdown"
+                    f"UPRN {user_uprn} not found in address list for {user_postcode}"
                 )
+        else:
+            selected_uprn = valid_options[0]["value"]
 
-            # Click Find bin collections button
-            find_button = driver.find_element(By.ID, "MainContent_FindRounds")
-            find_button.click()
+        # Step 3: POST UPRN selection
+        action = form2.get("action", "")
+        post_url = f"{base}{action}" if action.startswith("/") else action
 
-            # Wait for results to load
-            WebDriverWait(driver, 10).until(
-                EC.presence_of_element_located((By.ID, "MainContent_MainOutput"))
+        data2 = {}
+        for inp in form2.find_all("input"):
+            name = inp.get("name")
+            if name:
+                data2[name] = inp.get("value", "")
+        data2["uprn"] = selected_uprn
+
+        r3 = s.post(post_url, data=data2, verify=False)
+        r3.raise_for_status()
+        soup3 = BeautifulSoup(r3.text, "html.parser")
+
+        # Parse collection dates from calendar
+        data = {"bins": []}
+        current_year = datetime.now().year
+
+        # Each month has an h3 heading, followed by day entries
+        # Day entries contain: day number, bin type, and bin colour
+        month_sections = soup3.find_all("h3")
+        for month_h3 in month_sections:
+            month_name = month_h3.text.strip()
+            if not re.match(
+                r"^(January|February|March|April|May|June|July|August|September|October|November|December)$",
+                month_name,
+            ):
+                continue
+
+            container = month_h3.find_parent("div")
+            if not container:
+                continue
+
+            # Find day entries - each has a day number and collection info
+            day_items = container.find_all(
+                "div", class_=re.compile(r"localgov-waste-collection-day")
             )
 
-            # Get the page source and parse with BeautifulSoup
-            soup = BeautifulSoup(driver.page_source, "html.parser")
+            if not day_items:
+                # Fallback: parse text content
+                text = container.get_text(separator="\n", strip=True)
+                lines = text.split("\n")
+                i = 0
+                while i < len(lines):
+                    line = lines[i].strip()
+                    if line.isdigit():
+                        day = int(line)
+                        # Next lines should be bin type info
+                        bin_types = []
+                        i += 1
+                        while i < len(lines) and not lines[i].strip().isdigit():
+                            bin_line = lines[i].strip()
+                            if bin_line and bin_line != month_name:
+                                bin_types.append(bin_line)
+                            i += 1
+                        # Group consecutive non-digit lines as bin type entries
+                        # Pattern: "Bin type\nColour" pairs
+                        j = 0
+                        while j < len(bin_types):
+                            bin_type = bin_types[j]
+                            if bin_type in (
+                                "Green",
+                                "Grey",
+                                "Brown",
+                                "Blue",
+                                "Black",
+                            ):
+                                j += 1
+                                continue
+                            try:
+                                collection_date = datetime(
+                                    current_year,
+                                    datetime.strptime(month_name, "%B").month,
+                                    day,
+                                )
+                                data["bins"].append(
+                                    {
+                                        "type": bin_type,
+                                        "collectionDate": collection_date.strftime(
+                                            date_format
+                                        ),
+                                    }
+                                )
+                            except ValueError:
+                                pass
+                            j += 1
+                    else:
+                        i += 1
 
-            # Extract bin collection data from the MainOutput div
-            main_output = soup.find("div", {"id": "MainContent_MainOutput"})
-            if not main_output:
-                raise ValueError("Could not find collection data on page")
+        if not data["bins"]:
+            # Fallback: try "Next collection" section
+            next_h2 = soup3.find("h2", string=re.compile(r"Next collection"))
+            if next_h2:
+                parent = next_h2.find_parent("div")
+                if parent:
+                    text = parent.get_text(separator="\n", strip=True)
+                    # Parse "Friday 15 May\nNon-recyclable waste" pattern
+                    date_match = re.search(
+                        r"(\w+day)\s+(\d{1,2})\s+(\w+)", text
+                    )
+                    if date_match:
+                        day = int(date_match.group(2))
+                        month = date_match.group(3)
+                        try:
+                            collection_date = datetime.strptime(
+                                f"{day} {month} {current_year}", "%d %B %Y"
+                            )
+                            # Find bin type after the date
+                            type_match = re.search(
+                                r"(?:Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday)\s+\d{1,2}\s+\w+\n(.+)",
+                                text,
+                            )
+                            if type_match:
+                                bin_type = type_match.group(1).strip()
+                                data["bins"].append(
+                                    {
+                                        "type": bin_type,
+                                        "collectionDate": collection_date.strftime(
+                                            date_format
+                                        ),
+                                    }
+                                )
+                        except ValueError:
+                            pass
 
-            bindata = {"bins": []}
+        if not data["bins"]:
+            raise ValueError("No collection data found on page")
 
-            # Parse the text content
-            text = main_output.get_text()
+        data["bins"].sort(
+            key=lambda x: datetime.strptime(x.get("collectionDate"), date_format)
+        )
 
-            # Extract Grey bin (recycling) dates
-            grey_match = re.search(
-                r"Grey bin.*?(\d{1,2}\s+\w+\s+\d{4})", text, re.DOTALL
-            )
-            if grey_match:
-                date_str = grey_match.group(1)
-                collection_date = datetime.strptime(date_str, "%d %B %Y").strftime(
-                    date_format
-                )
-                bindata["bins"].append(
-                    {"type": "Grey bin (recycling)", "collectionDate": collection_date}
-                )
-
-            # Extract Green bin (non-recyclable waste) dates
-            green_match = re.search(
-                r"Green bin.*?(\d{1,2}\s+\w+\s+\d{4})", text, re.DOTALL
-            )
-            if green_match:
-                date_str = green_match.group(1)
-                collection_date = datetime.strptime(date_str, "%d %B %Y").strftime(
-                    date_format
-                )
-                bindata["bins"].append(
-                    {
-                        "type": "Green bin (non-recyclable waste)",
-                        "collectionDate": collection_date,
-                    }
-                )
-
-            # Sort by collection date
-            bindata["bins"].sort(
-                key=lambda x: datetime.strptime(x.get("collectionDate"), date_format)
-            )
-
-        except Exception as e:
-            print(f"An error occurred: {e}")
-            raise
-        finally:
-            # Close the driver
-            if driver:
-                driver.quit()
-
-        return bindata
+        return data

--- a/uk_bin_collection/uk_bin_collection/councils/WirralCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/WirralCouncil.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from datetime import datetime
 
@@ -26,7 +27,7 @@ class CouncilClass(AbstractGetBinDataClass):
         )
 
         # Step 1: GET form to obtain form_build_id
-        r1 = s.get(url, verify=False)
+        r1 = s.get(url, timeout=30)
         r1.raise_for_status()
         soup1 = BeautifulSoup(r1.text, "html.parser")
 
@@ -42,7 +43,7 @@ class CouncilClass(AbstractGetBinDataClass):
         data1["postcode"] = user_postcode
 
         # Step 2: POST postcode to get address list
-        r2 = s.post(url, data=data1, verify=False)
+        r2 = s.post(url, data=data1, timeout=30)
         r2.raise_for_status()
         soup2 = BeautifulSoup(r2.text, "html.parser")
 
@@ -76,7 +77,12 @@ class CouncilClass(AbstractGetBinDataClass):
 
         # Step 3: POST UPRN selection
         action = form2.get("action", "")
-        post_url = f"{base}{action}" if action.startswith("/") else action
+        if not action:
+            post_url = url
+        elif action.startswith("/"):
+            post_url = f"{base}{action}"
+        else:
+            post_url = action
 
         data2 = {}
         for inp in form2.find_all("input"):
@@ -85,13 +91,15 @@ class CouncilClass(AbstractGetBinDataClass):
                 data2[name] = inp.get("value", "")
         data2["uprn"] = selected_uprn
 
-        r3 = s.post(post_url, data=data2, verify=False)
+        r3 = s.post(post_url, data=data2, timeout=30)
         r3.raise_for_status()
         soup3 = BeautifulSoup(r3.text, "html.parser")
 
         # Parse collection dates from calendar
         data = {"bins": []}
-        current_year = datetime.now().year
+        now = datetime.now()
+        current_year = now.year
+        current_month = now.month
 
         # Each month has an h3 heading, followed by day entries
         # Day entries contain: day number, bin type, and bin colour
@@ -145,9 +153,11 @@ class CouncilClass(AbstractGetBinDataClass):
                                 j += 1
                                 continue
                             try:
+                                parsed_month = datetime.strptime(month_name, "%B").month
+                                year = current_year + 1 if parsed_month < current_month else current_year
                                 collection_date = datetime(
-                                    current_year,
-                                    datetime.strptime(month_name, "%B").month,
+                                    year,
+                                    parsed_month,
                                     day,
                                 )
                                 data["bins"].append(
@@ -158,8 +168,8 @@ class CouncilClass(AbstractGetBinDataClass):
                                         ),
                                     }
                                 )
-                            except ValueError:
-                                pass
+                            except ValueError as e:
+                                logging.warning(f"Failed to parse date {day} {month_name}: {e}")
                             j += 1
                     else:
                         i += 1
@@ -179,8 +189,10 @@ class CouncilClass(AbstractGetBinDataClass):
                         day = int(date_match.group(2))
                         month = date_match.group(3)
                         try:
+                            parsed_month = datetime.strptime(month, "%B").month
+                            year = current_year + 1 if parsed_month < current_month else current_year
                             collection_date = datetime.strptime(
-                                f"{day} {month} {current_year}", "%d %B %Y"
+                                f"{day} {month} {year}", "%d %B %Y"
                             )
                             # Find bin type after the date
                             type_match = re.search(
@@ -197,8 +209,8 @@ class CouncilClass(AbstractGetBinDataClass):
                                         ),
                                     }
                                 )
-                        except ValueError:
-                            pass
+                        except ValueError as e:
+                            logging.warning(f"Failed to parse fallback date {day} {month}: {e}")
 
         if not data["bins"]:
             raise ValueError("No collection data found on page")


### PR DESCRIPTION
## Summary
- Old URL (`wdp.wirral.gov.uk`) no longer resolves — council migrated to `wirral.gov.uk/bins-and-recycling/bin-collection-dates` running LocalGov Drupal
- Rewrote as pure requests (no Selenium needed): GET form tokens → POST postcode → POST UPRN selection → parse calendar
- Returns full 6-month calendar with all collection types

## Test
- Postcode: CH44 2BH
- UPRN: 42029386

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable retrieval of Wirral bin collection dates with improved address validation, clearer error handling when address options are missing, and a “Next collection” fallback to surface upcoming pickups.

* **Refactor**
  * Reworked the backend fetch/parsing flow for Wirral Council to improve stability and make schedule extraction more robust across varied page layouts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robbrad/UKBinCollectionData/pull/2055)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->