### PR TITLE
fix: search by postcode only in newark and sherwood scraper

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/NewarkAndSherwoodDC.py
+++ b/uk_bin_collection/uk_bin_collection/councils/NewarkAndSherwoodDC.py
@@ -1,62 +1,142 @@
-from datetime import timedelta
+import re
+from datetime import datetime, timedelta
 
+import requests
 from bs4 import BeautifulSoup
 
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
 
-# import the wonderful Beautiful Soup and the URL grabber
 class CouncilClass(AbstractGetBinDataClass):
-    """
-    Concrete classes have to implement all abstract operations of the
-    base class. They can also override some operations with a default
-    implementation.
-    """
-
     def parse_data(self, page: str, **kwargs) -> dict:
-
+        user_postcode = kwargs.get("postcode")
+        user_paon = kwargs.get("paon")
         user_uprn = kwargs.get("uprn")
-        check_uprn(user_uprn)
+        check_postcode(user_postcode)
 
-        URI = f"https://app.newark-sherwooddc.gov.uk/bincollection/calendar?pid={user_uprn}"
+        base = "https://app.newark-sherwooddc.gov.uk/bincollection"
 
-        # Make the GET request
-        response = requests.get(URI)
-        # Get page with BS4
-        soup = BeautifulSoup(response.text, features="html.parser")
-        soup.prettify()
+        s = requests.Session()
+        s.headers.update(
+            {
+                "User-Agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+                "(KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
+            }
+        )
 
-        # Work out some date bounds
+        # Step 1: GET form to obtain ASP.NET tokens
+        r1 = s.get(f"{base}/", verify=False)
+        r1.raise_for_status()
+        soup1 = BeautifulSoup(r1.text, "html.parser")
+
+        viewstate = soup1.find("input", id="__VIEWSTATE")["value"]
+        viewstate_gen = soup1.find("input", id="__VIEWSTATEGENERATOR")["value"]
+        event_val = soup1.find("input", id="__EVENTVALIDATION")["value"]
+
+        # Step 2: POST postcode search via __doPostBack
+        search_query = user_postcode  # always search by postcode only
+
+        form_data = {
+            "__VIEWSTATE": viewstate,
+            "__VIEWSTATEGENERATOR": viewstate_gen,
+            "__EVENTVALIDATION": event_val,
+            "__EVENTTARGET": "ctl00$MainContent$LinkButtonSearch",
+            "__EVENTARGUMENT": "",
+            "ctl00$MainContent$TextBoxSearch": search_query,
+        }
+
+        r2 = s.post(f"{base}/", data=form_data, verify=False)
+        r2.raise_for_status()
+        soup2 = BeautifulSoup(r2.text, "html.parser")
+
+        # Step 3: Find address links (collection.aspx?pid=UPRN)
+        address_links = []
+        for a in soup2.find_all("a"):
+            href = a.get("href", "")
+            if "collection.aspx" in href and "pid=" in href:
+                pid = re.search(r"pid=(\d+)", href)
+                if pid:
+                    address_links.append(
+                        {
+                            "text": a.text.strip(),
+                            "pid": pid.group(1),
+                            "href": href,
+                        }
+                    )
+
+        if not address_links:
+            raise ValueError(
+                f"No addresses found for postcode {user_postcode}"
+            )
+
+        # Step 4: Select address by UPRN, house number, or first match
+        selected = None
+        if user_uprn:
+            for addr in address_links:
+                if addr["pid"] == str(user_uprn):
+                    selected = addr
+                    break
+
+        if not selected and user_paon:
+            paon_lower = user_paon.lower()
+            for addr in address_links:
+                if addr["text"].lower().startswith(paon_lower):
+                    selected = addr
+                    break
+            if not selected:
+                for addr in address_links:
+                    if paon_lower in addr["text"].lower():
+                        selected = addr
+                        break
+
+        if not selected:
+            selected = address_links[0]
+
+        # Step 5: GET calendar page (uses same pid as collection.aspx)
+        collection_url = f"{base}/calendar?pid={selected['pid']}"
+        r3 = s.get(collection_url, verify=False)
+        r3.raise_for_status()
+        soup3 = BeautifulSoup(r3.text, "html.parser")
+
+        # Step 6: Parse collection dates
         today = datetime.today()
-        eight_weeks = datetime.today() + timedelta(days=8 * 7)
+        eight_weeks = today + timedelta(days=8 * 7)
         data = {"bins": []}
 
-        # Each month calendar is a table, so get the object then find all rows in that object.
-        # Month and year is also a row and not included in the date, so save it then remove the row
-        for month in soup.select('table[class*="table table-condensed"]'):
+        for month in soup3.select('table[class*="table table-condensed"]'):
             info = month.find_all("tr")
+            if not info:
+                continue
             month_year = info[0].text.strip()
-
             info.pop(0)
-            # Each remaining item is a bin collection, so get the type and tidy up the date.
+
             for item in info:
-                bin_type = item.text.split(",")[0].strip()
-                bin_date = datetime.strptime(
-                    remove_ordinal_indicator_from_date_string(
-                        item.text.split(",")[1].strip() + " " + month_year
-                    ),
-                    "%A %d %B %Y",
-                )
-                # Only include dates on or after today, but also only within eight weeks
+                text = item.text.strip()
+                if "," not in text:
+                    continue
+                bin_type = text.split(",")[0].strip()
+                date_str = text.split(",")[1].strip() + " " + month_year
+                try:
+                    bin_date = datetime.strptime(
+                        remove_ordinal_indicator_from_date_string(date_str),
+                        "%A %d %B %Y",
+                    )
+                except ValueError:
+                    continue
+
                 if (
                     today.date() <= bin_date.date() <= eight_weeks.date()
-                    and "cancelled" not in bin_type
+                    and "cancelled" not in bin_type.lower()
                 ):
-                    dict_data = {
-                        "type": bin_type,
-                        "collectionDate": bin_date.strftime(date_format),
-                    }
-                    data["bins"].append(dict_data)
+                    data["bins"].append(
+                        {
+                            "type": bin_type,
+                            "collectionDate": bin_date.strftime(date_format),
+                        }
+                    )
+
+        if not data["bins"]:
+            raise ValueError("No collection data found")
 
         return data


### PR DESCRIPTION
## Summary
- The ASP.NET search form only accepts postcodes, not combined postcode+house strings
- Previous code appended house_number to postcode (e.g. "NG24 1BT 1 Midland Terrace") which returned zero results
- Now searches by postcode alone and matches house number against the returned address list
- Match priority: UPRN exact, then paon prefix, then paon contains, then first result

## Testing
- NG24 1BT + house "1 Midland Terrace": 13 bins returned
- UPRN path still works (backward compatible)