### PR TITLE
feat: WestMorlandAndFurness - add postcode + house number lookup

### DIFF
--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -2716,11 +2716,13 @@
         "LAD24CD": "S12000040"
     },
     "WestMorlandAndFurness": {
-        "uprn": "100110353478",
+        "postcode": "LA9 4QU",
+        "house_number": "23",
+        "uprn": "100110698636",
         "url": "https://www.westmorlandandfurness.gov.uk/",
         "wiki_command_url_override": "https://www.westmorlandandfurness.gov.uk/",
         "wiki_name": "Westmorland and Furness",
-        "wiki_note": "Provide your UPRN. You can find your UPRN using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
+        "wiki_note": "Provide your postcode and house number. UPRN is also accepted but no longer required.",
         "LAD24CD": "E06000064"
     },
     "WestNorthamptonshireCouncil": {

--- a/uk_bin_collection/uk_bin_collection/councils/WestMorlandAndFurness.py
+++ b/uk_bin_collection/uk_bin_collection/councils/WestMorlandAndFurness.py
@@ -4,26 +4,57 @@ from bs4 import BeautifulSoup
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
+BASE_URL = "https://www.westmorlandandfurness.gov.uk/bins-recycling-and-street-cleaning/waste-collection-schedule"
 
-# import the wonderful Beautiful Soup and the URL grabber
+
+def _resolve_uprn(postcode, uprn=None, paon=None):
+    """Resolve UPRN via postcode address search if not provided."""
+    if uprn:
+        return str(uprn)
+
+    if not postcode:
+        raise ValueError("Provide a postcode or UPRN.")
+
+    resp = requests.get(
+        f"{BASE_URL}/find",
+        params={"postcode": postcode},
+        timeout=30,
+    )
+    resp.raise_for_status()
+
+    soup = BeautifulSoup(resp.text, "html.parser")
+    select_el = soup.find("select", {"name": "uprn"})
+    if not select_el:
+        raise ValueError(f"No addresses found for postcode: {postcode}")
+
+    options = [(opt["value"], opt.text.strip()) for opt in select_el.find_all("option") if opt.get("value")]
+    if not options:
+        raise ValueError(f"No addresses found for postcode: {postcode}")
+
+    if paon:
+        paon_norm = str(paon).strip().upper()
+        for val, text in options:
+            text_upper = text.upper()
+            if text_upper.startswith(paon_norm + " ") or text_upper.startswith(paon_norm + ","):
+                return val
+        for val, text in options:
+            if paon_norm in text.upper():
+                return val
+
+    return options[0][0]
+
+
 class CouncilClass(AbstractGetBinDataClass):
-    """
-    Concrete classes have to implement all abstract operations of the
-    base class. They can also override some operations with a default
-    implementation.
-    """
-
     def parse_data(self, page: str, **kwargs) -> dict:
-
         user_uprn = kwargs.get("uprn")
-        check_uprn(user_uprn)
+        user_postcode = kwargs.get("postcode")
+        user_paon = kwargs.get("paon")
+
+        resolved_uprn = _resolve_uprn(user_postcode, uprn=user_uprn, paon=user_paon)
+
         bindata = {"bins": []}
 
-        URI = f"https://www.westmorlandandfurness.gov.uk/bins-recycling-and-street-cleaning/waste-collection-schedule/view/{user_uprn}"
-
-        headers = {
-            "user-agent": "Mozilla/5.0",
-        }
+        URI = f"{BASE_URL}/view/{resolved_uprn}"
 
         current_year = datetime.now().year
         current_month = datetime.now().month
@@ -31,7 +62,6 @@ class CouncilClass(AbstractGetBinDataClass):
         response = requests.get(URI)
 
         soup = BeautifulSoup(response.text, "html.parser")
-        # Extract links to collection shedule pages and iterate through the pages
         schedule = soup.findAll("div", {"class": "waste-collection__month"})
         for month in schedule:
             collectionmonth = datetime.strptime(month.find("h3").text, "%B")
@@ -44,8 +74,8 @@ class CouncilClass(AbstractGetBinDataClass):
                 collectiondate = datetime.strptime(day, "%d")
                 collectiondate = collectiondate.replace(month=collectionmonth)
                 bintype = collectionday.find(
-                    "span", {"class": "waste-collection__day--colour"}
-                ).text
+                    "span", {"class": "waste-collection__day--type"}
+                ).text.strip()
 
                 if (current_month > 9) and (collectiondate.month < 4):
                     collectiondate = collectiondate.replace(year=(current_year + 1))

--- a/uk_bin_collection/uk_bin_collection/councils/WestMorlandAndFurness.py
+++ b/uk_bin_collection/uk_bin_collection/councils/WestMorlandAndFurness.py
@@ -1,3 +1,5 @@
+import re
+
 import requests
 from bs4 import BeautifulSoup
 
@@ -38,7 +40,7 @@ def _resolve_uprn(postcode, uprn=None, paon=None):
             if text_upper.startswith(paon_norm + " ") or text_upper.startswith(paon_norm + ","):
                 return val
         for val, text in options:
-            if paon_norm in text.upper():
+            if re.search(rf"\b{re.escape(paon_norm)}\b", text.upper()):
                 return val
 
     return options[0][0]
@@ -48,7 +50,7 @@ class CouncilClass(AbstractGetBinDataClass):
     def parse_data(self, page: str, **kwargs) -> dict:
         user_uprn = kwargs.get("uprn")
         user_postcode = kwargs.get("postcode")
-        user_paon = kwargs.get("paon")
+        user_paon = kwargs.get("paon") or kwargs.get("house_number")
 
         resolved_uprn = _resolve_uprn(user_postcode, uprn=user_uprn, paon=user_paon)
 
@@ -59,7 +61,8 @@ class CouncilClass(AbstractGetBinDataClass):
         current_year = datetime.now().year
         current_month = datetime.now().month
 
-        response = requests.get(URI)
+        response = requests.get(URI, timeout=30)
+        response.raise_for_status()
 
         soup = BeautifulSoup(response.text, "html.parser")
         schedule = soup.findAll("div", {"class": "waste-collection__month"})


### PR DESCRIPTION
## Summary
- Users can now provide **either** UPRN **or** postcode + house number — whichever they have.
- UPRN takes priority when provided (backward compatible with existing users).
- When only postcode + house number is given, the scraper searches the council's LocalGov Drupal page, parses the address dropdown, and resolves the UPRN automatically.
- Falls back to first address if no house number match found.

## How it works
1. If UPRN provided → use directly (existing behavior, unchanged)
2. If no UPRN → `GET /waste-collection-schedule/find?postcode=X` → parse `<select name="uprn">` → match by house number in option text → use matched UPRN with existing `/view/{uprn}` page

## Testing
- UPRN path (backward compat): `LA9 4QU` + UPRN `100110698636` ✅
- Postcode + house number: `LA9 4QU` + paon `23` ✅
- API end-to-end via bin-resolve-v2.php ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Search bin collections by postcode and house number (UPRN now optional)
  * More reliable schedule lookup using the council's base schedule source
  * Improved extraction of bin types for displayed collection days

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robbrad/UKBinCollectionData/pull/2064)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->