### PR TITLE
feat: DumfriesandGallowayCouncil - add postcode + house number lookup

### DIFF
--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -698,11 +698,13 @@
         "LAD24CD": "E08000027"
     },
     "DumfriesandGallowayCouncil": {
-        "uprn": "137034556",
+        "postcode": "DG7 1AA",
+        "house_number": "Glenafton",
+        "uprn": "137005550",
         "skip_get_url": true,
         "url": "https://www.dumfriesandgalloway.gov.uk",
         "wiki_name": "Dumfries and Galloway Council",
-        "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
+        "wiki_note": "Provide your postcode and house number/name. UPRN is also accepted but no longer required.",
         "LAD24CD": "S12000006"
     },
     "DundeeCityCouncil": {

--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -700,7 +700,7 @@
     "DumfriesandGallowayCouncil": {
         "postcode": "DG7 1AA",
         "house_number": "Glenafton",
-        "uprn": "137005550",
+        "uprn": "137034556",
         "skip_get_url": true,
         "url": "https://www.dumfriesandgalloway.gov.uk",
         "wiki_name": "Dumfries and Galloway Council",

--- a/uk_bin_collection/uk_bin_collection/councils/DumfriesandGallowayCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/DumfriesandGallowayCouncil.py
@@ -5,43 +5,70 @@ from datetime import datetime, timedelta
 import requests
 from bs4 import BeautifulSoup
 from icalevents.icalevents import events
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.support.wait import WebDriverWait
 
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
+SEARCH_URL = "https://www.dumfriesandgalloway.gov.uk/bins-recycling/waste-collection-schedule/find"
+ICS_BASE = "https://www.dumfriesandgalloway.gov.uk/bins-recycling/waste-collection-schedule/download"
+
+
+def _resolve_uprn(postcode, uprn=None, paon=None):
+    """Resolve UPRN via postcode address search if not provided."""
+    if uprn:
+        return str(uprn)
+
+    if not postcode:
+        raise ValueError("Provide a postcode or UPRN.")
+
+    resp = requests.get(SEARCH_URL, params={"postcode": postcode}, timeout=30)
+    resp.raise_for_status()
+
+    soup = BeautifulSoup(resp.text, "html.parser")
+    select_el = soup.find("select", {"name": "uprn"})
+    if not select_el:
+        raise ValueError(f"No addresses found for postcode: {postcode}")
+
+    options = [(opt["value"], opt.text.strip()) for opt in select_el.find_all("option") if opt.get("value")]
+    if not options:
+        raise ValueError(f"No addresses found for postcode: {postcode}")
+
+    if paon:
+        paon_norm = str(paon).strip().upper()
+        for val, text in options:
+            text_upper = text.upper()
+            if text_upper.startswith(paon_norm + " ") or text_upper.startswith(paon_norm + ","):
+                return val
+        for val, text in options:
+            if paon_norm in text.upper():
+                return val
+
+    return options[0][0]
+
 
 class CouncilClass(AbstractGetBinDataClass):
     def parse_data(self, page: str, **kwargs) -> dict:
-        """
-        Fetch upcoming bin collections for a property and return them as structured data.
-        
-        Parses an ICS calendar URL constructed from the provided `uprn` to collect events occurring within the next 60 days and returns each collection entry with its type and formatted collection date.
-        
-        Parameters:
-            uprn (str): Unique Property Reference Number used to build the council's ICS calendar URL.
-        
-        Returns:
-            dict: A dictionary with a single key `"bins"` containing a list of collection records. Each record is a dict with:
-                - "type" (str): Collection type/name.
-                - "collectionDate" (str): Collection date formatted according to `date_format`.
-        """
         driver = None
         try:
             data = {"bins": []}
 
             user_uprn = kwargs.get("uprn")
-            check_uprn(user_uprn)
+            user_postcode = kwargs.get("postcode")
+            user_paon = kwargs.get("paon")
 
-            ics_url = f"https://www.dumfriesandgalloway.gov.uk/bins-recycling/waste-collection-schedule/download/{user_uprn}"
+            resolved_uprn = _resolve_uprn(user_postcode, uprn=user_uprn, paon=user_paon)
 
-            # Get events from ICS file within the next 60 days
+            ics_url = f"{ICS_BASE}/{resolved_uprn}"
+
+            import requests as req
+            ics_resp = req.get(ics_url, timeout=30)
+            ics_text = ics_resp.text
+            if "<br" in ics_text or "<html" in ics_text.lower() or "VCALENDAR" not in ics_text:
+                return data
+
             now = datetime.now()
             future = now + timedelta(days=60)
 
-            # Parse ICS calendar
             upcoming_events = events(ics_url, start=now, end=future)
 
             for event in sorted(upcoming_events, key=lambda e: e.start):

--- a/uk_bin_collection/uk_bin_collection/councils/DumfriesandGallowayCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/DumfriesandGallowayCouncil.py
@@ -1,5 +1,3 @@
-import re
-import time
 from datetime import datetime, timedelta
 
 import requests
@@ -43,51 +41,49 @@ def _resolve_uprn(postcode, uprn=None, paon=None):
             if paon_norm in text.upper():
                 return val
 
+    if paon:
+        raise ValueError(
+            f"Address not found for PAON={paon} in postcode {postcode}"
+        )
     return options[0][0]
 
 
 class CouncilClass(AbstractGetBinDataClass):
     def parse_data(self, page: str, **kwargs) -> dict:
-        driver = None
-        try:
-            data = {"bins": []}
+        data = {"bins": []}
 
-            user_uprn = kwargs.get("uprn")
-            user_postcode = kwargs.get("postcode")
-            user_paon = kwargs.get("paon")
+        user_uprn = kwargs.get("uprn")
+        user_postcode = kwargs.get("postcode")
+        user_paon = kwargs.get("paon")
 
-            resolved_uprn = _resolve_uprn(user_postcode, uprn=user_uprn, paon=user_paon)
+        resolved_uprn = _resolve_uprn(user_postcode, uprn=user_uprn, paon=user_paon)
 
-            ics_url = f"{ICS_BASE}/{resolved_uprn}"
+        ics_url = f"{ICS_BASE}/{resolved_uprn}"
 
-            import requests as req
-            ics_resp = req.get(ics_url, timeout=30)
-            ics_text = ics_resp.text
-            if "<br" in ics_text or "<html" in ics_text.lower() or "VCALENDAR" not in ics_text:
-                return data
+        ics_resp = requests.get(ics_url, timeout=30)
+        ics_resp.raise_for_status()
+        ics_text = ics_resp.text
+        if "<br" in ics_text or "<html" in ics_text.lower() or "VCALENDAR" not in ics_text:
+            raise ValueError(
+                f"ICS feed returned invalid data for UPRN {resolved_uprn} (status {ics_resp.status_code}, url {ics_url})"
+            )
 
-            now = datetime.now()
-            future = now + timedelta(days=60)
+        now = datetime.now()
+        future = now + timedelta(days=60)
 
-            upcoming_events = events(ics_url, start=now, end=future)
+        upcoming_events = events(ics_url, start=now, end=future)
 
-            for event in sorted(upcoming_events, key=lambda e: e.start):
-                if event.summary and event.start:
-                    collections = event.summary.split(",")
-                    for collection in collections:
-                        data["bins"].append(
-                            {
-                                "type": collection.strip(),
-                                "collectionDate": event.start.date().strftime(
-                                    date_format
-                                ),
-                            }
-                        )
-        except Exception as e:
-            print(f"An error occurred: {e}")
-            raise
-        finally:
-            if driver:
-                driver.quit()
+        for event in sorted(upcoming_events, key=lambda e: e.start):
+            if event.summary and event.start:
+                collections = event.summary.split(",")
+                for collection in collections:
+                    data["bins"].append(
+                        {
+                            "type": collection.strip(),
+                            "collectionDate": event.start.date().strftime(
+                                date_format
+                            ),
+                        }
+                    )
 
         return data


### PR DESCRIPTION
## Summary
- Users can now provide **either** UPRN **or** postcode + house number/name — whichever they have.
- UPRN takes priority when provided (backward compatible with existing users).
- When no UPRN is given, searches the council`s LocalGov Drupal page by postcode. The address dropdown contains UPRNs as option values — matched by house number/name.
- Falls back to first address if no match found.

## How it works
1. If UPRN provided → use directly (existing behavior)
2. If no UPRN → `GET /waste-collection-schedule/find?postcode=X` → parse `<select name="uprn">` → match by house number in option text
3. Use resolved UPRN to download ICS calendar via existing endpoint

## Testing
- UPRN path (backward compat): UPRN `137005550` ✅
- Postcode + house name: `DG7 1AA` + paon `Glenafton` ✅
- Tested directly on VPS ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dumfries & Galloway lookup now derives addresses from postcode + house name/number when UPRN isn’t provided, fetches calendar data directly, and skips invalid/non-calendar responses for more reliable collection schedules.
* **Documentation**
  * Updated guidance: postcode + house number accepted (UPRN optional) and input instructions clarified for Dumfries & Galloway.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robbrad/UKBinCollectionData/pull/2063)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->