### PR TITLE
feat: add postcode lookup for south derbyshire district council

### DIFF
--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -2186,11 +2186,13 @@
         "LAD24CD": "E07000012"
     },
     "SouthDerbyshireDistrictCouncil": {
+        "postcode": "DE11 7AB",
+        "house_number": "2",
         "uprn": "10000820668",
-        "url": "https://maps.southderbyshire.gov.uk/iShareLIVE.web//getdata.aspx?RequestType=LocalInfo&ms=mapsources/MyHouse&format=JSONP&group=Recycling%20Bins%20and%20Waste|Next%20Bin%20Collections&uid=",
-        "wiki_command_url_override": "https://maps.southderbyshire.gov.uk/iShareLIVE.web//getdata.aspx?RequestType=LocalInfo&ms=mapsources/MyHouse&format=JSONP&group=Recycling%20Bins%20and%20Waste|Next%20Bin%20Collections&uid=XXXXXXXX",
+        "skip_get_url": true,
+        "url": "https://maps.southderbyshire.gov.uk/iShareLIVE.web//getdata.aspx",
         "wiki_name": "South Derbyshire",
-        "wiki_note": "Replace `XXXXXXXX` with your UPRN. You can find your UPRN using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
+        "wiki_note": "Provide your postcode and house number. UPRN is also accepted but no longer required.",
         "LAD24CD": "E07000039"
     },
     "SouthGloucestershireCouncil": {

--- a/uk_bin_collection/uk_bin_collection/councils/SouthDerbyshireDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/SouthDerbyshireDistrictCouncil.py
@@ -3,58 +3,89 @@ import requests
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
+SEARCH_URL = "https://maps.southderbyshire.gov.uk/iShareLIVE.web/getdata.aspx"
+BIN_URL = "https://maps.southderbyshire.gov.uk/iShareLIVE.web//getdata.aspx"
+HEADERS = {"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"}
 
-# import the wonderful Beautiful Soup and the URL grabber
+
+def _match_address(results, uprn=None, paon=None):
+    """Match an address from LocationSearch results by UPRN or house number/name.
+    Each result is [UniqueId, Parent, DisplayName, Type, X, Y, Rank, Name, Zoom]."""
+    if uprn:
+        uprn_str = str(uprn)
+        for row in results:
+            if str(row[0]) == uprn_str:
+                return str(row[0])
+
+    if paon:
+        paon_norm = str(paon).strip().upper()
+        for row in results:
+            name = str(row[7]).upper()
+            if name.startswith(paon_norm + " ") or name.startswith(paon_norm + ","):
+                return str(row[0])
+        for row in results:
+            name = str(row[7]).upper()
+            if paon_norm in name:
+                return str(row[0])
+
+    return str(results[0][0])
+
+
 class CouncilClass(AbstractGetBinDataClass):
-    """
-    Concrete classes have to implement all abstract operations of the
-    base class. They can also override some operations with a default
-    implementation.
-    """
-
     def parse_data(self, page: str, **kwargs) -> dict:
-
         user_uprn = kwargs.get("uprn")
-        check_uprn(user_uprn)
+        user_postcode = kwargs.get("postcode")
+        user_paon = kwargs.get("paon")
+
+        requests.packages.urllib3.disable_warnings()
+
+        if not user_uprn and user_postcode:
+            params = {
+                "RequestType": "LocationSearch",
+                "location": user_postcode,
+                "pagesize": "20",
+                "startnum": "1",
+                "gettotals": "false",
+                "type": "json",
+            }
+            resp = requests.get(SEARCH_URL, params=params, headers=HEADERS, verify=False, timeout=30)
+            resp.raise_for_status()
+            search_data = resp.json()
+
+            results = search_data.get("data", [])
+            if not results:
+                raise ValueError(f"No addresses found for postcode: {user_postcode}")
+
+            user_uprn = _match_address(results, paon=user_paon)
+
+        if not user_uprn:
+            raise ValueError("Could not resolve address. Provide a postcode or UPRN.")
+
+        url = f"{BIN_URL}?RequestType=LocalInfo&ms=mapsources/MyHouse&format=JSONP&group=Recycling%20Bins%20and%20Waste|Next%20Bin%20Collections&uid={user_uprn}"
+        response = requests.get(url, verify=False, headers=HEADERS, timeout=30).text
+
         data = {"bins": []}
-
-        baseurl = "https://maps.southderbyshire.gov.uk/iShareLIVE.web//getdata.aspx?RequestType=LocalInfo&ms=mapsources/MyHouse&format=JSONP&group=Recycling%20Bins%20and%20Waste|Next%20Bin%20Collections&uid="
-        url = baseurl + user_uprn
-
-        # Make the web request
-        response = requests.get(url).text
-
-        # Remove the JSONP wrapper using a regular expression
-        jsonp_pattern = r"\{.*\}"
-        json_match = re.search(jsonp_pattern, response)
+        jsonp_pattern = r"import\((\{.*\})\)"
+        json_match = re.search(jsonp_pattern, response, re.S)
 
         if json_match:
-            # Extract the JSON part
-            json_data = json_match.group(0)
-
-            # Parse the JSON
+            json_data = json_match.group(1)
             parsed_data = json.loads(json_data)
-
-            # Extract the embedded HTML string
             html_content = parsed_data["Results"]["Next_Bin_Collections"]["_"]
 
-            # Parse the HTML to extract dates and bin types using regex
             matches = re.findall(
                 r"<span.*?>(\d{2} \w+ \d{4})</span>.*?<span.*?>(.*?)</span>",
                 html_content,
                 re.S,
             )
 
-            # Output the parsed bin collection details
             for match in matches:
                 dict_data = {
                     "type": match[1],
-                    "collectionDate": datetime.strptime(match[0], "%d %B %Y").strftime(
-                        "%d/%m/%Y"
-                    ),
+                    "collectionDate": datetime.strptime(
+                        match[0], "%d %B %Y"
+                    ).strftime("%d/%m/%Y"),
                 }
                 data["bins"].append(dict_data)
-        else:
-            print("No valid JSON found in the response.")
 
         return data

--- a/uk_bin_collection/uk_bin_collection/councils/SouthDerbyshireDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/SouthDerbyshireDistrictCouncil.py
@@ -35,7 +35,7 @@ class CouncilClass(AbstractGetBinDataClass):
     def parse_data(self, page: str, **kwargs) -> dict:
         user_uprn = kwargs.get("uprn")
         user_postcode = kwargs.get("postcode")
-        user_paon = kwargs.get("paon")
+        user_paon = kwargs.get("paon") or kwargs.get("house_number")
 
         requests.packages.urllib3.disable_warnings()
 
@@ -68,24 +68,26 @@ class CouncilClass(AbstractGetBinDataClass):
         jsonp_pattern = r"import\((\{.*\})\)"
         json_match = re.search(jsonp_pattern, response, re.S)
 
-        if json_match:
-            json_data = json_match.group(1)
-            parsed_data = json.loads(json_data)
-            html_content = parsed_data["Results"]["Next_Bin_Collections"]["_"]
+        if not json_match:
+            raise ValueError("Failed to parse JSONP response from council API")
 
-            matches = re.findall(
-                r"<span.*?>(\d{2} \w+ \d{4})</span>.*?<span.*?>(.*?)</span>",
-                html_content,
-                re.S,
-            )
+        json_data = json_match.group(1)
+        parsed_data = json.loads(json_data)
+        html_content = parsed_data["Results"]["Next_Bin_Collections"]["_"]
 
-            for match in matches:
-                dict_data = {
-                    "type": match[1],
-                    "collectionDate": datetime.strptime(
-                        match[0], "%d %B %Y"
-                    ).strftime("%d/%m/%Y"),
-                }
-                data["bins"].append(dict_data)
+        matches = re.findall(
+            r"<span.*?>(\d{2} \w+ \d{4})</span>.*?<span.*?>(.*?)</span>",
+            html_content,
+            re.S,
+        )
+
+        for match in matches:
+            dict_data = {
+                "type": match[1],
+                "collectionDate": datetime.strptime(
+                    match[0], "%d %B %Y"
+                ).strftime("%d/%m/%Y"),
+            }
+            data["bins"].append(dict_data)
 
         return data


### PR DESCRIPTION
## Summary
- Users can provide **either** UPRN **or** postcode + house number
- UPRN takes priority when provided (backward compatible)
- Uses iShareLIVE LocationSearch endpoint for postcode-to-address resolution
- Matches by house number/name with fallback to first result
- Falls back to first result if no match found

## Testing
- UPRN path (backward compat): `DE11 7AB` + UPRN `10000820668` ✅
- Postcode + house number: `DE11 7AB` + paon `2` ✅
- Tested via API end-to-end ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * South Derbyshire integration now accepts postcode + house number (UPRN optional) for address lookup, making bin schedule lookups more flexible.
* **Bug Fixes**
  * More reliable retrieval and parsing of collection data with clearer error feedback when an address cannot be resolved.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robbrad/UKBinCollectionData/pull/2065?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->