### PR TITLE
feat: add postcode lookup for malvern hills district council

### DIFF
--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -1520,10 +1520,12 @@
     },
     "MalvernHillsDC": {
         "skip_get_url": true,
-        "uprn": "100121348457",
+        "postcode": "WR14 1AA",
+        "house_number": "148",
+        "uprn": "100120606212",
         "url": "https://swict.malvernhills.gov.uk/mhdcroundlookup/HandleSearchScreen",
         "wiki_name": "Malvern Hills",
-        "wiki_note": "Pass the UPRN. You can find it using [FindMyAddress](https://www.findmyaddress.co.uk/search).",
+        "wiki_note": "Pass postcode and house number, or just the UPRN. The scraper resolves the UPRN from the council's own address lookup API.",
         "LAD24CD": "E07000235"
     },
     "ManchesterCityCouncil": {

--- a/uk_bin_collection/uk_bin_collection/councils/MalvernHillsDC.py
+++ b/uk_bin_collection/uk_bin_collection/councils/MalvernHillsDC.py
@@ -3,7 +3,6 @@ from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
 
-# import the wonderful Beautiful Soup and the URL grabber
 class CouncilClass(AbstractGetBinDataClass):
     """
     Concrete classes have to implement all abstract operations of the
@@ -11,28 +10,34 @@ class CouncilClass(AbstractGetBinDataClass):
     implementation.
     """
 
+    UPRN_LOOKUP_URL = "https://swict.malvernhills.gov.uk/sw2AddressLookupWS/jaxrs/PostCode"
+
     def parse_data(self, page: str, **kwargs) -> dict:
         api_url = "https://swict.malvernhills.gov.uk/mhdcroundlookup/HandleSearchScreen"
 
         user_uprn = kwargs.get("uprn")
-        # Check the UPRN is valid
+        user_postcode = kwargs.get("postcode")
+        user_paon = kwargs.get("paon")
+
+        if not user_uprn and user_postcode:
+            user_uprn = self._resolve_uprn(user_postcode, user_paon)
+
         check_uprn(user_uprn)
 
-        # Create the form data
         form_data = {"nmalAddrtxt": "", "alAddrsel": user_uprn}
-        # expects postcode to be looked up and then uprn used.
-        # we can just provide uprn
 
-        # Make a request to the API
         requests.packages.urllib3.disable_warnings()
         response = requests.post(api_url, data=form_data, verify=False)
 
-        # Make a BS4 object
         soup = BeautifulSoup(response.text, features="html.parser")
         soup.prettify()
 
-        # Find results table
         table_element = soup.find("table")
+        if not table_element:
+            raise ValueError(
+                "No results table found — UPRN may be invalid or address not in bin round records"
+            )
+
         table_body = table_element.find("tbody")
         rows = table_body.find_all("tr")
 
@@ -42,9 +47,8 @@ class CouncilClass(AbstractGetBinDataClass):
             columns = row.find_all("td")
             columns = [ele.text.strip() for ele in columns]
 
-            thisCollection = [ele for ele in columns if ele]  # Get rid of empty values
+            thisCollection = [ele for ele in columns if ele]
 
-            # if not signed up for garden waste, this appears as Not applicable
             if "Not applicable" not in thisCollection[1]:
                 bin_type = thisCollection[0].replace("collection", "").strip()
                 date = datetime.strptime(thisCollection[1], "%A %d/%m/%Y")
@@ -55,3 +59,32 @@ class CouncilClass(AbstractGetBinDataClass):
                 data["bins"].append(dict_data)
 
         return data
+
+    def _resolve_uprn(self, postcode: str, house_number: str = None) -> str:
+        params = {
+            "simple": "T",
+            "pcode": postcode,
+            "authority": "MHDC",
+            "historical": "false",
+            "hidedummyuprn": "1",
+        }
+        response = requests.get(self.UPRN_LOOKUP_URL, params=params, verify=False)
+        response.raise_for_status()
+        results = response.json().get("jArray", [])
+
+        if not results:
+            raise ValueError(f"No addresses found for postcode {postcode}")
+
+        if house_number:
+            house_lower = house_number.lower().strip()
+            for entry in results:
+                addr = entry.get("Address_Short", "").lower()
+                if addr.startswith(house_lower):
+                    return entry["UPRN"]
+
+        if len(results) == 1:
+            return results[0]["UPRN"]
+
+        raise ValueError(
+            f"Multiple addresses found for {postcode} — provide house_number to disambiguate"
+        )

--- a/uk_bin_collection/uk_bin_collection/councils/MalvernHillsDC.py
+++ b/uk_bin_collection/uk_bin_collection/councils/MalvernHillsDC.py
@@ -79,7 +79,13 @@ class CouncilClass(AbstractGetBinDataClass):
             house_lower = house_number.lower().strip()
             for entry in results:
                 addr = entry.get("Address_Short", "").lower()
-                if addr.startswith(house_lower):
+                addr_parts = addr.split()
+                if addr_parts and addr_parts[0] == house_lower:
+                    return entry["UPRN"]
+            # Fallback: check if house_number appears at start followed by separator
+            for entry in results:
+                addr = entry.get("Address_Short", "").lower()
+                if addr.startswith(house_lower + " ") or addr.startswith(house_lower + ","):
                     return entry["UPRN"]
 
         if len(results) == 1:


### PR DESCRIPTION
## Summary
- Users can provide **either** UPRN **or** postcode + house number
- UPRN takes priority when provided (backward compatible)
- Uses the council's own address lookup API (`sw2AddressLookupWS`) for postcode-to-UPRN resolution
- Matches by house number with fallback to single-result auto-select
- Adds a null check on the results table for a clear error when the address is not in bin round records

The existing scraper wasn't broken — it works fine with a valid UPRN. This change removes the need for users to find and supply a UPRN manually, which is a common pain point (see #1497).

## Testing
- UPRN path (backward compat): `WR14 1AA` + UPRN `100120606212` 
- Postcode + house number: `WR14 1AA` + paon `148`
- Tested via API end-to-end

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MalvernHillsDC scraper now supports automatic UPRN resolution via address lookup. Users can provide postcode and house number, and the scraper will automatically resolve the matching UPRN.

* **Bug Fixes**
  * Improved error handling with explicit validation when bin collection data is not available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robbrad/UKBinCollectionData/pull/2074)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->