### PR TITLE
fix: rewrite east ayrshire council scraper for recollect api

### DIFF
--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -729,11 +729,13 @@
         "LAD24CD": "E09000009"
     },
     "EastAyrshireCouncil": {
-        "uprn": "127074727",
+        "house_number": "57 Whatriggs Road",
+        "postcode": "KA1 3RB",
+        "skip_get_url": true,
         "url": "https://www.east-ayrshire.gov.uk",
         "wiki_command_url_override": "https://www.east-ayrshire.gov.uk",
         "wiki_name": "East Ayrshire",
-        "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
+        "wiki_note": "Pass postcode and house number or full address. Uses the ReCollect API.",
         "LAD24CD": "S12000008"
     },
     "EastbourneBoroughCouncil": {

--- a/uk_bin_collection/uk_bin_collection/councils/EastAyrshireCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/EastAyrshireCouncil.py
@@ -1,49 +1,141 @@
+import re
+from datetime import datetime, timedelta
+
 import requests
-from bs4 import BeautifulSoup
 
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
+HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
+}
 
-# import the wonderful Beautiful Soup and the URL grabber
+AREA = "EastAyrshireUK"
+SERVICE = "50014"
+
+
 class CouncilClass(AbstractGetBinDataClass):
-    """
-    Concrete classes have to implement all abstract operations of the
-    base class. They can also override some operations with a default
-    implementation.
-    """
-
     def parse_data(self, page: str, **kwargs) -> dict:
+        data = {"bins": []}
 
-        user_uprn = kwargs.get("uprn")
-        check_uprn(user_uprn)
-        bindata = {"bins": []}
+        user_paon = kwargs.get("paon") or kwargs.get("number")
+        postcode = kwargs.get("postcode")
 
-        URI = f"https://www.east-ayrshire.gov.uk/Housing/RubbishAndRecycling/Collection-days/ViewYourRecyclingCalendar.aspx?r={user_uprn}"
+        # Strip trailing postcode from paon (resolve-v2 sends full address)
+        if user_paon and postcode:
+            user_paon = re.sub(r',?\s*' + re.escape(postcode) + r'\s*$', '', user_paon).strip()
 
-        # Make the GET request
-        response = requests.get(URI)
+        suggest_url = f"https://api.eu.recollect.net/api/areas/{AREA}/services/{SERVICE}/address-suggest"
 
-        # Parse the HTML
-        soup = BeautifulSoup(response.content, "html.parser")
+        place_id = None
 
-        # Find each <time> element in the schedule
-        for entry in soup.find_all("time"):
+        if user_paon and not user_paon.strip().isdigit():
+            params = {"q": user_paon, "locale": "en-GB"}
+            response = requests.get(suggest_url, headers=HEADERS, params=params, timeout=30)
+            response.raise_for_status()
+            for result in response.json():
+                if result.get("type") == "parcel" and result.get("place_id"):
+                    place_id = result["place_id"]
+                    break
 
-            ScheduleItems = entry.find_all(class_="ScheduleItem")
+        if not place_id and postcode:
+            params = {"q": postcode, "locale": "en-GB"}
+            response = requests.get(suggest_url, headers=HEADERS, params=params, timeout=30)
+            response.raise_for_status()
+            results = response.json()
 
-            for ScheduleItem in ScheduleItems:
-                dict_data = {
-                    "type": ScheduleItem.text.strip(),
-                    "collectionDate": datetime.strptime(
-                        entry["datetime"],
-                        "%Y-%m-%d",
-                    ).strftime("%d/%m/%Y"),
-                }
-                bindata["bins"].append(dict_data)
+            parcels = [r for r in results if r.get("type") == "parcel" and r.get("place_id")]
+            if parcels:
+                if user_paon:
+                    for p in parcels:
+                        name = p.get("name", "")
+                        if name.lower().startswith(user_paon.lower()):
+                            place_id = p["place_id"]
+                            break
+                if not place_id and parcels:
+                    place_id = parcels[0]["place_id"]
 
