### PR TITLE
fix: rewrite DurhamCouncil scraper for new AJAX/JSON-RPC backend

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/DurhamCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/DurhamCouncil.py
@@ -33,7 +33,7 @@ class CouncilClass(AbstractGetBinDataClass):
         today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
 
         bin_types = {
-            "Empty Bin Refuse 240L": "Refuse",
+            "Empty Bin Refuse 240L": "Rubish",
             "Empty Bin Recycling 240L": "Recycling",
             "Empty Bin Organic 240L": "Garden Waste",
         }

--- a/uk_bin_collection/uk_bin_collection/councils/DurhamCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/DurhamCouncil.py
@@ -1,19 +1,27 @@
+import logging
 import re
-from datetime import datetime
-import requests
-from bs4 import BeautifulSoup
-from bs4 import XMLParsedAsHTMLWarning
 import warnings
+from datetime import datetime
+
+import requests
+from bs4 import BeautifulSoup, XMLParsedAsHTMLWarning
+
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
+_LOGGER = logging.getLogger(__name__)
+
+warnings.filterwarnings("ignore", category=XMLParsedAsHTMLWarning)
+
 
 class CouncilClass(AbstractGetBinDataClass):
+    # Durham exposes bin data via a JSON-RPC POST endpoint rather than a
+    # static page, so this scraper fetches its own data and ignores the
+    # `page` arg. input.json sets skip_get_url=true to avoid a wasted GET.
     def parse_data(self, page: str, **kwargs) -> dict:
         uprn = kwargs.get("uprn")
         check_uprn(uprn)
 
-        requests.packages.urllib3.disable_warnings()
         response = requests.post(
             "https://www.durham.gov.uk/apiserver/ajaxlibrary/",
             json={
@@ -23,17 +31,22 @@ class CouncilClass(AbstractGetBinDataClass):
                 "id": "21",
                 "name": "V2 AJAX End Point Library Worker",
             },
-            verify=False,
         )
         response.raise_for_status()
-
         xml_string = response.json()["result"]
-        warnings.filterwarnings("ignore", category=XMLParsedAsHTMLWarning)
+
         soup = BeautifulSoup(xml_string, "html.parser")
-
         today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
-        next_dates = {}
+        
+        # Format comes back as, for example: "Empty Bin Refuse 240L" 
+        # Futureproof regex to match:
+        # Optional "Empty Bin " prefix, capture bin label, optional " 240L"
+        # volume suffix. Whitespace is flexible throughout.
+        name_pattern = re.compile(
+            r"(?:Empty\s+Bin\s+)?(.+?)(?:\s+\d+\s*[Ll])?$"
+        )
 
+        next_dates = {}
         for job in soup.find_all("job"):
             name_tag = job.find("name")
             start_tag = job.find("scheduledstart")
@@ -41,22 +54,26 @@ class CouncilClass(AbstractGetBinDataClass):
                 continue
 
             raw_name = name_tag.get_text(strip=True)
-            match = re.search(r"Empty Bin (.+?) \d+L", raw_name)
+            match = name_pattern.search(raw_name)
             if not match:
+                _LOGGER.warning("Could not parse bin name %r", raw_name)
                 continue
-
-            label = match.group(1)
+            label = match.group(1).strip()
 
             try:
                 scheduled = datetime.strptime(
                     start_tag.get_text(strip=True)[:10], "%Y-%m-%d"
                 )
             except ValueError:
+                _LOGGER.warning(
+                    "Could not parse scheduled date %r for bin %r",
+                    start_tag.get_text(strip=True),
+                    raw_name,
+                )
                 continue
 
             if scheduled < today:
                 continue
-
             if label not in next_dates or scheduled < next_dates[label]:
                 next_dates[label] = scheduled
 

--- a/uk_bin_collection/uk_bin_collection/councils/DurhamCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/DurhamCouncil.py
@@ -1,49 +1,74 @@
-import re
 from datetime import datetime
-
 import requests
 from bs4 import BeautifulSoup
+from bs4 import XMLParsedAsHTMLWarning
+import warnings
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
 
-# import the wonderful Beautiful Soup and the URL grabber
 class CouncilClass(AbstractGetBinDataClass):
-    """
-    Concrete classes have to implement all abstract operations of the
-    base class. They can also override some operations with a default
-    implementation.
-    """
-
     def parse_data(self, page: str, **kwargs) -> dict:
-        url = "https://www.durham.gov.uk/bincollections?uprn="
         uprn = kwargs.get("uprn")
         check_uprn(uprn)
-        url += uprn
-        requests.packages.urllib3.disable_warnings()
-        page = requests.get(url)
 
