### PR TITLE
fix(StratfordUponAvonCouncil): Add postcode lookup via council API

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/StratfordUponAvonCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/StratfordUponAvonCouncil.py
@@ -1,94 +1,125 @@
+import requests
 from bs4 import BeautifulSoup
+
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
 
-# import the wonderful Beautiful Soup and the URL grabber
 class CouncilClass(AbstractGetBinDataClass):
-    """
-    Concrete classes have to implement all abstract operations of the
-    base class. They can also override some operations with a default
-    implementation.
-    """
-
     def parse_data(self, page: str, **kwargs) -> dict:
-        driver = None
-        try:
-            # Get postcode and UPRN from kwargs
-            # user_postcode = kwargs.get("postcode")
-            user_uprn = kwargs.get("uprn")
-            # check_postcode(user_postcode)
-            check_uprn(user_uprn)
-            url = "https://www.stratford.gov.uk/waste-recycling/when-we-collect.cfm/part/calendar"
-            payload = {
-                "frmAddress1": "",
-                "frmAddress2": "",
-                "frmAddress3": "",
-                "frmAddress4": "",
-                "frmPostcode": "",
-                "frmUPRN": user_uprn,
+        user_postcode = kwargs.get("postcode")
+        user_paon = kwargs.get("paon")
+        user_uprn = kwargs.get("uprn")
+        check_postcode(user_postcode)
+
+        api_base = "https://api.stratford.gov.uk/v1/addresses/postcode"
+        calendar_url = "https://www.stratford.gov.uk/waste-recycling/when-we-collect.cfm/part/calendar"
+
+        s = requests.Session()
+        s.headers.update(
+            {
+                "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+                "(KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36",
+                "Referer": "https://www.stratford.gov.uk/waste-recycling/when-we-collect.cfm",
+                "Origin": "https://www.stratford.gov.uk",
             }
-            headers = {"Content-Type": "application/x-www-form-urlencoded"}
+        )
 
-            requests.packages.urllib3.disable_warnings()
-            response = requests.request("POST", url, data=payload, headers=headers)
+        # Step 1: Lookup addresses by postcode via API
+        postcode_stripped = user_postcode.replace(" ", "")
+        params = {"national": "false", "includeNonPostal": "false"}
+        r1 = s.get(f"{api_base}/{postcode_stripped}", params=params, verify=False)
+        r1.raise_for_status()
+        result = r1.json()
 
-            # Make a BS4 object
-            soup = BeautifulSoup(response.content, features="html.parser")
-            soup.prettify()
+        addresses = result.get("data", [])
+        if not addresses:
+            raise ValueError(f"No addresses found for postcode {user_postcode}")
 
-            # Find the table
-            table = soup.find("table", class_="table")
+        # Step 2: Match address by UPRN or house number
+        selected_uprn = None
 
-            data = {"bins": []}
+        if user_uprn:
+            for addr in addresses:
+                if str(addr.get("uprn")) == str(user_uprn):
+                    selected_uprn = str(addr["uprn"])
+                    break
 
-            if table:
-                # Extract the column headers (bin names)
-                column_headers = [
-                    header.text.strip()
-                    for header in table.select("thead th.text-center strong")
-                ]
+        if not selected_uprn and user_paon:
+            paon_lower = user_paon.lower().strip()
+            for addr in addresses:
+                line1 = (addr.get("addressLine1") or "").lower()
+                full = (addr.get("fullAddress") or "").lower()
+                if line1.startswith(paon_lower) or full.startswith(paon_lower):
+                    selected_uprn = str(addr["uprn"])
+                    break
+            if not selected_uprn:
+                for addr in addresses:
+                    full = (addr.get("fullAddress") or "").lower()
+                    if paon_lower in full:
+                        selected_uprn = str(addr["uprn"])
+                        break
 
-                # Extract the rows containing collection information
-                collection_rows = table.select("tbody tr")
+        if not selected_uprn:
+            selected_uprn = str(addresses[0]["uprn"])
 
-                # Create a dictionary to store the next date for each bin
-                next_collection_dates = {bin: None for bin in column_headers}
+        # Step 3: POST to calendar with UPRN
+        payload = {
+            "frmAddress1": "",
+            "frmAddress2": "",
+            "frmAddress3": "",
+            "frmAddress4": "",
+            "frmPostcode": "",
+            "frmUPRN": selected_uprn,
+        }
 
-                # Iterate through the rows
-                for row in collection_rows:
-                    # Get the date from the first cell
-                    date_str = row.find("td").text.strip()
-                    date_obj = datetime.strptime(date_str, "%A, %d/%m/%Y")
+        r2 = s.post(calendar_url, data=payload, verify=False)
+        r2.raise_for_status()
+        soup = BeautifulSoup(r2.text, "html.parser")
 
-                    # Get the collection information for each bin (td elements with title attribute)
-                    collection_info = [
-                        cell["title"] if cell["title"] else "Not Collected"
-                        for cell in row.select("td.text-center")
-                    ]
+        # Step 4: Parse collection table
+        table = soup.find("table", class_="table")
+        if not table:
+            raise ValueError("Collection table not found")
 
-                    # Iterate through each bin type and its collection date
-                    for bin, status in zip(column_headers, collection_info):
-                        # If the bin hasn't had a collection date yet or the new date is earlier, update it
-                        if status != "Not Collected" and (
-                            not next_collection_dates[bin]
-                            or date_obj < next_collection_dates[bin]
-                        ):
-                            next_collection_dates[bin] = date_obj
+        data = {"bins": []}
+        column_headers = [
+            header.text.strip()
+            for header in table.select("thead th.text-center strong")
+        ]
 
-                data["bins"] = [
-                    {"type": bin, "collectionDate": next_date.strftime(date_format)}
-                    for bin, next_date in next_collection_dates.items()
-                ]
-            else:
-                print("Table not found in the HTML content.")
-        except Exception as e:
-            # Here you can log the exception if needed
-            print(f"An error occurred: {e}")
-            # Optionally, re-raise the exception if you want it to propagate
-            raise
-        finally:
-            # This block ensures that the driver is closed regardless of an exception
-            if driver:
-                driver.quit()
+        next_collection_dates = {b: None for b in column_headers}
+
+        for row in table.select("tbody tr"):
+            date_cell = row.find("td")
+            if not date_cell:
+                continue
+            date_str = date_cell.text.strip()
+            try:
+                date_obj = datetime.strptime(date_str, "%A, %d/%m/%Y")
+            except ValueError:
+                continue
+
+            collection_info = [
+                cell.get("title", "Not Collected")
+                for cell in row.select("td.text-center")
+            ]
+
+            for bin_type, status in zip(column_headers, collection_info):
+                if status and status != "Not Collected":
+                    if (
+                        not next_collection_dates[bin_type]
+                        or date_obj < next_collection_dates[bin_type]
+                    ):
+                        next_collection_dates[bin_type] = date_obj
+
+        data["bins"] = [
+            {"type": b, "collectionDate": d.strftime(date_format)}
+            for b, d in next_collection_dates.items()
+            if d is not None
+        ]
+
+        if not data["bins"]:
+            raise ValueError("No collection data found")
+
         return data

--- a/uk_bin_collection/uk_bin_collection/councils/StratfordUponAvonCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/StratfordUponAvonCouncil.py
@@ -26,9 +26,11 @@ class CouncilClass(AbstractGetBinDataClass):
         )
 
         # Step 1: Lookup addresses by postcode via API
+        if not user_postcode:
+            raise ValueError("Postcode is required")
         postcode_stripped = user_postcode.replace(" ", "")
         params = {"national": "false", "includeNonPostal": "false"}
-        r1 = s.get(f"{api_base}/{postcode_stripped}", params=params, verify=False)
+        r1 = s.get(f"{api_base}/{postcode_stripped}", params=params, timeout=30)
         r1.raise_for_status()
         result = r1.json()
 
@@ -61,6 +63,10 @@ class CouncilClass(AbstractGetBinDataClass):
                         break
 
         if not selected_uprn:
+            if user_uprn or user_paon:
+                raise ValueError(
+                    f"Address not found for UPRN={user_uprn} PAON={user_paon} in postcode {user_postcode}"
+                )
             selected_uprn = str(addresses[0]["uprn"])
 
         # Step 3: POST to calendar with UPRN
@@ -73,7 +79,7 @@ class CouncilClass(AbstractGetBinDataClass):
             "frmUPRN": selected_uprn,
         }
 
