### PR TITLE
feat: EastDevonDC - add postcode + house number lookup via addressfinder

### DIFF
--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -753,11 +753,13 @@
         "LAD24CD": "E07000009"
     },
     "EastDevonDC": {
-        "uprn": "010090909915",
+        "postcode": "EX10 8DP",
+        "house_number": "EGYPT",
+        "uprn": "010000273781",
         "url": "https://eastdevon.gov.uk/recycling-and-waste/recycling-waste-information/when-is-my-bin-collected/",
         "skip_get_url": true,
         "wiki_name": "East Devon",
-        "wiki_note": "Pass the UPRN. You can find it using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
+        "wiki_note": "Provide your postcode and house number/name. UPRN is also accepted but no longer required.",
         "LAD24CD": "E07000040"
     },
     "EastDunbartonshireCouncil": {

--- a/uk_bin_collection/uk_bin_collection/councils/EastDevonDC.py
+++ b/uk_bin_collection/uk_bin_collection/councils/EastDevonDC.py
@@ -1,87 +1,122 @@
 import re
 from datetime import datetime
 
-import pandas as pd
+import requests
 from bs4 import BeautifulSoup
 
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
 
-class CouncilClass(AbstractGetBinDataClass):
-    """
-    Concrete classes have to implement all abstract operations of the
-    baseclass. They can also override some
-    operations with a default implementation.
-    """
+def _match_address(addresses, uprn=None, paon=None):
+    """Match an address from addressfinder results by UPRN or house number/name."""
+    if uprn:
+        uprn_str = str(uprn).zfill(12)
+        for addr in addresses:
+            if str(addr.get("UPRN", "")) == uprn_str:
+                return addr
 
-    def parse_data(self, page: str, **kwargs) -> dict:
+    if paon:
+        paon_norm = str(paon).strip().upper()
+        for addr in addresses:
+            label = str(addr.get("label", "")).upper()
+            if label.startswith(paon_norm + " ") or label.startswith(paon_norm + ","):
+                return addr
+        for addr in addresses:
+            label = str(addr.get("label", "")).upper()
+            if paon_norm in label:
+                return addr
 
-        try:
-            user_uprn = kwargs.get("uprn")
-            check_uprn(user_uprn)
-            url = f"https://eastdevon.gov.uk/recycling-and-waste/recycling-waste-information/when-is-my-bin-collected/future-collections-calendar/?UPRN={user_uprn}"
-            if not user_uprn:
-                # This is a fallback for if the user stored a URL in old system. Ensures backwards compatibility.
-                url = kwargs.get("url")
-        except Exception as e:
-            raise ValueError(f"Error getting identifier: {str(e)}")
+    return addresses[0]
 
-        # Make a BS4 object
-        page = requests.get(url)
-        soup = BeautifulSoup(page.text, features="html.parser")
-        soup.prettify()
 
-        data = {"bins": []}
-        month_class_name = 'class="eventmonth"'
-        regular_collection_class_name = "collectiondate regular-collection"
-        holiday_collection_class_name = "collectiondate bankholiday-change"
-        regex_string = "[^0-9]"
+def _parse_calendar_page(url):
+    """Parse the existing calendar page by UPRN (legacy path)."""
+    page = requests.get(url)
+    soup = BeautifulSoup(page.text, features="html.parser")
 
-        calendar_collection = soup.find("ol", {"class": "nonumbers news collections"})
-        calendar_list = calendar_collection.find_all("li")
-        current_month = ""
-        current_year = ""
+    data = {"bins": []}
+    month_class_name = 'class="eventmonth"'
+    regular_collection_class_name = "collectiondate regular-collection"
+    holiday_collection_class_name = "collectiondate bankholiday-change"
+    regex_string = "[^0-9]"
 
-        for element in calendar_list:
-            element_tag = str(element)
-            if month_class_name in element_tag:
-                current_month = datetime.strptime(element.text, "%B %Y").strftime("%m")
-                current_year = datetime.strptime(element.text, "%B %Y").strftime("%Y")
-            elif regular_collection_class_name in element_tag:
-                week_value = element.find_next(
-                    "span", {"class": f"{regular_collection_class_name}"}
-                )
-                day_of_week = re.sub(regex_string, "", week_value.text).strip()
-                collection_date = datetime(
-                    int(current_year), int(current_month), int(day_of_week)
-                ).strftime(date_format)
-                collections = week_value.find_next_siblings("span")
-                for item in collections:
-                    x = item.text
-                    bin_type = item.text.strip()
-                    if len(bin_type) > 1:
-                        dict_data = {
-                            "type": bin_type,
-                            "collectionDate": collection_date,
-                        }
-                        data["bins"].append(dict_data)
-            elif holiday_collection_class_name in element_tag:
-                week_value = element.find_next(
-                    "span", {"class": f"{holiday_collection_class_name}"}
-                )
-                day_of_week = re.sub(regex_string, "", week_value.text).strip()
-                collection_date = datetime(
-                    int(current_year), int(current_month), int(day_of_week)
-                ).strftime(date_format)
-                collections = week_value.find_next_siblings("span")
-                for item in collections:
-                    x = item.text
-                    bin_type = item.text.strip()
-                    if len(bin_type) > 1:
-                        dict_data = {
+    calendar_collection = soup.find("ol", {"class": "nonumbers news collections"})
+    if not calendar_collection:
+        return data
+
+    calendar_list = calendar_collection.find_all("li")
+    current_month = ""
+    current_year = ""
+
+    for element in calendar_list:
+        element_tag = str(element)
+        if month_class_name in element_tag:
+            current_month = datetime.strptime(element.text, "%B %Y").strftime("%m")
+            current_year = datetime.strptime(element.text, "%B %Y").strftime("%Y")
+        elif regular_collection_class_name in element_tag:
+            week_value = element.find_next(
+                "span", {"class": f"{regular_collection_class_name}"}
+            )
+            day_of_week = re.sub(regex_string, "", week_value.text).strip()
+            collection_date = datetime(
+                int(current_year), int(current_month), int(day_of_week)
+            ).strftime(date_format)
+            collections = week_value.find_next_siblings("span")
+            for item in collections:
+                bin_type = item.text.strip()
+                if len(bin_type) > 1:
+                    data["bins"].append(
+                        {"type": bin_type, "collectionDate": collection_date}
+                    )
+        elif holiday_collection_class_name in element_tag:
+            week_value = element.find_next(
+                "span", {"class": f"{holiday_collection_class_name}"}
+            )
+            day_of_week = re.sub(regex_string, "", week_value.text).strip()
+            collection_date = datetime(
+                int(current_year), int(current_month), int(day_of_week)
+            ).strftime(date_format)
+            collections = week_value.find_next_siblings("span")
+            for item in collections:
+                bin_type = item.text.strip()
+                if len(bin_type) > 1:
+                    data["bins"].append(
+                        {
                             "type": bin_type + " (bank holiday replacement)",
                             "collectionDate": collection_date,
                         }
-                        data["bins"].append(dict_data)
-        return data
+                    )
+    return data
+
+
+class CouncilClass(AbstractGetBinDataClass):
+    def parse_data(self, page: str, **kwargs) -> dict:
+        user_uprn = kwargs.get("uprn")
+        user_postcode = kwargs.get("postcode")
+        user_paon = kwargs.get("paon")
+
+        # Postcode path: use addressfinder API to resolve address and get UPRN
+        if user_postcode:
+            resp = requests.get(
+                "https://eastdevon.gov.uk/addressfinder",
+                params={"qtype": "bins", "term": user_postcode},
+                timeout=30,
+            )
+            resp.raise_for_status()
+            addresses = resp.json()
+
+            if addresses:
+                matched = _match_address(addresses, uprn=user_uprn, paon=user_paon)
+                user_uprn = matched.get("UPRN")
+
+        if not user_uprn:
+            raise ValueError(
+                "Could not resolve address. Provide a postcode or UPRN."
+            )
+
+        # East Devon requires 12-digit zero-padded UPRNs
+        user_uprn = str(user_uprn).zfill(12)
+        url = f"https://eastdevon.gov.uk/recycling-and-waste/recycling-waste-information/when-is-my-bin-collected/future-collections-calendar/?UPRN={user_uprn}"
+
+        return _parse_calendar_page(url)

--- a/uk_bin_collection/uk_bin_collection/councils/EastDevonDC.py
+++ b/uk_bin_collection/uk_bin_collection/councils/EastDevonDC.py
@@ -11,9 +11,9 @@ from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataC
 def _match_address(addresses, uprn=None, paon=None):
     """Match an address from addressfinder results by UPRN or house number/name."""
     if uprn:
-        uprn_str = str(uprn).zfill(12)
+        uprn_str = str(uprn).strip().zfill(12)
         for addr in addresses:
-            if str(addr.get("UPRN", "")) == uprn_str:
+            if str(addr.get("UPRN", "")).strip().zfill(12) == uprn_str:
                 return addr
 
     if paon:
@@ -27,12 +27,17 @@ def _match_address(addresses, uprn=None, paon=None):
             if paon_norm in label:
                 return addr
 
+    if uprn or paon:
+        raise ValueError(
+            f"Address not found for UPRN={uprn} PAON={paon}"
+        )
     return addresses[0]
 
 
 def _parse_calendar_page(url):
     """Parse the existing calendar page by UPRN (legacy path)."""
-    page = requests.get(url)
+    page = requests.get(url, timeout=30)
+    page.raise_for_status()
     soup = BeautifulSoup(page.text, features="html.parser")
 
     data = {"bins": []}
@@ -43,7 +48,7 @@ def _parse_calendar_page(url):
 
     calendar_collection = soup.find("ol", {"class": "nonumbers news collections"})
     if not calendar_collection:
-        return data
+        raise ValueError(f"No collection calendar found at {url}")
 
     calendar_list = calendar_collection.find_all("li")
     current_month = ""
@@ -96,8 +101,11 @@ class CouncilClass(AbstractGetBinDataClass):
         user_postcode = kwargs.get("postcode")
         user_paon = kwargs.get("paon")
 
+        if user_uprn and not str(user_uprn).strip().isdigit():
+            raise ValueError("UPRN must be numeric")
+
         # Postcode path: use addressfinder API to resolve address and get UPRN
-        if user_postcode:
+        if user_postcode and not user_uprn:
             resp = requests.get(
                 "https://eastdevon.gov.uk/addressfinder",
                 params={"qtype": "bins", "term": user_postcode},


### PR DESCRIPTION
## Summary
- Users can now provide **either** UPRN **or** postcode + house number/name — whichever they have.
- UPRN takes priority when provided (backward compatible with existing users).
- When postcode is given, calls East Devon`s `/addressfinder?qtype=bins&term={postcode}` endpoint which returns addresses with UPRNs. Matches by house number/name, then uses the resolved UPRN with the existing calendar page.
- Falls back to first address if no match found.

## How it works
1. If postcode provided → `GET /addressfinder?qtype=bins&term={postcode}` → JSON with addresses + UPRNs
2. Match by UPRN (if given) or house number/name in `label` field
3. Use resolved UPRN with existing `?UPRN=X` calendar page

## Testing
- UPRN path (backward compat): UPRN `010000273781` ✅
- Postcode + house name: `EX10 8DP` + paon `EGYPT` ✅
- API end-to-end via bin-resolve-v2.php (22 bins returned) ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Address lookup for East Devon now supports postcode + house number resolution (UPRN optional) and normalises the resolved UPRN.

* **Bug Fixes**
  * Improved timeout and error handling for address lookups.
  * Parsing now reliably returns an empty bins payload when calendar data is missing.

* **Chores**
  * Updated test/config guidance for East Devon to use postcode and house number.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robbrad/UKBinCollectionData/pull/2062)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->