-        # Make a BS4 object
-        soup = BeautifulSoup(page.text, features="html.parser")
+        requests.packages.urllib3.disable_warnings()
+        response = requests.post(
+            "https://www.durham.gov.uk/apiserver/ajaxlibrary/",
+            json={
+                "jsonrpc": "2.0",
+                "method": "durham.Localities.GetBartecCalendar",
+                "params": {"uprn": uprn},
+                "id": "21",
+                "name": "V2 AJAX End Point Library Worker",
+            },
+            verify=False,
+        )
+        response.raise_for_status()
+
+        xml_string = response.json()["result"]
+        warnings.filterwarnings("ignore", category=XMLParsedAsHTMLWarning)
+        soup = BeautifulSoup(xml_string, "html.parser")
+
+        today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+
+        bin_types = {
+            "Empty Bin Refuse 240L": "Refuse",
+            "Empty Bin Recycling 240L": "Recycling",
+            "Empty Bin Organic 240L": "Garden Waste",
+        }
+
+        next_dates = {}
+
+        for job in soup.find_all("job"):
+            name_tag = job.find("name")
+            start_tag = job.find("scheduledstart")
+            if not name_tag or not start_tag:
+                continue
+
+            raw_name = name_tag.get_text(strip=True)
+            if raw_name not in bin_types:
+                continue
+
+            try:
+                scheduled = datetime.strptime(
+                    start_tag.get_text(strip=True)[:10], "%Y-%m-%d"
+                )
+            except ValueError:
+                continue
+
+            if scheduled < today:
+                continue
+
+            label = bin_types[raw_name]
+            if label not in next_dates or scheduled < next_dates[label]:
+                next_dates[label] = scheduled
 
         data = {"bins": []}
-
-        for bin_type in ["rubbish", "recycling", "gardenwaste"]:
-            bin_info = soup.find(class_=f"bins{bin_type}")
-
-            if bin_info:
-                collection_text = bin_info.get_text(strip=True)
-
-                if collection_text:
-                    results = re.search("\\d\\d? [A-Za-z]+ \\d{4}", collection_text)
-                    if results:
-                        date = datetime.strptime(results[0], "%d %B %Y")
-                        if date:
-                            data["bins"].append(
-                                {
-                                    "type": bin_type,
-                                    "collectionDate": date.strftime(date_format),
-                                }
-                            )
+        for bin_type, collection_date in next_dates.items():
+            data["bins"].append({
+                "type": bin_type,
+                "collectionDate": collection_date.strftime(date_format),
+            })
 
         return data

--- a/uk_bin_collection/uk_bin_collection/councils/DurhamCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/DurhamCouncil.py
@@ -1,3 +1,5 @@
+"""Bin collection scraper for Durham County Council."""
+
 import logging
 import re
 import warnings
@@ -11,14 +13,39 @@ from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataC
 
 _LOGGER = logging.getLogger(__name__)
 
-warnings.filterwarnings("ignore", category=XMLParsedAsHTMLWarning)
-
 
 class CouncilClass(AbstractGetBinDataClass):
-    # Durham exposes bin data via a JSON-RPC POST endpoint rather than a
-    # static page, so this scraper fetches its own data and ignores the
-    # `page` arg. input.json sets skip_get_url=true to avoid a wasted GET.
+    """Scraper for Durham County Council bin collection data.
+
+    Durham's public bin lookup page (durham.gov.uk/bincollections) is
+    rendered client-side from a JSON-RPC endpoint. This scraper bypasses
+    the rendered page and calls the JSON-RPC backend directly, parsing
+    the XML payload it returns.
+
+    The `page` argument to `parse_data` is unused; `input.json` sets
+    `skip_get_url=true` for this council so no upstream GET is made.
+    """
+
     def parse_data(self, page: str, **kwargs) -> dict:
+        """Fetch and parse upcoming bin collections for a Durham UPRN.
+
+        Args:
+            page: Unused. Required by the abstract base class signature
+                but ignored here — see class docstring.
+            **kwargs: Must contain `uprn` (Unique Property Reference
+                Number) identifying the property to look up.
+
+        Returns:
+            A dict in the project's standard schema:
+            ``{"bins": [{"type": str, "collectionDate": str}, ...]}``
+            where `collectionDate` is formatted per `common.date_format`
+            and only the next upcoming collection per bin type is
+            included.
+
+        Raises:
+            ValueError: If the JSON-RPC endpoint returns an error
+                response or an unexpected payload shape.
+        """
         uprn = kwargs.get("uprn")
         check_uprn(uprn)
 
@@ -31,19 +58,28 @@ class CouncilClass(AbstractGetBinDataClass):
                 "id": "21",
                 "name": "V2 AJAX End Point Library Worker",
             },
+            timeout=30,
         )
         response.raise_for_status()
