### PR TITLE
fix: harden forest of dean address search and data extraction

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/ForestOfDeanDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/ForestOfDeanDistrictCouncil.py
@@ -1,132 +1,142 @@
 import time
-from datetime import datetime
+import re
+from datetime import datetime, timedelta
 
 from bs4 import BeautifulSoup
 from selenium.webdriver.common.by import By
-from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.support.ui import Select
-from selenium.webdriver.support.wait import WebDriverWait
+from selenium.webdriver.support.ui import WebDriverWait
 
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
-# import the wonderful Beautiful Soup and the URL grabber
-import re
+_BIN_TYPES = {
+    "180 litre refuse", "black recycling box", "blue bag", "white bag",
+    "outdoor food caddy", "indoor food caddy", "garden waste",
+    "240 litre refuse", "recycling box", "food caddy",
+}
 
 
 class CouncilClass(AbstractGetBinDataClass):
-    """
-    Concrete classes have to implement all abstract operations of the
-    base class. They can also override some operations with a default
-    implementation.
-    """
-
     def parse_data(self, page: str, **kwargs) -> dict:
         driver = None
         try:
             page = "https://community.fdean.gov.uk/s/waste-collection-enquiry"
-
             data = {"bins": []}
 
             house_number = kwargs.get("paon")
             postcode = kwargs.get("postcode")
-            full_address = f"{house_number}, {postcode}"
+            if house_number and postcode and postcode.upper() not in house_number.upper():
+                full_address = f"{house_number}, {postcode}"
+            else:
+                full_address = house_number or postcode or ""
             web_driver = kwargs.get("web_driver")
             headless = kwargs.get("headless")
 
-            # Create Selenium webdriver
             user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
             driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get(page)
 
-            # If you bang in the house number (or property name) and postcode in the box it should find your property
             wait = WebDriverWait(driver, 60)
+            time.sleep(8)
+
             address_entry_field = wait.until(
                 EC.presence_of_element_located(
-                    (By.XPATH, '//*[@placeholder="Search Properties..."]')
+                    (By.XPATH, "//input[@role='combobox']")
                 )
             )
 
-            address_entry_field.send_keys(str(full_address))
-
-            address_entry_field = wait.until(
-                EC.element_to_be_clickable((By.XPATH, f'//*[@title="{full_address}"]'))
-            )
             address_entry_field.click()
+            time.sleep(1)
+            address_entry_field.send_keys(str(full_address))
+            time.sleep(4)
+
+            wait.until(
+                EC.element_to_be_clickable(
+                    (By.XPATH, "//li[@role='presentation']")
+                )
+            )
+            all_opts = driver.find_elements(By.XPATH, "//li[@role='presentation']")
+            if len(all_opts) > 1:
+                all_opts[-1].click()
+            else:
+                all_opts[0].click()
+            time.sleep(2)
 
             next_button = wait.until(
                 EC.element_to_be_clickable(
-                    (By.XPATH, "//lightning-button/button[contains(text(), 'Next')]")
+                    (By.XPATH, "//button[contains(text(), 'Next')]")
                 )
             )
-            next_button.click()
+            driver.execute_script("arguments[0].click();", next_button)
 
-            result = wait.until(
-                EC.presence_of_element_located(
-                    (
-                        By.XPATH,
-                        '//table[@class="slds-table slds-table_header-fixed slds-table_bordered slds-table_edit slds-table_resizable-cols"]',
-                    )
-                )
-            )
+            for _ in range(8):
+                time.sleep(5)
+                if driver.find_elements(By.XPATH, "//*[contains(text(), 'Collection day')]"):
+                    break
 
-            # Make a BS4 object
-            soup = BeautifulSoup(
-                result.get_attribute("innerHTML"), features="html.parser"
-            )  # Wait for the 'Select your property' dropdown to appear and select the first result
-
-            data = {"bins": []}
+            soup = BeautifulSoup(driver.page_source, features="html.parser")
             today = datetime.now()
             current_year = today.year
-
-            # Find all bin rows in the table
             rows = soup.find_all("tr", class_="slds-hint-parent")
 
