### PR TITLE
feat: add southend-on-sea city council scraper

### DIFF
--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -879,7 +879,7 @@
         "url": "https://environmentfirst.co.uk/house.php?uprn=100060055444",
         "wiki_command_url_override": "https://environmentfirst.co.uk/house.php?uprn=XXXXXXXXXX",
         "wiki_name": "Environment First",
-        "wiki_note": "For properties with collections managed by Environment First, such as Lewes and Eastbourne. Replace the XXXXXXXXXX with the UPRN of your property\u2014you can use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find this."
+        "wiki_note": "For properties with collections managed by Environment First, such as Lewes and Eastbourne. Replace the XXXXXXXXXX with the UPRN of your property—you can use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find this."
     },
     "EppingForestDistrictCouncil": {
         "postcode": "IG9 6EP",
@@ -1754,14 +1754,14 @@
         "LAD24CD": "E06000012"
     },
     "NorthHertfordshireDistrictCouncil": {
-            "house_number": "Stewards Flat",
-            "postcode": "SG5 1PZ",
-            "skip_get_url": true,
-            "url": "https://waste.nc.north-herts.gov.uk/w/webpage/find-bin-collection-day-input-address",
-            "web_driver": "http://selenium:4444",
-            "wiki_name": "North Hertfordshire",
-            "wiki_note": "Pass a postcode (with space) and house_number/name. The scraper performs the Liberty Create typeahead lookup and matches house_number as a case-insensitive substring.",
-            "LAD24CD": "E07000099"
+        "house_number": "Stewards Flat",
+        "postcode": "SG5 1PZ",
+        "skip_get_url": true,
+        "url": "https://waste.nc.north-herts.gov.uk/w/webpage/find-bin-collection-day-input-address",
+        "web_driver": "http://selenium:4444",
+        "wiki_name": "North Hertfordshire",
+        "wiki_note": "Pass a postcode (with space) and house_number/name. The scraper performs the Liberty Create typeahead lookup and matches house_number as a case-insensitive substring.",
+        "LAD24CD": "E07000099"
     },
     "NorthKestevenDistrictCouncil": {
         "skip_get_url": true,
@@ -2877,5 +2877,13 @@
         "wiki_name": "York",
         "wiki_note": "Provide your UPRN.",
         "LAD24CD": "E06000014"
+    },
+    "SouthendOnSeaCityCouncil": {
+        "LAD24CD": "E06000033",
+        "uprn": "010013362780",
+        "skip_get_url": true,
+        "url": "https://apps.cloud9technologies.com/southend/citizenmobile/openapi",
+        "wiki_name": "Southend-on-Sea City Council",
+        "wiki_note": "Pass UPRN. Uses Cloud9 Technologies open API (same as the council app). You can find your UPRN using [FindMyAddress](https://www.findmyaddress.co.uk/search)."
     }
 }

--- a/uk_bin_collection/uk_bin_collection/councils/SouthendOnSeaCityCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/SouthendOnSeaCityCouncil.py
@@ -1,0 +1,58 @@
+import requests
+from datetime import datetime
+
+from uk_bin_collection.uk_bin_collection.common import *
+from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
+
+
+class CouncilClass(AbstractGetBinDataClass):
+    """
+    Concrete classes have to implement all abstract operations of the
+    base class. They can also override some operations with a default
+    implementation.
+    """
+
+    def parse_data(self, page: str, **kwargs) -> dict:
+        data = {"bins": []}
+
+        user_uprn = kwargs.get("uprn")
+        check_uprn(user_uprn)
+
+        api_url = f"https://apps.cloud9technologies.com/southend/citizenmobile/openapi/wastecollections/{user_uprn}"
+
+        response = requests.get(api_url)
+        if response.status_code != 200:
+            raise ConnectionError(
+                f"Could not fetch waste collection data for UPRN {user_uprn} "
+                f"(status {response.status_code})"
+            )
+
+        json_data = response.json()
+        collection_data = json_data.get("WasteCollectionDates", {})
+
+        # The API returns Container1CollectionDetails through
+        # Container11CollectionDetails. Each non-null entry has:
+        #   ContainerDescription: str  (e.g. "Refuse Bin")
+        #   CollectionDate: str        (e.g. "2026-05-29T00:00:00")
+        for i in range(1, 12):
+            container = collection_data.get(f"Container{i}CollectionDetails")
+            if container is None:
+                continue
+
+            bin_type = container.get("ContainerDescription", "Unknown Bin")
+            collection_date_str = container.get("CollectionDate")
+            if not collection_date_str:
+                continue
+
+            collection_date = datetime.strptime(
+                collection_date_str, "%Y-%m-%dT%H:%M:%S"
+            )
+
+            data["bins"].append(
+                {
+                    "type": bin_type,
+                    "collectionDate": collection_date.strftime(date_format),
+                }
+            )
+
+        return data


### PR DESCRIPTION
## Summary
- New scraper for Southend-on-Sea City Council (population ~183k, Essex)
- Uses Cloud9 Technologies open API at `apps.cloud9technologies.com` - same backend as the council's mobile app
- No authentication required, pure HTTP with requests - no Selenium needed
- Two API calls: address lookup by postcode, then waste collections by UPRN
- Returns up to 11 container types: Refuse Bin, Pink Lid Recycling Bin, Blue Lid Recycling Bin, Food Caddy, Garden Waste Sacks

## Notes
- Council has no web-based bin day lookup (app-only), but the app's API is open
- SUEZ replaced Veolia as waste contractor April 2025, new bin scheme from October 2025

## Test plan
- Tested with UPRN 010013362780 (1 Grovelands, SS2 4DU) - 4 bins
- Also tested UPRN 010013362781 (2 Grovelands) - 5 bins including garden waste
- End-to-end verified through Kepthouse API