-        xml_string = response.json()["result"]
+        payload = response.json()
+        if "error" in payload:
+            raise ValueError(f"Durham JSON-RPC error: {payload['error']}")
+        xml_string = payload.get("result")
+        if not isinstance(xml_string, str):
+            raise ValueError("Unexpected Durham JSON-RPC response: missing result")
 
-        soup = BeautifulSoup(xml_string, "html.parser")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", XMLParsedAsHTMLWarning)
+            soup = BeautifulSoup(xml_string, "html.parser")
+
         today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
-        
-        # Format comes back as, for example: "Empty Bin Refuse 240L" 
-        # Futureproof regex to match:
+
         # Optional "Empty Bin " prefix, capture bin label, optional " 240L"
-        # volume suffix. Whitespace is flexible throughout.
+        # volume suffix. Whitespace is flexible throughout. fullmatch() is
+        # used so unexpected leading/trailing content surfaces as a warning
+        # rather than being silently absorbed.
         name_pattern = re.compile(
-            r"(?:Empty\s+Bin\s+)?(.+?)(?:\s+\d+\s*[Ll])?$"
+            r"(?:Empty\s+Bin\s+)?(.+?)(?:\s+\d+\s*[Ll])?"
         )
 
         next_dates = {}
@@ -54,7 +90,7 @@ class CouncilClass(AbstractGetBinDataClass):
                 continue
 
             raw_name = name_tag.get_text(strip=True)
-            match = name_pattern.search(raw_name)
+            match = name_pattern.fullmatch(raw_name)
             if not match:
                 _LOGGER.warning("Could not parse bin name %r", raw_name)
                 continue

--- a/uk_bin_collection/uk_bin_collection/councils/DurhamCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/DurhamCouncil.py
@@ -1,3 +1,4 @@
+import re
 from datetime import datetime
 import requests
 from bs4 import BeautifulSoup
@@ -31,13 +32,6 @@ class CouncilClass(AbstractGetBinDataClass):
         soup = BeautifulSoup(xml_string, "html.parser")
 
         today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
-
-        bin_types = {
-            "Empty Bin Refuse 240L": "Rubbish",
-            "Empty Bin Recycling 240L": "Recycling",
-            "Empty Bin Organic 240L": "Garden Waste",
-        }
-
         next_dates = {}
 
         for job in soup.find_all("job"):
@@ -47,8 +41,11 @@ class CouncilClass(AbstractGetBinDataClass):
                 continue
 
             raw_name = name_tag.get_text(strip=True)
-            if raw_name not in bin_types:
+            match = re.search(r"Empty Bin (.+?) \d+L", raw_name)
+            if not match:
                 continue
+
+            label = match.group(1)
 
             try:
                 scheduled = datetime.strptime(
@@ -60,7 +57,6 @@ class CouncilClass(AbstractGetBinDataClass):
             if scheduled < today:
                 continue
 
-            label = bin_types[raw_name]
             if label not in next_dates or scheduled < next_dates[label]:
                 next_dates[label] = scheduled
 

--- a/uk_bin_collection/uk_bin_collection/councils/DurhamCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/DurhamCouncil.py
@@ -33,7 +33,7 @@ class CouncilClass(AbstractGetBinDataClass):
         today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
 
         bin_types = {
-            "Empty Bin Refuse 240L": "Rubish",
+            "Empty Bin Refuse 240L": "Rubbish",
             "Empty Bin Recycling 240L": "Recycling",
             "Empty Bin Organic 240L": "Garden Waste",
         }


### PR DESCRIPTION
## Summary

Fixes the Durham Council scraper, which has been returning empty
results since the council migrated their bin lookup page to an
AJAX-driven UI.

Fixes #2021

## Approach

The new page (https://www.durham.gov.uk/bincollections?uprn=...)
serves an empty container HTML that is populated client-side via
a call to `/apiserver/ajaxlibrary/`. The scraper now POSTs to this
endpoint directly (matching the JSON-RPC payload the JS would send)
and parses the returned XML (full event/calendar history, only next future date is parsed).

`input.json` already had `skip_get_url: true` set for this council
so no test config changes are needed.

## Behaviour changes

**Breaking:** bin types may now be abelled using the council's new back-end
names ("Refuse", "Recycling", "Garden Waste") rather than the
previous slugs.
Users with HA automations or templates keyed on the old labels will
need to update.

## Testing

Verified against my (in area) UPRN in my HA deployment. Returns
all expected upcoming bin collections with correct dates but needed to update bin names manually (easiest to remove then re-add the integration)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Durham bin collection now uses a new backend data feed for fetching schedules, improving reliability.
  * Collection entries are normalized (consistent bin labels) and only upcoming dates are shown; invalid or unparsable entries are skipped with warnings.
  * Improved response validation and error handling to reduce missing/incorrect collection dates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robbrad/UKBinCollectionData/pull/2084?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->