### PR TITLE
feat: rewrite north west leicestershire as pure http scraper

### DIFF
--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -1825,12 +1825,12 @@
     },
     "NorthWestLeicestershire": {
         "postcode": "DE74 2FZ",
+        "house_number": "1",
+        "postcode": "DE74 2FZ",
         "skip_get_url": true,
-        "uprn": "100030572613",
-        "url": "https://www.nwleics.gov.uk/pages/collection_information",
-        "web_driver": "http://selenium:4444",
+        "url": "https://my.nwleics.gov.uk/",
         "wiki_name": "North West Leicestershire",
-        "wiki_note": "Pass the postcode and UPRN. This parser requires a Selenium webdriver.",
+        "wiki_note": "Pass the postcode and house number. No UPRN or Selenium needed.",
         "LAD24CD": "E07000134"
     },
     "NorthYorkshire": {

--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -1826,7 +1826,6 @@
     "NorthWestLeicestershire": {
         "postcode": "DE74 2FZ",
         "house_number": "1",
-        "postcode": "DE74 2FZ",
         "skip_get_url": true,
         "url": "https://my.nwleics.gov.uk/",
         "wiki_name": "North West Leicestershire",

--- a/uk_bin_collection/uk_bin_collection/councils/NorthWestLeicestershire.py
+++ b/uk_bin_collection/uk_bin_collection/councils/NorthWestLeicestershire.py
@@ -1,16 +1,10 @@
-import re  # Import regular expressions
+import re
 from datetime import datetime, timedelta
 
 from bs4 import BeautifulSoup
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.support.ui import Select
-from selenium.webdriver.support.wait import WebDriverWait
 
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
-
-# import the wonderful Beautiful Soup and the URL grabber
 
 
 class CouncilClass(AbstractGetBinDataClass):
@@ -20,96 +14,99 @@ class CouncilClass(AbstractGetBinDataClass):
     implementation.
     """
 
+    AUTOCOMPLETE_URL = (
+        "https://my.nwleics.gov.uk/data/ac/addresses.json"
+    )
+    LOCATION_URL = "https://my.nwleics.gov.uk/location"
+    HOME_URL = "https://my.nwleics.gov.uk/"
+
     def parse_data(self, page: str, **kwargs) -> dict:
-        driver = None
-        try:
-            data = {"bins": []}
+        user_postcode = kwargs.get("postcode")
+        user_paon = kwargs.get("paon")
+        check_postcode(user_postcode)
 
-            user_uprn = kwargs.get("uprn")
-            user_postcode = kwargs.get("postcode")
-            web_driver = kwargs.get("web_driver")
-            headless = kwargs.get("headless")
-            check_uprn(user_uprn)
-            check_postcode(user_postcode)
-            # Create Selenium webdriver
-            page = f"https://my.nwleics.gov.uk/my-property-finder?address={user_postcode}&go=1"
+        nwl_id = self._resolve_address(user_postcode, user_paon)
 
-            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
-            driver = create_webdriver(web_driver, headless, user_agent, __name__)
-            driver.get(page)
+        session = requests.Session()
+        session.headers.update(
+            {
+                "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            }
+        )
 
-            # If you bang in the house number (or property name) and postcode in the box it should find your property
+        session.get(
+            self.LOCATION_URL,
+            params={"put": nwl_id, "rememberme": "0", "redirect": "/"},
+            allow_redirects=True,
+        )
 
-            # iframe_presense = WebDriverWait(driver, 30).until(
-            #    EC.presence_of_element_located((By.ID, "fillform-frame-1"))
-            # )
+        response = session.get(self.HOME_URL)
+        soup = BeautifulSoup(response.text, features="html.parser")
 
-            # driver.switch_to.frame(iframe_presense)
-            wait = WebDriverWait(driver, 60)
-
-            address_link = wait.until(
-                EC.element_to_be_clickable(
-                    (By.XPATH, f'//a[contains(@href, "{user_uprn}")]')
-                )
+        refuse_list = soup.find("ul", class_="refuse")
+        if not refuse_list:
+            raise ValueError(
+                "No refuse collection data found for this address"
             )
 
-            address_link.click()
+        data = {"bins": []}
+        current_year = datetime.now().year
+        current_date = datetime.now().date()
 
-            refuse_element = wait.until(
-                EC.presence_of_element_located(
-                    (By.XPATH, f'//h3[contains(text(), "Refuse Collection Dates")]')
-                )
+        for li in refuse_list.find_all("li"):
+            date_tag = li.find("strong", class_="date")
+            link_tag = li.find("a")
+            if not date_tag or not link_tag:
+                continue
+
+            date_str = date_tag.text.strip()
+            waste_type = link_tag.text.strip()
+
+            if date_str.lower() == "today":
+                parsed_date = current_date
+            elif date_str.lower() == "tomorrow":
+                parsed_date = current_date + timedelta(days=1)
+            else:
+                date_str = re.sub(r"(st|nd|rd|th)", "", date_str)
+                parsed_date = datetime.strptime(date_str, "%a %d %b").date()
+
+            if parsed_date.year < current_date.year:
+                parsed_date = parsed_date.replace(year=current_year)
+
+            if parsed_date < current_date:
+                parsed_date = parsed_date.replace(year=current_year + 1)
+
+            data["bins"].append(
+                {
+                    "type": waste_type,
+                    "collectionDate": parsed_date.strftime(date_format),
+                }
             )
 
-            soup = BeautifulSoup(driver.page_source, features="html.parser")
-
-            # Find the unordered list containing refuse collection details
-            refuse_list = soup.find("ul", class_="refuse")
-
-            current_year = datetime.now().year
-
-            if refuse_list:
-                # Iterate through list items within the unordered list
-                for li in refuse_list.find_all("li"):
-                    date = li.find(
-                        "strong", class_="date"
-                    ).text.strip()  # Extract the date
-                    waste_type = li.find("a").text.strip()  # Extract the waste type
-
-                    # Parse the date from the string
-                    # check for today and tomorrow
-                    if date.lower() == "today":
-                        parsed_date = datetime.now().date()
-                    elif date.lower() == "tomorrow":
-                        parsed_date = (datetime.now() + timedelta(days=1)).date()
-                    else:
-                        date = re.sub(r"(st|nd|rd|th)", "", date)
-                        parsed_date = datetime.strptime(date, "%a %d %b").date()
-
-                    current_date = datetime.now().date()
-
-                    # double check we've got a year and if not the current one
-                    if parsed_date.year < current_date.year:
-                        parsed_date = parsed_date.replace(year=current_date.year)
-
-                    # check if the date is in the past and if so add a year
-                    if parsed_date < current_date:
-                        parsed_date = parsed_date.replace(year=current_date.year + 1)
-
-                    # Append data to your 'bins' list (this replicates your existing logic)
-                    data["bins"].append(
-                        {
-                            "type": waste_type,
-                            "collectionDate": parsed_date.strftime("%d/%m/%Y"),
-                        }
-                    )
-        except Exception as e:
-            # Here you can log the exception if needed
-            print(f"An error occurred: {e}")
-            # Optionally, re-raise the exception if you want it to propagate
-            raise
-        finally:
-            # This block ensures that the driver is closed regardless of an exception
-            if driver:
-                driver.quit()
         return data
+
+    def _resolve_address(self, postcode: str, house_number: str = None) -> str:
+        response = requests.get(
+            self.AUTOCOMPLETE_URL, params={"term": postcode}
+        )
+        response.raise_for_status()
+        results = response.json()
+
+        if not results:
+            raise ValueError(f"No addresses found for postcode {postcode}")
+
+        if house_number:
+            house_lower = house_number.lower().strip()
+            for entry in results:
+                label = entry.get("label", "").lower()
+                if label.startswith(house_lower + ",") or label.startswith(
+                    house_lower + " "
+                ):
+                    return entry["value"]
+
+        if len(results) == 1:
+            return results[0]["value"]
+
+        raise ValueError(
+            f"Multiple addresses found for {postcode} — provide house_number to disambiguate"
+        )

--- a/uk_bin_collection/uk_bin_collection/councils/NorthWestLeicestershire.py
+++ b/uk_bin_collection/uk_bin_collection/councils/NorthWestLeicestershire.py
@@ -22,7 +22,7 @@ class CouncilClass(AbstractGetBinDataClass):
 
     def parse_data(self, page: str, **kwargs) -> dict:
         user_postcode = kwargs.get("postcode")
-        user_paon = kwargs.get("paon")
+        user_paon = kwargs.get("paon") or kwargs.get("house_number")
         check_postcode(user_postcode)
 
         nwl_id = self._resolve_address(user_postcode, user_paon)
@@ -34,13 +34,16 @@ class CouncilClass(AbstractGetBinDataClass):
             }
         )
 
-        session.get(
+        location_resp = session.get(
             self.LOCATION_URL,
             params={"put": nwl_id, "rememberme": "0", "redirect": "/"},
             allow_redirects=True,
+            timeout=30,
         )
+        location_resp.raise_for_status()
 
-        response = session.get(self.HOME_URL)
+        response = session.get(self.HOME_URL, timeout=30)
+        response.raise_for_status()
         soup = BeautifulSoup(response.text, features="html.parser")
 
         refuse_list = soup.find("ul", class_="refuse")
@@ -68,10 +71,14 @@ class CouncilClass(AbstractGetBinDataClass):
                 parsed_date = current_date + timedelta(days=1)
             else:
                 date_str = re.sub(r"(st|nd|rd|th)", "", date_str)
-                parsed_date = datetime.strptime(date_str, "%a %d %b").date()
-
-            if parsed_date.year < current_date.year:
-                parsed_date = parsed_date.replace(year=current_year)
+                try:
+                    parsed_date = datetime.strptime(
+                        f"{date_str} {current_year}", "%a %d %b %Y"
+                    ).date()
+                except ValueError:
+                    parsed_date = datetime.strptime(
+                        f"{date_str} {current_year + 1}", "%a %d %b %Y"
+                    ).date()
 
             if parsed_date < current_date:
                 parsed_date = parsed_date.replace(year=current_year + 1)
@@ -87,7 +94,7 @@ class CouncilClass(AbstractGetBinDataClass):
 
     def _resolve_address(self, postcode: str, house_number: str = None) -> str:
         response = requests.get(
-            self.AUTOCOMPLETE_URL, params={"term": postcode}
+            self.AUTOCOMPLETE_URL, params={"term": postcode}, timeout=30
         )
         response.raise_for_status()
         results = response.json()


### PR DESCRIPTION
## Summary
- Rewrites the scraper from Selenium to pure HTTP requests — no Chrome or webdriver needed
- The previous scraper timed out because it passed raw OS UPRNs to the Cuttlefish CMS, which uses its own internal `nwl`-prefixed address IDs
- Uses the council's address autocomplete endpoint (`/data/ac/addresses.json`) to resolve postcode + house number to an internal ID, then sets a session cookie via `/location` and parses the homepage HTML
- Input is now postcode + house number only (no UPRN needed)

The existing Selenium scraper wasn't fundamentally broken — the timeout was caused by the ID mismatch, not a site change. This rewrite fixes the root cause and removes the Selenium dependency.

## Testing
- Postcode + house number: `DE74 2FZ` + paon `1`
- Tested via API end-to-end — 21 collection entries returned (Refuse, Garden Waste, Red Box, Blue Bag, Yellow Bag)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Refactor
* **NorthWestLeicestershire Council Integration** – Updated address lookup method to accept postcode and house number instead of UPRN, eliminating browser automation dependency for improved query performance and simplicity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robbrad/UKBinCollectionData/pull/2075)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->