### PR TITLE
fix: make South Lanarkshire schedule parsing defensive

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/SouthLanarkshireCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/SouthLanarkshireCouncil.py
@@ -1,3 +1,4 @@
+import logging
 import time
 from datetime import timedelta
 
@@ -6,6 +7,7 @@ from bs4 import BeautifulSoup
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
+logger = logging.getLogger(__name__)
 
 # import the wonderful Beautiful Soup and the URL grabber
 class CouncilClass(AbstractGetBinDataClass):
@@ -74,17 +76,27 @@ class CouncilClass(AbstractGetBinDataClass):
                     td_cell = row.find("td")
 
                     if th_cell is None or td_cell is None:
+                        logger.warning("Skipping schedule row with missing th or td cell")
                         continue
 
                     schedule_type = th_cell.get_text().strip()
 
                     # collection schedule contains area name -> filter out
                     if schedule_type == "Area":
+                        logger.debug("Skipping area row in collection schedule")
                         continue
 
                     td_text = td_cell.get_text(" ", strip=True)
                     results2 = re.search("([^(]+)", td_text)
-                    schedule_cadence = td_text.split(" ", 1)[1] if " " in td_text else ""
+
+                    if " " not in td_text:
+                        logger.warning(
+                            "Skipping schedule cadence parsing for unexpected schedule text: %s",
+                            td_text,
+                        )
+                        schedule_cadence = ""
+                    else:
+                        schedule_cadence = td_text.split(" ", 1)[1]
                     if results2:
                         schedule_day = results2[1].strip()
                         for collection_type in week_collection_types:

--- a/uk_bin_collection/uk_bin_collection/councils/SouthLanarkshireCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/SouthLanarkshireCouncil.py
@@ -70,14 +70,21 @@ class CouncilClass(AbstractGetBinDataClass):
             )
             for day in week_days:
                 for row in collection_schedule:
-                    schedule_type = row.find("th").get_text().strip()
+                    th_cell = row.find("th")
+                    td_cell = row.find("td")
+
+                    if th_cell is None or td_cell is None:
+                        continue
+
+                    schedule_type = th_cell.get_text().strip()
 
                     # collection schedule contains area name -> filter out
                     if schedule_type == "Area":
                         continue
 
-                    results2 = re.search("([^(]+)", row.find("td").get_text().strip())
-                    schedule_cadence = row.find("td").get_text().strip().split(" ")[1]
+                    td_text = td_cell.get_text(" ", strip=True)
+                    results2 = re.search("([^(]+)", td_text)
+                    schedule_cadence = td_text.split(" ", 1)[1] if " " in td_text else ""
                     if results2:
                         schedule_day = results2[1].strip()
                         for collection_type in week_collection_types:


### PR DESCRIPTION
Closes #2018.

## Summary

This makes the South Lanarkshire Council parser more defensive when reading the collection schedule table.

The current parser assumes that every schedule <td> has at least two space-separated parts:

row.find("td").get_text().strip().split(" ")[1]

For some South Lanarkshire rows this can raise:

IndexError: list index out of range

This PR stores the <th> and <td> cells, skips malformed rows, and safely defaults schedule_cadence to an empty string when there is no second token.

## Testing

- Ran SouthLanarkshireCouncil manually against a South Lanarkshire URL
- Ran:

poetry run pytest uk_bin_collection/tests/step_defs/ -k "SouthLanarkshireCouncil"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing robustness for South Lanarkshire bin collection schedules to better handle unexpected or malformed rows and skipped area-only entries.
  * More reliable extraction of collection cadence by normalizing schedule text before analysis.
  * Added diagnostic warnings to reduce silent failures during schedule retrieval.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robbrad/UKBinCollectionData/pull/2077)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->