### PR TITLE
fix: CalderdaleCouncil - rewrite as pure requests

### DIFF
--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -409,7 +409,6 @@
         "skip_get_url": true,
         "uprn": "010035034598",
         "url": "https://www.calderdale.gov.uk/environment/waste/household-collections/collectiondayfinder.jsp",
-        "web_driver": "http://selenium:4444",
         "wiki_name": "Calderdale",
         "wiki_note": "Pass the UPRN and postcode. To get the UPRN, you can use [FindMyAddress](https://www.findmyaddress.co.uk/search).",
         "LAD24CD": "E08000033"
@@ -879,7 +878,7 @@
         "url": "https://environmentfirst.co.uk/house.php?uprn=100060055444",
         "wiki_command_url_override": "https://environmentfirst.co.uk/house.php?uprn=XXXXXXXXXX",
         "wiki_name": "Environment First",
-        "wiki_note": "For properties with collections managed by Environment First, such as Lewes and Eastbourne. Replace the XXXXXXXXXX with the UPRN of your property\u2014you can use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find this."
+        "wiki_note": "For properties with collections managed by Environment First, such as Lewes and Eastbourne. Replace the XXXXXXXXXX with the UPRN of your property—you can use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find this."
     },
     "EppingForestDistrictCouncil": {
         "postcode": "IG9 6EP",
@@ -1754,14 +1753,14 @@
         "LAD24CD": "E06000012"
     },
     "NorthHertfordshireDistrictCouncil": {
-            "house_number": "Stewards Flat",
-            "postcode": "SG5 1PZ",
-            "skip_get_url": true,
-            "url": "https://waste.nc.north-herts.gov.uk/w/webpage/find-bin-collection-day-input-address",
-            "web_driver": "http://selenium:4444",
-            "wiki_name": "North Hertfordshire",
-            "wiki_note": "Pass a postcode (with space) and house_number/name. The scraper performs the Liberty Create typeahead lookup and matches house_number as a case-insensitive substring.",
-            "LAD24CD": "E07000099"
+        "house_number": "Stewards Flat",
+        "postcode": "SG5 1PZ",
+        "skip_get_url": true,
+        "url": "https://waste.nc.north-herts.gov.uk/w/webpage/find-bin-collection-day-input-address",
+        "web_driver": "http://selenium:4444",
+        "wiki_name": "North Hertfordshire",
+        "wiki_note": "Pass a postcode (with space) and house_number/name. The scraper performs the Liberty Create typeahead lookup and matches house_number as a case-insensitive substring.",
+        "LAD24CD": "E07000099"
     },
     "NorthKestevenDistrictCouncil": {
         "skip_get_url": true,

--- a/uk_bin_collection/uk_bin_collection/councils/CalderdaleCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/CalderdaleCouncil.py
@@ -1,123 +1,104 @@
-# This script pulls (in one hit) the data from Bromley Council Bins Data
-import datetime
-import time
+import re
 from datetime import datetime
 
 import requests
 from bs4 import BeautifulSoup
-from selenium.webdriver.common.by import By
-from selenium.webdriver.common.keys import Keys
-from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.support.ui import Select
-from selenium.webdriver.support.wait import WebDriverWait
 
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
 
-# import the wonderful Beautiful Soup and the URL grabber
 class CouncilClass(AbstractGetBinDataClass):
-    """
-    Concrete classes have to implement all abstract operations of the
-    base class. They can also override some operations with a default
-    implementation.
-    """
-
     def parse_data(self, page: str, **kwargs) -> dict:
-        driver = None
-        try:
-            user_uprn = kwargs.get("uprn")
-            user_postcode = kwargs.get("postcode")
-            check_uprn(user_uprn)
-            check_postcode(user_postcode)
+        user_uprn = str(kwargs.get("uprn")).zfill(12)
+        user_postcode = kwargs.get("postcode")
+        check_uprn(user_uprn)
+        check_postcode(user_postcode)
 
-            bin_data_dict = {"bins": []}
-            collections = []
-            web_driver = kwargs.get("web_driver")
-            headless = kwargs.get("headless")
+        base_url = "https://www.calderdale.gov.uk/environment/waste/household-collections/collectiondayfinder.jsp"
 
-            data = {"bins": []}
+        session = requests.Session()
+        session.headers.update(
+            {
+                "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36",
+            }
+        )
 
-            # Get our initial session running
-            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
-            driver = create_webdriver(web_driver, headless, user_agent, __name__)
-            driver.get(kwargs.get("url"))
+        # Step 1: POST postcode to get address list
+        resp = session.post(
+            base_url,
+            data={
+                "postcode": user_postcode,
+                "email-address": "",
+                "find": "Find an address for this postcode",
+            },
+        )
+        resp.raise_for_status()
 
-            wait = WebDriverWait(driver, 30)
-            postcode = wait.until(
-                EC.presence_of_element_located((By.XPATH, '//*[@id="pPostcode"]'))
+        soup = BeautifulSoup(resp.text, "html.parser")
+        select_el = soup.find("select", {"id": "uprn"})
+        if not select_el:
+            raise ValueError(f"No addresses found for postcode: {user_postcode}")
+
+        # Check UPRN exists in dropdown
+        options = select_el.find_all("option")
+        uprn_values = [opt["value"] for opt in options if opt.get("value")]
+        if str(user_uprn) not in uprn_values:
+            raise ValueError(
+                f"UPRN {user_uprn} not found for postcode {user_postcode}. "
+                f"Available: {uprn_values[:5]}"
             )
 
-            postcode.send_keys(user_postcode)
-            postcode_search_btn = wait.until(
-                EC.element_to_be_clickable((By.CLASS_NAME, "searchbox_submit"))
-            )
-            postcode_search_btn.send_keys(Keys.ENTER)
-            # Wait for the 'Select your property' dropdown to appear and select the first result
-            dropdown = wait.until(EC.element_to_be_clickable((By.ID, "uprn")))
+        # Step 2: POST with UPRN to get collection data
+        resp = session.post(
+            base_url,
+            data={
+                "postcode": user_postcode,
+                "email-address": "",
+                "uprn": str(user_uprn),
+                "gdprTerms": "Yes",
+                "privacynoticeid": "323",
+                "find": "Show me my collection days",
+            },
+        )
+        resp.raise_for_status()
 
-            # Create a 'Select' for it, then select the first address in the list
-            # (Index 0 is "Make a selection from the list")
-            dropdownSelect = Select(dropdown)
-            dropdownSelect.select_by_value(str(user_uprn))
-            checkbox = wait.until(EC.presence_of_element_located((By.ID, "gdprTerms")))
-            checkbox.send_keys(Keys.SPACE)
-            get_bin_data_btn = wait.until(
-                EC.element_to_be_clickable((By.CLASS_NAME, "searchbox_submit"))
-            )
-            get_bin_data_btn.send_keys(Keys.ENTER)
-            # Make a BS4 object
-            results = wait.until(EC.presence_of_element_located((By.ID, "collection")))
-            soup = BeautifulSoup(driver.page_source, features="html.parser")
-            soup.prettify()
+        soup = BeautifulSoup(resp.text, "html.parser")
+        table = soup.find("table", {"id": "collection"})
+        if not table:
+            raise ValueError("Collection table not found in response")
 
-            data = {"bins": []}
+        data = {"bins": []}
 
-            # Get collections
-            row_index = 0
-            for row in soup.find("table", {"id": "collection"}).find_all("tr"):
-                # Skip headers row
-                if row_index < 1:
-                    row_index += 1
-                    continue
-                else:
-                    # Get bin info
-                    bin_info = row.find_all("td")
-                    # Get the bin type
-                    bin_type = bin_info[0].find("strong").get_text(strip=True)
-                    # Get the collection date
-                    collection_date = ""
-                    for p in bin_info[2].find_all("p"):
-                        if "your next collection" in p.get_text(strip=True):
-                            collection_date = datetime.strptime(
-                                " ".join(
-                                    p.get_text(strip=True)
-                                    .replace("will be your next collection.", "")
-                                    .split()
-                                ),
-                                "%A %d %B %Y",
-                            )
+        for row in table.find_all("tr"):
+            bin_info = row.find_all("td")
+            if not bin_info:
+                continue
 
-                    if collection_date != "":
-                        # Append the bin type and date to the data dict
-                        dict_data = {
-                            "type": bin_type,
-                            "collectionDate": collection_date.strftime(date_format),
-                        }
-                        data["bins"].append(dict_data)
+            strong = bin_info[0].find("strong")
+            if not strong:
+                continue
+            bin_type = strong.get_text(strip=True)
 
-                    row_index += 1
+            # Find next collection date in the last column
+            for p in bin_info[-1].find_all("p"):
+                text = p.get_text(strip=True)
+                if "will be your next collection" in text:
+                    date_text = text.replace("will be your next collection.", "").strip()
+                    # Normalise whitespace (server pads with spaces)
+                    date_text = " ".join(date_text.split())
+                    try:
+                        parsed = datetime.strptime(date_text, "%A %d %B %Y")
+                        data["bins"].append(
+                            {
+                                "type": bin_type,
+                                "collectionDate": parsed.strftime(date_format),
+                            }
+                        )
+                    except ValueError:
+                        continue
 
-            data["bins"].sort(
-                key=lambda x: datetime.strptime(x.get("collectionDate"), date_format)
-            )
-        except Exception as e:
-            # Here you can log the exception if needed
-            print(f"An error occurred: {e}")
-            # Optionally, re-raise the exception if you want it to propagate
-            raise
-        finally:
-            # This block ensures that the driver is closed regardless of an exception
-            if driver:
-                driver.quit()
+        data["bins"].sort(
+            key=lambda x: datetime.strptime(x.get("collectionDate"), date_format)
+        )
         return data

--- a/uk_bin_collection/uk_bin_collection/councils/CalderdaleCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/CalderdaleCouncil.py
@@ -32,6 +32,7 @@ class CouncilClass(AbstractGetBinDataClass):
                 "email-address": "",
                 "find": "Find an address for this postcode",
             },
+            timeout=30,
         )
         resp.raise_for_status()
 
@@ -60,6 +61,7 @@ class CouncilClass(AbstractGetBinDataClass):
                 "privacynoticeid": "323",
                 "find": "Show me my collection days",
             },
+            timeout=30,
         )
         resp.raise_for_status()
 


### PR DESCRIPTION
## Summary
- Rewrote CalderdaleCouncil scraper to use direct HTTP POST to the JSP form instead of Selenium
- The council's server-side form has no reCAPTCHA, so pure requests work reliably
- Two-step flow: POST postcode → get address dropdown, POST UPRN → get collection table
- Added UPRN zero-padding (`.zfill(12)`) since the council uses 12-digit padded UPRNs
- Removed `web_driver` from input.json as Selenium is no longer needed

## Testing
- Tested directly on VPS: returns Recycling, Waste, and Garden collection dates
- Tested via production API proxy: returns correct data for geocoded addresses

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Calderdale collection retrieval revamped for faster, more reliable results with improved postcode/UPRN handling, cleaner date extraction, and consistent sorting of upcoming collections (no browser automation required).

* **Chores**
  * Council configuration entries updated: Calderdale and North Hertfordshire adjustments and a minor wiki note text fix for EnvironmentFirst.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robbrad/UKBinCollectionData/pull/2058)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->