### PR TITLE
fix: BaberghDistrictCouncil - handle "Today - " / "Tomorrow - " date prefix

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/BaberghDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/BaberghDistrictCouncil.py
@@ -1,4 +1,5 @@
 import datetime
+import re
 import time
 from datetime import datetime
 
@@ -9,6 +10,15 @@ from selenium.webdriver.support.ui import Select, WebDriverWait
 
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
+
+
+# Matches the council's date format e.g. "Thu 14 May 2026". A single <p>
+# can contain multiple dates separated by commas, and "Next Collection:" can
+# be prefixed with "Today - <date>" / "Tomorrow - <date>".
+_DATE_RE = re.compile(
+    r"\b(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun) \d{1,2} "
+    r"(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4}\b"
+)
 
 
 # import the wonderful Beautiful Soup and the URL grabber
@@ -114,29 +124,28 @@ class CouncilClass(AbstractGetBinDataClass):
                     p_tags = card.find_all("p")  # any <p>
 
                     for p_tag in p_tags:
-                        if p_tag.get_text().startswith("Frequency"):
+                        text = p_tag.get_text()
+                        if text.startswith("Frequency"):
                             continue
 
-                        # Collect text in p excluding the strong tag
-                        date_str = (p_tag.get_text()).split(":")[1].strip()
-
-                        # Handle multiple comma-separated dates
-                        for single_date in date_str.split(","):
-                            single_date = single_date.strip()
-                            if not single_date:
-                                continue
-                            # Strip leading day name prefix if present (e.g. "Mon 27 Apr 2026")
+                        # A single <p> can contain multiple dates — the
+                        # "Following Collections:" tag renders comma-separated
+                        # dates when the council has 3 upcoming collections,
+                        # and "Next Collection:" can be prefixed with
+                        # "Today - <date>". Pull every well-formed date out
+                        # of the text and emit one entry per date.
+                        for date_str in _DATE_RE.findall(text):
                             collection_date = datetime.strptime(
-                                single_date, "%a %d %b %Y"
+                                date_str, "%a %d %b %Y"
                             )
-
-                            dict_data = {
-                                "type": collection_type,
-                                "collectionDate": collection_date.strftime(
-                                    date_format
-                                ),
-                            }
-                            data["bins"].append(dict_data)
+                            data["bins"].append(
+                                {
+                                    "type": collection_type,
+                                    "collectionDate": collection_date.strftime(
+                                        date_format
+                                    ),
+                                }
+                            )
         except Exception as e:
             # Here you can log the exception if needed
             print(f"An error occurred: {e}")

--- a/uk_bin_collection/uk_bin_collection/councils/BaberghDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/BaberghDistrictCouncil.py
@@ -134,7 +134,23 @@ class CouncilClass(AbstractGetBinDataClass):
                         # and "Next Collection:" can be prefixed with
                         # "Today - <date>". Pull every well-formed date out
                         # of the text and emit one entry per date.
-                        for date_str in _DATE_RE.findall(text):
+                        matches = _DATE_RE.findall(text)
+
+                        # Fail loud if a collection-labelled line yields no
+                        # parseable dates. Silent drops here would freeze
+                        # downstream sensors on a future format change (a
+                        # bare regex miss is otherwise indistinguishable
+                        # from "no upcoming collection").
+                        if not matches and (
+                            text.startswith("Next Collection")
+                            or text.startswith("Following Collections")
+                        ):
+                            raise ValueError(
+                                f"No parseable dates in {collection_type!r} "
+                                f"collection line: {text!r}"
+                            )
+
+                        for date_str in matches:
                             collection_date = datetime.strptime(
                                 date_str, "%a %d %b %Y"
                             )


### PR DESCRIPTION
## Summary

Babergh's collection-day site now prefixes the **Next Collection** value with `Today - ` or `Tomorrow - `, e.g. `Today - Thu 14 May 2026`. The parser previously called `strptime(single_date, "%a %d %b %Y")` which raises `ValueError` on the prefixed form, crashing every scrape since the format change on 14 May 2026.

Switched to the same regex-based date extraction `MidSuffolkDistrictCouncil` already uses — Babergh and Mid Suffolk are paired districts on the same web platform, so the formats track in lockstep. The regex pulls every well-formed `Day DD Mon YYYY` token out of each `<p>`, naturally ignoring the `Today - ` / `Tomorrow - ` / `Frequency:` prefixes and still handling the existing multi-date `Following Collections:` case.

## Error this fixes

```
ValueError: time data 'Today - Thu 14 May 2026' does not match format '%a %d %b %Y'
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collection date extraction for Babergh District Council to ensure more reliable and accurate bin collection schedules.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robbrad/UKBinCollectionData/pull/2080)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->