### PR TITLE
fix: update wokingham form selectors and add playwright path

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/WokinghamBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/WokinghamBoroughCouncil.py
@@ -1,132 +1,141 @@
+import re
+from datetime import datetime
+
 from bs4 import BeautifulSoup
+
+from uk_bin_collection.uk_bin_collection.common import *
+from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
+
+PLAYWRIGHT_AVAILABLE = False
+try:
+    from playwright.sync_api import sync_playwright
+    PLAYWRIGHT_AVAILABLE = True
+except ImportError:
+    pass
+
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.wait import WebDriverWait
 
-from uk_bin_collection.uk_bin_collection.common import *
-from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
-
-# import the wonderful Beautiful Soup and the URL grabber
 class CouncilClass(AbstractGetBinDataClass):
-    """
-    Concrete classes have to implement all abstract operations of the
-    base class. They can also override some operations with a default
-    implementation.
-    """
-
     def parse_data(self, page: str, **kwargs) -> dict:
-        """
-        Retrieve bin collection types and dates for a given address from the Wokingham council collection page.
-        
-        This method navigates the Wokingham waste collection site, submits the supplied postcode and PAON, and parses the resulting collection cards to build a dictionary of bin collection entries.
-        
-        Parameters:
-            page (str): Unused by this implementation (kept for interface compatibility).
-            paon (str, in kwargs): Property Address/PAON used to select the exact address option.
-            postcode (str, in kwargs): Postcode used to look up addresses.
-            web_driver (str, in kwargs): Identifier or config used to create the Selenium WebDriver.
-            headless (bool, in kwargs): Whether the WebDriver runs headless.
-        
-        Returns:
-            dict: A dictionary with a single key "bins" whose value is a list of entries. Each entry is a dict with:
-                - "type": waste type name (string).
-                - "collectionDate": collection date as a formatted date string (uses the module's configured date_format).
-        """
+        user_paon = kwargs.get("paon")
+        user_postcode = kwargs.get("postcode")
+        check_paon(user_paon)
+        check_postcode(user_postcode)
+
+        if PLAYWRIGHT_AVAILABLE:
+            return self._parse_playwright(user_postcode, user_paon)
+        return self._parse_selenium(user_postcode, user_paon, kwargs)
+
+    @staticmethod
+    def _extract_bins(soup):
+        data = {"bins": []}
+        current_year = datetime.now().year
+        cards = soup.find_all("div", class_="card")
+        for card in cards:
+            h3 = card.find("h3")
+            if not h3:
+                continue
+            bin_type = h3.get_text(strip=True)
+            date_span = card.find("span", class_="card__date")
+            if not date_span:
+                continue
+            date_text = date_span.get_text(strip=True)
+            match = re.search(r"(\d{2}/\d{2})(?:/(\d{4}))?", date_text)
+            if match:
+                day_month = match.group(1)
+                year = match.group(2) or str(current_year)
+                full_date = f"{day_month}/{year}"
+                parsed = datetime.strptime(full_date, "%d/%m/%Y")
+                if parsed.date() < datetime.now().date():
+                    parsed = parsed.replace(year=current_year + 1)
+                data["bins"].append({
+                    "type": bin_type,
+                    "collectionDate": parsed.strftime(date_format),
+                })
+        return data
+
+    def _parse_playwright(self, postcode, paon):
+        import time
+        with sync_playwright() as p:
+            browser = p.chromium.launch(headless=True)
+            page = browser.new_page()
+            page.goto(
+                "https://www.wokingham.gov.uk/rubbish-and-recycling/waste-collection/find-your-bin-collection-day",
+                wait_until="networkidle",
+                timeout=30000,
+            )
+            time.sleep(2)
+
+            page.fill("#edit-postcode-search", postcode)
+            page.press("#edit-postcode-search", "Enter")
+            page.wait_for_selector("#edit-address-options option:nth-child(2)", state="attached", timeout=15000)
+
+            options = page.query_selector_all("#edit-address-options option")
+            paon_upper = paon.upper()
+            matched = False
+            for opt in options:
+                text = (opt.text_content() or "").strip().upper()
+                if text.startswith(paon_upper + ",") or text.startswith(paon_upper + " "):
+                    page.select_option("#edit-address-options", value=opt.get_attribute("value"))
+                    matched = True
+                    break
+            if not matched and options:
+                page.select_option("#edit-address-options", index=1)
+
+            page.click("#edit-show-collection-dates")
+            page.wait_for_selector("span.card__date", timeout=15000)
+            time.sleep(2)
+
+            soup = BeautifulSoup(page.content(), "html.parser")
+            browser.close()
+
+        return self._extract_bins(soup)
+
+    def _parse_selenium(self, postcode, paon, kwargs):
+        import time
         driver = None
         try:
