### PR TITLE
feat: add postcode lookup for vale of glamorgan council

### DIFF
--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -2570,11 +2570,13 @@
         "LAD24CD": "E07000077"
     },
     "ValeofGlamorganCouncil": {
+        "postcode": "CF63 4AE",
+        "house_number": "3",
         "skip_get_url": true,
         "uprn": "64029020",
         "url": "https://www.valeofglamorgan.gov.uk/en/living/Recycling-and-Waste/",
         "wiki_name": "The Vale of Glamorgan",
-        "wiki_note": "Provide your UPRN. Find it using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
+        "wiki_note": "Provide your postcode and house number. UPRN is also accepted but no longer required.",
         "LAD24CD": "W06000014"
     },
     "ValeofWhiteHorseCouncil": {

--- a/uk_bin_collection/uk_bin_collection/councils/ValeofGlamorganCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/ValeofGlamorganCouncil.py
@@ -3,32 +3,67 @@ from bs4 import BeautifulSoup
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
+BASE_URL = "https://myvale.valeofglamorgan.gov.uk/getdata.aspx"
+HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+    "Accept": "*/*",
+    "Accept-Language": "en-GB,en;q=0.6",
+    "Referer": "https://www.valeofglamorgan.gov.uk/",
+}
 
-# import the wonderful Beautiful Soup and the URL grabber
+
+def _match_address(results, uprn=None, paon=None):
+    """Match an address from LocationSearch results by UPRN or house number/name.
+    Each result is [UniqueId, Parent, DisplayName, Type, X, Y, Rank, Name, Zoom]."""
+    if uprn:
+        uprn_str = str(uprn)
+        for row in results:
+            if str(row[0]) == uprn_str:
+                return str(row[0])
+
+    if paon:
+        paon_norm = str(paon).strip().upper()
+        for row in results:
+            name = str(row[7]).upper()
+            if name.startswith(paon_norm + " ") or name.startswith(paon_norm + ","):
+                return str(row[0])
+        for row in results:
+            name = str(row[7]).upper()
+            if paon_norm in name:
+                return str(row[0])
+
+    return str(results[0][0])
+
+
 class CouncilClass(AbstractGetBinDataClass):
-    """
-    Concrete classes have to implement all abstract operations of the
-    base class. They can also override some operations with a default
-    implementation.
-    """
-
     def parse_data(self, page: str, **kwargs) -> dict:
         requests.packages.urllib3.disable_warnings()
         user_uprn = kwargs.get("uprn")
-        check_uprn(user_uprn)
-        headers = {
-            "Accept": "*/*",
-            "Accept-Language": "en-GB,en;q=0.6",
-            "Connection": "keep-alive",
-            "Referer": "https://www.valeofglamorgan.gov.uk/",
-            "Sec-Fetch-Dest": "script",
-            "Sec-Fetch-Mode": "no-cors",
-            "Sec-Fetch-Site": "same-site",
-            "Sec-GPC": "1",
-            "sec-ch-ua": '"Not?A_Brand";v="8", "Chromium";v="108", "Brave";v="108"',
-            "sec-ch-ua-mobile": "?0",
-            "sec-ch-ua-platform": '"Windows"',
-        }
+        user_postcode = kwargs.get("postcode")
+        user_paon = kwargs.get("paon")
+
+        if not user_uprn and user_postcode:
+            params = {
+                "RequestType": "LocationSearch",
+                "location": user_postcode,
+                "pagesize": "20",
+                "startnum": "1",
+                "gettotals": "false",
+                "type": "json",
+            }
+            resp = requests.get(BASE_URL, params=params, headers=HEADERS, timeout=30)
+            resp.raise_for_status()
+            search_data = resp.json()
+
+            results = search_data.get("data", [])
+            if not results:
+                raise ValueError(f"No addresses found for postcode: {user_postcode}")
+
+            user_uprn = _match_address(results, paon=user_paon)
+
+        if not user_uprn:
+            raise ValueError("Could not resolve address. Provide a postcode or UPRN.")
+
         params = {
             "RequestType": "LocalInfo",
             "ms": "ValeOfGlamorgan/AllMaps",
@@ -36,47 +71,28 @@ class CouncilClass(AbstractGetBinDataClass):
             "type": "jsonp",
             "callback": "AddressInfoCallback",
             "uid": user_uprn,
-            "import": "jQuery35107288886041176057_1736292844067",
-            "_": "1736292844068",
         }
 
-        # Get a response from the council
-        response = requests.get(
-            "https://myvale.valeofglamorgan.gov.uk/getdata.aspx",
-            params=params,
-            headers=headers,
-        ).text
-
+        response = requests.get(BASE_URL, params=params, headers=HEADERS).text
         response = response.replace("AddressInfoCallback(", "").rstrip(");")
 