-        bindata["bins"].sort(
-            key=lambda x: datetime.strptime(x.get("collectionDate"), "%d/%m/%Y")
+            if not place_id:
+                qualifiers = [r for r in results if r.get("type") == "place_qualifier"]
+                if qualifiers:
+                    qual = qualifiers[0]
+                    params2 = {"q": postcode, "locale": "en-GB", "place_qualifier_id": qual["qualifier_id"]}
+                    response2 = requests.get(suggest_url, headers=HEADERS, params=params2, timeout=30)
+                    response2.raise_for_status()
+                    addresses = [r for r in response2.json() if r.get("type") == "parcel" and r.get("place_id")]
+
+                    if addresses and user_paon:
+                        for addr in addresses:
+                            name = addr.get("name", "")
+                            if name.lower().startswith(user_paon.lower()):
+                                place_id = addr["place_id"]
+                                break
+                            num_match = re.match(r"^(\d+[a-zA-Z]?)\b", user_paon.strip())
+                            if num_match and name.startswith(num_match.group(1) + " "):
+                                place_id = addr["place_id"]
+                                break
+
+                    if not place_id and addresses:
+                        place_id = addresses[0]["place_id"]
+
+        if not place_id and user_paon and postcode:
+            for q in [f"{user_paon} {postcode}", user_paon]:
+                params = {"q": q, "locale": "en-GB"}
+                response = requests.get(suggest_url, headers=HEADERS, params=params, timeout=30)
+                response.raise_for_status()
+                for result in response.json():
+                    if result.get("type") == "parcel" and result.get("place_id"):
+                        place_id = result["place_id"]
+                        break
+                if place_id:
+                    break
+
+        if not place_id:
+            raise ValueError(
+                f"No address found for: {user_paon or postcode}"
+            )
+
+        now = datetime.now()
+        after = now.strftime("%Y-%m-%d")
+        before = (now + timedelta(days=60)).strftime("%Y-%m-%d")
+
+        events_url = f"https://api.eu.recollect.net/api/places/{place_id}/services/{SERVICE}/events"
+        params = {
+            "nomerge": "1",
+            "hide": "reminder_only",
+            "after": after,
+            "before": before,
+            "locale": "en-GB",
+        }
+        response = requests.get(events_url, headers=HEADERS, params=params, timeout=60)
+        response.raise_for_status()
+        events_data = response.json()
+
+        seen = set()
+        for event in events_data.get("events", []):
+            day = event.get("day")
+            if not day:
+                continue
+
+            for flag in event.get("flags", []):
+                if flag.get("event_type") != "pickup":
+                    continue
+
+                bin_type = flag.get("subject") or flag.get("name", "Unknown")
+                collection_date = datetime.strptime(day, "%Y-%m-%d").strftime(date_format)
+
+                key = (bin_type, collection_date)
+                if key not in seen:
+                    seen.add(key)
+                    data["bins"].append(
+                        {
+                            "type": bin_type,
+                            "collectionDate": collection_date,
+                        }
+                    )
+
+        data["bins"].sort(
+            key=lambda x: datetime.strptime(x.get("collectionDate"), date_format)
         )
 
-        return bindata
+        return data


### PR DESCRIPTION
## Summary

East Ayrshire Council migrated their bin collection lookup from a direct UPRN-based page to the ReCollect platform. The old scraper returned empty results because the council portal now requires session cookies to set an address.

This rewrites the scraper to hit the ReCollect address-suggest and events APIs directly:

- Accepts postcode + house number (or a full address string)
- Tries multiple resolution strategies: direct paon search, postcode search with qualifier disambiguation, combined query fallback
- Strips trailing postcode from the house number field (handles resolve-v2 style full-address inputs)
- No Selenium required - pure requests

## Testing

- Postcode + full address: KA1 3RB + '57 Whatriggs Road' - returns bins
- Postcode only with fallback to first result: works when address resolves to parcels
- Tested via API end-to-end on production wrapper

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Updated East Ayrshire Council bin collection lookup to accept postcode with house number or full address instead of UPRN
  * Enhanced collection date retrieval and address resolution for more reliable results

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robbrad/UKBinCollectionData/pull/2081?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->