-        r2 = s.post(calendar_url, data=payload, verify=False)
+        r2 = s.post(calendar_url, data=payload, timeout=30)
         r2.raise_for_status()
         soup = BeautifulSoup(r2.text, "html.parser")
 
@@ -105,7 +111,11 @@ class CouncilClass(AbstractGetBinDataClass):
                 for cell in row.select("td.text-center")
             ]
 
-            for bin_type, status in zip(column_headers, collection_info):
+            try:
+                pairs = list(zip(column_headers, collection_info, strict=True))
+            except ValueError:
+                pairs = list(zip(column_headers, collection_info))
+            for bin_type, status in pairs:
                 if status and status != "Not Collected":
                     if (
                         not next_collection_dates[bin_type]


### PR DESCRIPTION
## Summary
- API-resolved UPRNs don't match council's system — calendar POST returns search form instead of results
- Added postcode search via `api.stratford.gov.uk/v1/addresses/postcode/` to resolve correct UPRN before POSTing to calendar
- Address matching: UPRN → house number → first result

## Test
- Postcode: CV36 4AB
- UPRN: 100070212698

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced address resolution for Stratford-upon-Avon collections: supports postcode, property number (PAON) and UPRN lookup for more accurate matches.
  * More reliable parsing of collection calendars, extracting bin types and upcoming dates consistently.
* **Bug Fixes**
  * Fails fast with clearer validation when a collection schedule or matching address cannot be found.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robbrad/UKBinCollectionData/pull/2057)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->