### PR TITLE
feat: LondonBoroughCamdenCouncil - add postcode + house number lookup

### DIFF
--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -1403,10 +1403,11 @@
     "LondonBoroughCamdenCouncil": {
         "uprn": "5063139",
         "postcode": "NW6 1PL",
+        "house_number": "27",
         "skip_get_url": true,
-        "url": "https://environmentservices.camden.gov.uk/property",
+        "url": "https://recyclingandrubbishcollections.camden.gov.uk",
         "wiki_name": "Camden",
-        "wiki_note": "Pass the property ID as UPRN. Find your property at https://www.camden.gov.uk/check-collection-day then use the property ID from the URL (e.g., https://environmentservices.camden.gov.uk/property/5063139).",
+        "wiki_note": "Provide your postcode and house number. UPRN is also accepted but no longer required.",
         "LAD24CD": "E09000007"
     },
     "LondonBoroughEaling": {

--- a/uk_bin_collection/uk_bin_collection/councils/LondonBoroughCamdenCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/LondonBoroughCamdenCouncil.py
@@ -1,7 +1,32 @@
 import requests
-from bs4 import BeautifulSoup
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
+
+BASE_URL = "https://recyclingandrubbishcollections.camden.gov.uk/api"
+COUNCIL_ID = "27"
+
+
+def _match_property(properties, uprn=None, paon=None):
+    """Match a property from search results by UPRN or house number/name."""
+    if uprn:
+        for prop in properties:
+            if str(prop.get("uprn", "")) == str(uprn):
+                return prop["id"]
+
+    if paon:
+        paon_norm = str(paon).strip().upper()
+        # Exact start match (e.g. "12" matches "12 MABLEDON PLACE, ...")
+        for prop in properties:
+            name = str(prop.get("name", "")).upper()
+            if name.startswith(paon_norm + " ") or name.startswith(paon_norm + ","):
+                return prop["id"]
+        # Contains match (e.g. "FLAT 3" matches "FLAT 3, 12 MABLEDON PLACE, ...")
+        for prop in properties:
+            name = str(prop.get("name", "")).upper()
+            if paon_norm in name:
+                return prop["id"]
+
+    return properties[0]["id"]
 
 
 class CouncilClass(AbstractGetBinDataClass):
@@ -12,54 +37,63 @@ class CouncilClass(AbstractGetBinDataClass):
     def parse_data(self, page: str, **kwargs) -> dict:
         user_uprn = kwargs.get("uprn")
         user_postcode = kwargs.get("postcode")
-        check_uprn(user_uprn)
+        user_paon = kwargs.get("paon")
         check_postcode(user_postcode)
 
-        # Build the property URL
-        property_url = f"https://environmentservices.camden.gov.uk/property/{user_uprn}"
+        headers = {"Content-Type": "application/json"}
 
-        # Make the request
-        response = requests.get(property_url)
-        response.raise_for_status()
+        # Step 1: Search by postcode to resolve property ID
+        search_resp = requests.post(
+            f"{BASE_URL}/getPropertySearch",
+            json={"councilId": COUNCIL_ID, "searchQuery": user_postcode},
+            headers=headers,
+            timeout=30,
+        )
+        search_resp.raise_for_status()
+        search_data = search_resp.json()
 
-        # Parse the HTML
-        soup = BeautifulSoup(response.content, "html.parser")
+        properties = search_data.get("data", [])
+        if not properties:
+            raise ValueError(f"No properties found for postcode: {user_postcode}")
+
+        point_id = _match_property(properties, uprn=user_uprn, paon=user_paon)
+
+        # Step 2: Get collection days
+        collection_resp = requests.post(
+            f"{BASE_URL}/getCollectionDays",
+            json={
+                "pointId": str(point_id),
+                "pointType": "PointAddress",
+                "councilId": COUNCIL_ID,
+            },
+            headers=headers,
+            timeout=30,
+        )
+        collection_resp.raise_for_status()
+        collection_data = collection_resp.json()
 
         data = {"bins": []}
+        now = datetime.now()
 
-        # Find all service wrappers
-        service_wrappers = soup.find_all("div", class_="service-wrapper")
+        for service in collection_data.get("activeServices", []):
+            bin_type = service.get("serviceName", "Unknown")
 
-        for service in service_wrappers:
-            # Get the service name (bin type)
-            service_name_elem = service.find("h3", class_="service-name")
-            if not service_name_elem:
-                continue
+            for schedule in service.get("serviceSchedules", []):
+                date_str = schedule.get("currentScheduledDate")
+                if not date_str:
+                    continue
 
-            bin_type = service_name_elem.get_text(strip=True)
-            # Remove "Add to my calendar" text if present
-            bin_type = bin_type.replace("Add to my calendar", "").strip()
+                collection_date = datetime.fromisoformat(date_str)
+                if collection_date.date() >= now.date():
+                    data["bins"].append(
+                        {
+                            "type": bin_type,
+                            "collectionDate": collection_date.strftime(date_format),
+                        }
+                    )
 
-            # Find the next collection date
-            next_collection_elem = service.find("td", class_="next-service")
-            if not next_collection_elem:
-                continue
-
-            next_collection_date = next_collection_elem.get_text(strip=True)
-
-            # Parse the date (format: dd/mm/yyyy)
-            try:
-                collection_date = datetime.strptime(
-                    next_collection_date, "%d/%m/%Y"
-                )
-                data["bins"].append(
-                    {
-                        "type": bin_type,
-                        "collectionDate": collection_date.strftime(date_format),
-                    }
-                )
-            except ValueError:
-                # Skip if date parsing fails
-                continue
+        data["bins"].sort(
+            key=lambda x: datetime.strptime(x.get("collectionDate"), date_format)
+        )
 
         return data

--- a/uk_bin_collection/uk_bin_collection/councils/LondonBoroughCamdenCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/LondonBoroughCamdenCouncil.py
@@ -26,6 +26,10 @@ def _match_property(properties, uprn=None, paon=None):
             if paon_norm in name:
                 return prop["id"]
 
+    if uprn or paon:
+        raise ValueError(
+            f"Property not found for UPRN={uprn} PAON={paon}"
+        )
     return properties[0]["id"]
 
 
@@ -72,10 +76,14 @@ class CouncilClass(AbstractGetBinDataClass):
         collection_resp.raise_for_status()
         collection_data = collection_resp.json()
 
+        active_services = collection_data.get("activeServices")
+        if not isinstance(active_services, list):
+            raise ValueError("Unexpected API response format")
+
         data = {"bins": []}
         now = datetime.now()
 
-        for service in collection_data.get("activeServices", []):
+        for service in active_services:
             bin_type = service.get("serviceName", "Unknown")
 
             for schedule in service.get("serviceSchedules", []):


### PR DESCRIPTION
## Summary
- Users can now provide **either** UPRN **or** postcode + house number — whichever they have.
- UPRN takes priority when provided (backward compatible with existing users).
- When only postcode + house number is given, the scraper searches via the existing `getPropertySearch` API and matches the property by house number/name in the returned address list.
- Falls back to first result if no house number match found.

## How it works
1. If UPRN provided → match by UPRN in postcode search results (existing behavior)
2. If no UPRN → match by house number/name in the `name` field of returned properties
3. If neither matches → use first property at that postcode

## Testing
- UPRN path (backward compat): `WC1H 9AZ` + UPRN `5123509` ✅
- Postcode + house number: `WC1H 9AZ` + paon `9` ✅
- API end-to-end via bin-resolve-v2.php ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Camden bin collection lookup now uses the council backend API instead of HTML scraping.
  * Property search accepts postcode plus house/PAON or UPRN and resolves the matching property.
  * Collection schedules are retrieved from the API, filtered to upcoming dates, formatted, and sorted.

* **Chores**
  * Example configuration and guidance updated to request postcode and house number (UPRN optional).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robbrad/UKBinCollectionData/pull/2059)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->