### PR TITLE
feat: add merthyr tydfil county borough council scraper

### DIFF
--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -879,7 +879,7 @@
         "url": "https://environmentfirst.co.uk/house.php?uprn=100060055444",
         "wiki_command_url_override": "https://environmentfirst.co.uk/house.php?uprn=XXXXXXXXXX",
         "wiki_name": "Environment First",
-        "wiki_note": "For properties with collections managed by Environment First, such as Lewes and Eastbourne. Replace the XXXXXXXXXX with the UPRN of your property\u2014you can use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find this."
+        "wiki_note": "For properties with collections managed by Environment First, such as Lewes and Eastbourne. Replace the XXXXXXXXXX with the UPRN of your property—you can use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find this."
     },
     "EppingForestDistrictCouncil": {
         "postcode": "IG9 6EP",
@@ -1754,14 +1754,14 @@
         "LAD24CD": "E06000012"
     },
     "NorthHertfordshireDistrictCouncil": {
-            "house_number": "Stewards Flat",
-            "postcode": "SG5 1PZ",
-            "skip_get_url": true,
-            "url": "https://waste.nc.north-herts.gov.uk/w/webpage/find-bin-collection-day-input-address",
-            "web_driver": "http://selenium:4444",
-            "wiki_name": "North Hertfordshire",
-            "wiki_note": "Pass a postcode (with space) and house_number/name. The scraper performs the Liberty Create typeahead lookup and matches house_number as a case-insensitive substring.",
-            "LAD24CD": "E07000099"
+        "house_number": "Stewards Flat",
+        "postcode": "SG5 1PZ",
+        "skip_get_url": true,
+        "url": "https://waste.nc.north-herts.gov.uk/w/webpage/find-bin-collection-day-input-address",
+        "web_driver": "http://selenium:4444",
+        "wiki_name": "North Hertfordshire",
+        "wiki_note": "Pass a postcode (with space) and house_number/name. The scraper performs the Liberty Create typeahead lookup and matches house_number as a case-insensitive substring.",
+        "LAD24CD": "E07000099"
     },
     "NorthKestevenDistrictCouncil": {
         "skip_get_url": true,
@@ -2877,5 +2877,13 @@
         "wiki_name": "York",
         "wiki_note": "Provide your UPRN.",
         "LAD24CD": "E06000014"
+    },
+    "MerthyrTydfilCountyBoroughCouncil": {
+        "postcode": "CF48 3BN",
+        "skip_get_url": true,
+        "url": "https://www.merthyr.gov.uk/resident/bins-and-recycling/check-your-collection-day/",
+        "wiki_name": "Merthyr Tydfil",
+        "wiki_note": "Pass the postcode. Area-based collection - no UPRN or house number needed. Some postcodes return no results while rounds are changing.",
+        "LAD24CD": "W06000024"
     }
 }