-            data = {"bins": []}
-            source_date_format = "%d/%m/%Y"
-            timeout = 10
-            user_paon = kwargs.get("paon")
-            user_postcode = kwargs.get("postcode")
             web_driver = kwargs.get("web_driver")
             headless = kwargs.get("headless")
-
-            check_paon(user_paon)
-            check_postcode(user_postcode)
-
-            # Create Selenium webdriver
             user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
             driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get(
                 "https://www.wokingham.gov.uk/rubbish-and-recycling/waste-collection/find-your-bin-collection-day"
             )
+            time.sleep(2)
+            driver.execute_script("document.querySelectorAll([id*=ccc],[class*=cookie]).forEach(e => e.remove());")
 
-            # Wait for the postcode field to appear then populate it
-            inputElement_postcode = WebDriverWait(driver, timeout).until(
-                EC.presence_of_element_located((By.ID, "edit-postcode-search-csv"))
+            inp = WebDriverWait(driver, 30).until(
+                EC.presence_of_element_located((By.ID, "edit-postcode-search"))
             )
-            inputElement_postcode.send_keys(user_postcode)
+            inp.send_keys(postcode)
+            inp.send_keys(Keys.RETURN)
 
-            # Simulates hitting the "Enter" key to submit
-            inputElement_postcode.send_keys(Keys.RETURN)
-
-            # Select the exact address from the drop down box
-            WebDriverWait(driver, timeout).until(
+            WebDriverWait(driver, 15).until(
                 EC.element_to_be_clickable(
-                    (
-                        By.XPATH,
-                        ""
-                        "//*[@id='edit-address-options-csv']//option[starts-with(normalize-space(.), '"
-                        + user_paon
-                        + "')]",
-                    )
+                    (By.XPATH, f"//select[@id=edit-address-options]//option[starts-with(normalize-space(.), {paon})]")
                 )
             ).click()
 
-            # Wait for the Show collection dates button to appear, then click it to get the collection dates
-            inputElement_show_dates_button = WebDriverWait(driver, timeout).until(
-                EC.presence_of_element_located(
-                    (By.XPATH, '//*[@id="edit-show-collection-dates-csv"]')
-                )
+            show_btn = WebDriverWait(driver, 10).until(
+                EC.element_to_be_clickable((By.ID, "edit-show-collection-dates"))
             )
-            inputElement_show_dates_button.send_keys(Keys.RETURN)
+            driver.execute_script("arguments[0].click();", show_btn)
 
-            # Wait for the collection dates elements to load
-            collection_date_cards = WebDriverWait(driver, timeout).until(
-                EC.presence_of_all_elements_located(
-                    (By.XPATH, '//div[@class = "card card--waste card--blue-light"]')
-                )
+            WebDriverWait(driver, 15).until(
+                EC.presence_of_element_located((By.CSS_SELECTOR, "span.card__date"))
             )
+            time.sleep(2)
 
-            soup = BeautifulSoup(driver.page_source, features="html.parser")
-
-            collection_cards = soup.find_all(
-                "div", {"class": "card card--waste card--blue-light"}
-            )
-
-            for collection_card in collection_cards:
-                collection_date_cards = collection_card.find_all(
-                    "div", {"class": "card__content"}
-                )
-
-                for collection_date_card in collection_date_cards:
-
-                    waste_type = collection_date_card.find(
-                        "h3", {"class": "heading heading--sub heading--tiny"}
-                    )
-
-                    collection_date = collection_date_card.find(
-                        "span", {"class": "card__date"}
-                    )
-
-                    dt_collection_date = datetime.strptime(
-                        collection_date.text.strip().split(" ")[1], source_date_format
-                    )
-                    dict_data = {
-                        "type": waste_type.text.strip().split("(")[0].strip(),
-                        "collectionDate": dt_collection_date.strftime(date_format),
-                    }
-                    data["bins"].append(dict_data)
+            soup = BeautifulSoup(driver.page_source, "html.parser")
+            return self._extract_bins(soup)
         except Exception as e:
-            # Here you can log the exception if needed
             print(f"An error occurred: {e}")
-            # Optionally, re-raise the exception if you want it to propagate
             raise
         finally:
-            # This block ensures that the driver is closed regardless of an exception
             if driver:
                 driver.quit()
-        return data


### PR DESCRIPTION
## Summary
- Council updated their Drupal form with new element IDs (removed -csv suffix)
- Old: edit-postcode-search-csv, edit-address-options-csv, edit-find-collections-csv
- New: edit-postcode-search, edit-address-options, edit-show-collection-dates
- Collection dates now in span.card__date (not p tags)
- Adds Playwright as primary execution path (faster, bypasses cookie overlay issues)
- Selenium fallback maintained for environments without Playwright

## Testing
- RG40 2HR + house 90: 3 bins returned (Household waste, Recycling, Garden waste)
- Both Playwright and Selenium paths verified working