### PR TITLE
feat: add tamworth borough council scraper

### DIFF
--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -879,7 +879,7 @@
         "url": "https://environmentfirst.co.uk/house.php?uprn=100060055444",
         "wiki_command_url_override": "https://environmentfirst.co.uk/house.php?uprn=XXXXXXXXXX",
         "wiki_name": "Environment First",
-        "wiki_note": "For properties with collections managed by Environment First, such as Lewes and Eastbourne. Replace the XXXXXXXXXX with the UPRN of your property\u2014you can use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find this."
+        "wiki_note": "For properties with collections managed by Environment First, such as Lewes and Eastbourne. Replace the XXXXXXXXXX with the UPRN of your property—you can use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find this."
     },
     "EppingForestDistrictCouncil": {
         "postcode": "IG9 6EP",
@@ -1754,14 +1754,14 @@
         "LAD24CD": "E06000012"
     },
     "NorthHertfordshireDistrictCouncil": {
-            "house_number": "Stewards Flat",
-            "postcode": "SG5 1PZ",
-            "skip_get_url": true,
-            "url": "https://waste.nc.north-herts.gov.uk/w/webpage/find-bin-collection-day-input-address",
-            "web_driver": "http://selenium:4444",
-            "wiki_name": "North Hertfordshire",
-            "wiki_note": "Pass a postcode (with space) and house_number/name. The scraper performs the Liberty Create typeahead lookup and matches house_number as a case-insensitive substring.",
-            "LAD24CD": "E07000099"
+        "house_number": "Stewards Flat",
+        "postcode": "SG5 1PZ",
+        "skip_get_url": true,
+        "url": "https://waste.nc.north-herts.gov.uk/w/webpage/find-bin-collection-day-input-address",
+        "web_driver": "http://selenium:4444",
+        "wiki_name": "North Hertfordshire",
+        "wiki_note": "Pass a postcode (with space) and house_number/name. The scraper performs the Liberty Create typeahead lookup and matches house_number as a case-insensitive substring.",
+        "LAD24CD": "E07000099"
     },
     "NorthKestevenDistrictCouncil": {
         "skip_get_url": true,
@@ -2877,5 +2877,14 @@
         "wiki_name": "York",
         "wiki_note": "Provide your UPRN.",
         "LAD24CD": "E06000014"
+    },
+    "TamworthBoroughCouncil": {
+        "uprn": "394021043",
+        "url": "https://www.lichfielddc.gov.uk",
+        "wiki_command_url_override": "https://www.lichfielddc.gov.uk",
+        "wiki_name": "Tamworth",
+        "wiki_note": "Tamworth waste services are operated by Lichfield District Council. You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
+        "LAD24CD": "E07000199",
+        "skip_get_url": true
     }
 }

--- a/uk_bin_collection/uk_bin_collection/councils/TamworthBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/TamworthBoroughCouncil.py
@@ -1,0 +1,67 @@
+import re
+
+import requests
+from bs4 import BeautifulSoup
+
+from uk_bin_collection.uk_bin_collection.common import *
+from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
+
+
+# import the wonderful Beautiful Soup and the URL grabber
+class CouncilClass(AbstractGetBinDataClass):
+    """
+    Concrete classes have to implement all abstract operations of the
+    base class. They can also override some operations with a default
+    implementation.
+    """
+
+    def parse_data(self, page: str, **kwargs) -> dict:
+
+        user_uprn = kwargs.get("uprn")
+        check_uprn(user_uprn)
+        bindata = {"bins": []}
+
+        def solve(s):
+            return re.sub(r"(\d)(st|nd|rd|th)", r"\1", s)
+
+        headers = {
+            "Origin": "https://www.lichfielddc.gov.uk",
+            "Referer": "https://www.lichfielddc.gov.uk",
+            "User-Agent": "Mozilla/5.0",
+        }
+
+        # Tamworth waste services are operated by Lichfield District Council
+        URI = f"https://www.lichfielddc.gov.uk/homepage/6/bin-collection-dates?uprn={user_uprn}"
+
+        # Make the GET request
+        response = requests.get(URI, headers=headers)
+
+        soup = BeautifulSoup(response.text, "html.parser")
+
+        bins = soup.find_all("h3", class_="bin-collection-tasks__heading")
+        dates = soup.find_all("p", class_="bin-collection-tasks__date")
+
+        current_year = datetime.now().year
+        current_month = datetime.now().month
+
+        for i in range(len(dates)):
+            bint = " ".join(bins[i].text.split()[2:4])
+            date = dates[i].text
+
+            date = datetime.strptime(
+                solve(date),
+                "%d %B",
+            )
+
+            if (current_month > 10) and (date.month < 3):
+                date = date.replace(year=(current_year + 1))
+            else:
+                date = date.replace(year=current_year)
+
+            dict_data = {
+                "type": bint,
+                "collectionDate": date.strftime("%d/%m/%Y"),
+            }
+            bindata["bins"].append(dict_data)
+
+        return bindata


### PR DESCRIPTION
## Summary
- New scraper for Tamworth Borough Council (population ~77k, Staffordshire)
- Tamworth waste services are operated by Lichfield District Council - uses the same Jadu portal at `lichfielddc.gov.uk`
- Tamworth addresses use UPRNs in the `394xxxxxxx` range
- Pure HTTP with requests + BeautifulSoup - no Selenium needed

## Test plan
- Tested with UPRN 394021043 (1 Rosy Cross, B79 7JR)
- Returns: Black Bin, Blue Bag, Blue Bin, Green Bin
- End-to-end verified through Kepthouse API