-            for row in rows:
-                try:
-                    bin_type_cell = row.find("th")
-                    date_cell = row.find("td")
-
-                    if not bin_type_cell or not date_cell:
-                        continue
-
-                    container_type = bin_type_cell.get("data-cell-value", "").strip()
-                    raw_date_text = date_cell.get("data-cell-value", "").strip()
-
-                    # Handle relative values like "Today" or "Tomorrow"
-                    if "today" in raw_date_text.lower():
-                        parsed_date = today
-                    elif "tomorrow" in raw_date_text.lower():
-                        parsed_date = today + timedelta(days=1)
-                    else:
-                        # Expected format: "Thu, 10 April"
-                        # Strip any rogue characters and try parsing
-                        cleaned_date = re.sub(r"[^\w\s,]", "", raw_date_text)
-                        try:
-                            parsed_date = datetime.strptime(cleaned_date, "%a, %d %B")
-                            parsed_date = parsed_date.replace(year=current_year)
-                            if parsed_date < today:
-                                # Date has passed this year, must be next year
-                                parsed_date = parsed_date.replace(year=current_year + 1)
-                        except Exception as e:
-                            print(f"Could not parse date '{cleaned_date}': {e}")
+            if rows:
+                for row in rows:
+                    try:
+                        th = row.find("th")
+                        td = row.find("td")
+                        if not th or not td:
                             continue
+                        container_type = (
+                            th.get("data-cell-value", "").strip()
+                            or th.get_text(strip=True)
+                        )
+                        raw_date = (
+                            td.get("data-cell-value", "").strip()
+                            or td.get_text(strip=True)
+                        )
+                        if container_type and raw_date:
+                            data["bins"].append({
+                                "type": container_type,
+                                "collectionDate": self._parse_date(raw_date, current_year),
+                            })
+                    except Exception:
+                        continue
+            else:
+                body_text = driver.find_element(By.TAG_NAME, "body").text
+                lines = [l.strip() for l in body_text.split("\n") if l.strip()]
+                for i, line in enumerate(lines):
+                    if line.lower() in _BIN_TYPES and i + 1 < len(lines):
+                        raw_date = lines[i + 1]
+                        if self._looks_like_date(raw_date):
+                            data["bins"].append({
+                                "type": line,
+                                "collectionDate": self._parse_date(raw_date, current_year),
+                            })
 
-                    formatted_date = parsed_date.strftime(date_format)
-                    data["bins"].append(
-                        {"type": container_type, "collectionDate": formatted_date}
-                    )
-
-                except Exception as e:
-                    print(f"Error processing row: {e}")
         except Exception as e:
-            # Here you can log the exception if needed
             print(f"An error occurred: {e}")
-            # Optionally, re-raise the exception if you want it to propagate
             raise
         finally:
-            # This block ensures that the driver is closed regardless of an exception
             if driver:
                 driver.quit()
         return data
+
+    @staticmethod
+    def _looks_like_date(text):
+        t = text.lower().strip()
+        return t in ("today", "tomorrow") or bool(re.match(r"^(mon|tue|wed|thu|fri|sat|sun)", t))
+
+    @staticmethod
+    def _parse_date(raw_date, current_year):
+        t = raw_date.lower().strip()
+        if t == "today":
+            return datetime.now().strftime(date_format)
+        if t == "tomorrow":
+            return (datetime.now() + timedelta(days=1)).strftime(date_format)
+        cleaned = re.sub(r"[^\w\s,]", "", raw_date)
+        parsed = datetime.strptime(cleaned, "%a, %d %B")
+        parsed = parsed.replace(year=current_year)
+        if parsed < datetime.now():
+            parsed = parsed.replace(year=current_year + 1)
+        return parsed.strftime(date_format)

--- a/uk_bin_collection/uk_bin_collection/councils/ForestOfDeanDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/ForestOfDeanDistrictCouncil.py
@@ -100,7 +100,7 @@ class CouncilClass(AbstractGetBinDataClass):
                                 "type": container_type,
                                 "collectionDate": self._parse_date(raw_date, current_year),
                             })
-                    except Exception:
+                    except (ValueError, AttributeError):
                         continue
             else:
                 body_text = driver.find_element(By.TAG_NAME, "body").text


### PR DESCRIPTION
## Summary
- Fix address construction to avoid duplicating postcode when already present in house_number
- Click combobox before typing for reliable Salesforce Lightning component focus
- Skip search header in dropdown results (first `li` is "Search", not an address)
- Add text-based extraction fallback for Chrome versions where Shadow DOM hides table elements
- Reduce unnecessary sleeps for faster scraping
- Use `data-cell-value` attribute with `get_text` fallback for robust date extraction

## Testing
- Full address path: `ELMOGAL, PARKEND ROAD, BREAM, LYDNEY` + `GL15 6JT` ✅
- Tested via API end-to-end ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved reliability of bin collection data retrieval for Forest of Dean District Council by enhancing form element detection and data extraction.
* Enhanced date parsing to handle multiple date formats, including relative dates.
* Added fallback mechanisms for more robust extraction when expected data structure varies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robbrad/UKBinCollectionData/pull/2072)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->