-        # Load the JSON and seek out the bin week text, then add it to the calendar URL. Also take the weekly
-        # collection type and generate dates for it. Then make a GET request for the calendar
-        bin_week = str(
-            json.loads(response)["Results"]["waste"]["roundday_residual"]
-        ).replace(" ", "-")
-        weekly_collection = str(
-            json.loads(response)["Results"]["waste"]["recycling_code"]
-        ).capitalize()
+        parsed = json.loads(response)
+        waste = parsed["Results"]["waste"]
+        bin_week = str(waste["roundday_residual"]).replace(" ", "-")
+        weekly_collection = str(waste["recycling_code"]).capitalize()
         weekly_dates = get_weekday_dates_in_period(
             datetime.now(), days_of_week.get(bin_week.split("-")[0].strip()), amount=48
         )
         schedule_url = f"https://www.valeofglamorgan.gov.uk/en/living/Recycling-and-Waste/collections/Black-Bag-Collections/{bin_week}.aspx"
-        response = requests.get(schedule_url, verify=False)
+        response = requests.get(schedule_url, verify=False, headers=HEADERS)
 
-        # BS4 parses the calendar
         soup = BeautifulSoup(response.text, features="html.parser")
-        soup.prettify()
 
-        # Some scraper variables
         collections = []
 
-        # Get the calendar table and find the headers
         table = soup.find("table", {"class": "TableStyle_Activities"}).find("tbody")
-        table_headers = table.find("tr").find_all("th")
-        # For all rows below the header, find all details in th next row
         for tr in soup.find_all("tr")[1:]:
             row = tr.find_all("td")
-            # Parse month and year - month needs converting from text to number
             month_and_year = row[0].text.split()
             if month_and_year[0] in list(calendar.month_abbr):
                 collection_month = datetime.strptime(month_and_year[0], "%b").month
@@ -86,10 +102,10 @@ class CouncilClass(AbstractGetBinDataClass):
                 collection_month = datetime.strptime(month_and_year[0], "%B").month
             collection_year = datetime.strptime(month_and_year[1], "%Y").year
 
-            # Get the collection dates column, remove anything that's not a number or space and then convert to dates
             for day in remove_alpha_characters(row[1].text.strip()).split():
                 try:
                     bin_date = datetime(collection_year, collection_month, int(day))
+                    table_headers = table.find("tr").find_all("th")
                     collections.append(
                         (
                             table_headers[1]
@@ -98,16 +114,14 @@ class CouncilClass(AbstractGetBinDataClass):
                             bin_date,
                         )
                     )
-                except Exception as ex:
+                except Exception:
                     continue
 
-        # Add in weekly dates to the tuple
         for date in weekly_dates:
             collections.append(
                 (weekly_collection, datetime.strptime(date, date_format))
             )
 
-        # Order all the data, only including future dates
         ordered_data = sorted(collections, key=lambda x: x[1])
         data = {"bins": []}
         for item in ordered_data:

--- a/uk_bin_collection/uk_bin_collection/councils/ValeofGlamorganCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/ValeofGlamorganCouncil.py
@@ -73,7 +73,7 @@ class CouncilClass(AbstractGetBinDataClass):
             "uid": user_uprn,
         }
 
-        response = requests.get(BASE_URL, params=params, headers=HEADERS).text
+        response = requests.get(BASE_URL, params=params, headers=HEADERS, timeout=30).text
         response = response.replace("AddressInfoCallback(", "").rstrip(");")
 
         parsed = json.loads(response)
@@ -84,7 +84,7 @@ class CouncilClass(AbstractGetBinDataClass):
             datetime.now(), days_of_week.get(bin_week.split("-")[0].strip()), amount=48
         )
         schedule_url = f"https://www.valeofglamorgan.gov.uk/en/living/Recycling-and-Waste/collections/Black-Bag-Collections/{bin_week}.aspx"
-        response = requests.get(schedule_url, verify=False, headers=HEADERS)
+        response = requests.get(schedule_url, verify=False, headers=HEADERS, timeout=30)
 
         soup = BeautifulSoup(response.text, features="html.parser")
 


### PR DESCRIPTION
## Summary
- Users can provide **either** UPRN **or** postcode + house number
- UPRN takes priority when provided (backward compatible)
- Uses iShareLIVE LocationSearch endpoint for postcode-to-address resolution
- No need for OS Places API - the existing iShareLIVE platform has its own address search
- Falls back to first result if no match found

## Testing
- UPRN path (backward compat): UPRN `64029020` ✅
- Postcode + house number: `CF63 4AE` + paon `3` ✅
- Tested via API end-to-end ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Vale of Glamorgan Council now accepts postcode and house number as input parameters; UPRN is no longer required.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robbrad/UKBinCollectionData/pull/2066)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->