--- a/uk_bin_collection/uk_bin_collection/councils/MerthyrTydfilCountyBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/MerthyrTydfilCountyBoroughCouncil.py
@@ -1,0 +1,181 @@
+import re
+from datetime import datetime, timedelta
+
+import requests
+from bs4 import BeautifulSoup
+
+from uk_bin_collection.uk_bin_collection.common import *
+from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
+
+API_URL = "https://www.merthyr.gov.uk/umbraco/Surface/BinDaySurface/GetCollectionDay"
+
+DAYS_OF_WEEK = [
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+    "Sunday",
+]
+
+
+def _next_occurrence(day_name: str) -> datetime:
+    """Return the next occurrence of *day_name* (today excluded)."""
+    today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+    target_idx = DAYS_OF_WEEK.index(day_name)
+    today_idx = today.weekday()
+    days_ahead = (target_idx - today_idx) % 7
+    if days_ahead == 0:
+        days_ahead = 7
+    return today + timedelta(days=days_ahead)
+
+
+def _next_fortnightly(
+    day_name: str, current_week: str, bin_week: str
+) -> datetime:
+    """Return the next fortnightly collection date.
+
+    The council alternates week "one" and week "two" on a Mon-Sun
+    boundary.  *current_week* is what the API reports for today.
+    *bin_week* is the week this particular bin type collects in.
+
+    Strategy:
+        1. Find the next occurrence of *day_name* (today excluded).
+        2. Decide whether that date falls in the current week (same
+           Mon-Sun span as today) or the following week.
+        3. Same-week occurrence keeps the current week label;
+           next-week occurrence flips it.
+        4. If the label matches *bin_week* -- use it; otherwise add 7.
+    """
+    today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+    target_idx = DAYS_OF_WEEK.index(day_name)
+    today_idx = today.weekday()
+
+    days_ahead = (target_idx - today_idx) % 7
+    if days_ahead == 0:
+        days_ahead = 7  # skip today
+
+    # Does the candidate fall in the same Mon-Sun week as today?
+    in_same_week = (today_idx + days_ahead) <= 6  # still within weekday 0-6
+    if in_same_week:
+        candidate_week = current_week
+    else:
+        candidate_week = "two" if current_week == "one" else "one"
+
+    if candidate_week != bin_week:
+        days_ahead += 7  # skip to the correct fortnightly week
+
+    return today + timedelta(days=days_ahead)
+
+
+class CouncilClass(AbstractGetBinDataClass):
+    """
+    Merthyr Tydfil County Borough Council bin collections.
+
+    Uses the council's Umbraco AJAX endpoint which accepts a postcode
+    and returns an HTML fragment with collection day names and a
+    week-one / week-two fortnightly indicator.
+
+    Resolution: postcode only (UPRN and house number are ignored --
+    the API resolves by postcode area).
+    """
+
+    def parse_data(self, page: str, **kwargs) -> dict:
+        postcode = kwargs.get("postcode")
+        check_postcode(postcode)
+
+        bindata = {"bins": []}
+
+        resp = requests.post(
+            API_URL,
+            data={"postcode": postcode},
+            headers={
+                "User-Agent": (
+                    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) "
+                    "Chrome/134.0.0.0 Safari/537.36"
+                ),
+                "X-Requested-With": "XMLHttpRequest",
+                "Referer": "https://www.merthyr.gov.uk/resident/bins-and-recycling/check-your-collection-day/",
+            },
+            timeout=30,
+        )
+        resp.raise_for_status()
+
+        soup = BeautifulSoup(resp.text, "html.parser")
+
+        # Check for "No results"
+        h4 = soup.find("h4")
+        if h4 and "No results" in h4.get_text():
+            return bindata
+
+        # Determine current week (one or two)
+        h5 = soup.find("h5")
+        if not h5:
+            raise ValueError(
+                "Could not determine current week from Merthyr response"
+            )
+        current_week_strong = h5.find("strong")
+        if not current_week_strong:
+            raise ValueError(
+                "Could not parse current week indicator"
+            )
+        current_week = current_week_strong.get_text(strip=True).lower()
+
+        # Parse each <p> for collection info
+        for p_tag in soup.find_all("p"):
+            text = p_tag.get_text()
+            strong_tags = p_tag.find_all("strong")
+
+            if not strong_tags:
+                continue
+
+            # Extract day name (always the first <strong>)
+            day_name = strong_tags[0].get_text(strip=True)
+            if day_name not in DAYS_OF_WEEK:
+                continue
+
+            # Determine bin type from the surrounding text
+            text_lower = text.lower()
+            if "recycling" in text_lower:
+                bin_type = "Recycling"
+            elif "household waste" in text_lower:
+                bin_type = "Household Waste"
+            elif "garden waste" in text_lower:
+                bin_type = "Garden Waste"
+            else:
+                # Unknown type -- use the text before "collection day"
+                match = re.match(r"Your (.+?) collection day", text)
+                bin_type = match.group(1).strip().title() if match else "Unknown"
+
+            # Determine frequency
+            if "every week" in text_lower:
+                # Weekly collection -- return next 4 occurrences
+                base = _next_occurrence(day_name)
+                for i in range(4):
+                    collection_date = base + timedelta(weeks=i)
+                    bindata["bins"].append({
+                        "type": bin_type,
+                        "collectionDate": collection_date.strftime(date_format),
+                    })
+            else:
+                # Fortnightly -- determine which week this bin collects in
+                bin_week_strong = strong_tags[-1] if len(strong_tags) > 1 else None
+                if not bin_week_strong:
+                    continue
+                bin_week = bin_week_strong.get_text(strip=True).lower()
+
+                base = _next_fortnightly(day_name, current_week, bin_week)
+                for i in range(2):
+                    collection_date = base + timedelta(weeks=i * 2)
+                    bindata["bins"].append({
+                        "type": bin_type,
+                        "collectionDate": collection_date.strftime(date_format),
+                    })
+
+        bindata["bins"].sort(
+            key=lambda x: datetime.strptime(x["collectionDate"], date_format)
+        )
+
+        return bindata


### PR DESCRIPTION
## Summary
- New scraper for Merthyr Tydfil County Borough Council (population ~60k, South Wales)
- Simple POST API at `merthyr.gov.uk/umbraco/Surface/BinDaySurface/GetCollectionDay`
- Area-based collection by postcode - no UPRN or house number needed
- Parses day names + week-one/two fortnightly alternation from HTML response
- Returns weekly recycling + fortnightly household waste and garden waste dates
- Pure HTTP with requests + BeautifulSoup - no Selenium needed

## Notes
- Council is actively changing collection rounds; some CF47 postcodes return no data
- CF48 area has best coverage currently

## Test plan
- Tested with CF48 3BN (Dowlais) - returns 8 bins across 3 types
- Also tested CF47 0HE, CF48 2BU
- End-to-end verified through Kepthouse API