### PR TITLE
fix: rewrite blackburn as pure http (remove selenium dependency)

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/BlackburnCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/BlackburnCouncil.py
@@ -1,116 +1,65 @@
 import json
-import logging
-import ssl
-from collections import OrderedDict
 from datetime import datetime
 
 import requests
 import urllib3
-from bs4 import BeautifulSoup
 
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
-
-class CustomHttpAdapter(requests.adapters.HTTPAdapter):
-    """Transport adapter" that allows us to use custom ssl_context."""
-
-    def __init__(self, ssl_context=None, **kwargs):
-        self.ssl_context = ssl_context
-        super().__init__(**kwargs)
-
-    def init_poolmanager(self, connections, maxsize, block=False):
-        self.poolmanager = urllib3.poolmanager.PoolManager(
-            num_pools=connections,
-            maxsize=maxsize,
-            block=block,
-            ssl_context=self.ssl_context,
-        )
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
 class CouncilClass(AbstractGetBinDataClass):
-    """
-    Concrete classes have to implement all abstract operations of the
-    base class. They can also override some operations with a default
-    implementation.
-    """
-
     def parse_data(self, page: str, **kwargs) -> dict:
-        # Make a BS4 object
+        uprn = kwargs.get("uprn")
+        check_uprn(uprn)
 
-        driver = None
-        try:
-            data = {"bins": []}
-            uprn = kwargs.get("uprn")
-            web_driver = kwargs.get("web_driver")
-            headless = kwargs.get("headless")
-            current_month = datetime.today().strftime("%m")
-            current_year = datetime.today().strftime("%Y")
-            url = (
-                f"https://mybins.blackburn.gov.uk/api/mybins/getbincollectiondays?uprn={uprn}&month={current_month}"
-                f"&year={current_year}"
-            )
-            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
-            driver = create_webdriver(web_driver, headless, user_agent, __name__)
-            driver.get(url)
+        data = {"bins": []}
+        current_month = datetime.today().strftime("%m")
+        current_year = datetime.today().strftime("%Y")
 
-            soup = BeautifulSoup(driver.page_source, "html.parser")
+        url = (
+            f"https://mybins.blackburn.gov.uk/api/mybins/getbincollectiondays"
+            f"?uprn={uprn}&month={current_month}&year={current_year}"
+        )
 
-            # Find the <pre> tag that contains the JSON data
-            pre_tag = soup.find("pre")
+        response = requests.get(
+            url,
+            headers={"User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36"},
+            verify=False,
+            timeout=30,
+        )
+        response.raise_for_status()
+        json_result = response.json()
 
-            if pre_tag:
-                # Extract the text content within the <pre> tag
+        bin_collections = json_result.get("BinCollectionDays", [])
+        for collection in bin_collections:
+            if collection is None:
+                continue
+            entry = collection[0] if isinstance(collection, list) else collection
+            bin_type = entry.get("BinType")
+            current_collection_date = entry.get("CollectionDate")
+            if not current_collection_date:
+                continue
+            current_dt = datetime.strptime(current_collection_date, "%Y-%m-%d")
+            next_collection_date = entry.get("NextScheduledCollectionDate")
 
-                # Return JSON from response and loop through collections
-                json_result = json.loads(pre_tag.contents[0])
-                bin_collections = json_result["BinCollectionDays"]
-                for collection in bin_collections:
-                    if collection is not None:
-                        bin_type = collection[0].get("BinType")
-                        current_collection_date = collection[0].get("CollectionDate")
-                        if current_collection_date is None:
-                            continue
-                        current_collection_date = datetime.strptime(
-                            current_collection_date, "%Y-%m-%d"
-                        )
-                        next_collection_date = collection[0].get(
-                            "NextScheduledCollectionDate"
-                        )
-                        if next_collection_date is None:
-                            continue
-                        next_collection_date = datetime.strptime(
-                            next_collection_date, "%Y-%m-%d"
-                        )
+            if next_collection_date:
+                next_dt = datetime.strptime(next_collection_date, "%Y-%m-%d")
+                if datetime.today().date() <= current_dt.date() < next_dt.date():
+                    collection_date = current_dt
+                else:
+                    collection_date = next_dt
+            else:
+                collection_date = current_dt
 
-                        # Work out the most recent collection date to display
-                        if (
-                            datetime.today().date()
-                            <= current_collection_date.date()
-                            < next_collection_date.date()
-                        ):
-                            collection_date = current_collection_date
-                        else:
-                            collection_date = next_collection_date
+            data["bins"].append({
+                "type": bin_type,
+                "collectionDate": collection_date.strftime(date_format),
+            })
 
-                        dict_data = {
-                            "type": bin_type,
-                            "collectionDate": collection_date.strftime(date_format),
-                        }
-                        data["bins"].append(dict_data)
-
-                        data["bins"].sort(
-                            key=lambda x: datetime.strptime(
-                                x.get("collectionDate"), date_format
-                            )
-                        )
-        except Exception as e:
-            # Here you can log the exception if needed
-            print(f"An error occurred: {e}")
-            # Optionally, re-raise the exception if you want it to propagate
-            raise
-        finally:
-            # This block ensures that the driver is closed regardless of an exception
-            if driver:
-                driver.quit()
+        data["bins"].sort(
+            key=lambda x: datetime.strptime(x.get("collectionDate"), date_format)
+        )
         return data


### PR DESCRIPTION
## Summary
- Rewrites BlackburnCouncil scraper as pure HTTP (no Selenium)
- The mybins.blackburn.gov.uk API is a simple JSON endpoint - no browser interaction needed
- Removes all Selenium/WebDriver imports and dependencies
- Uses requests with verify=False (their SSL cert has issues but API works)
- Much faster and more reliable than the previous browser-based approach

## Testing
- Direct API test with UPRN 100010733027: 6 bins returned
- Tested via end-to-end API with postcode resolution

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the bin collection data retrieval system for Blackburn Council for better performance and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/robbrad/UKBinCollectionData/pull/2099?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->