### PR TITLE
fix: rewrite fenland to use imactivate bins api

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/FenlandDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/FenlandDistrictCouncil.py
@@ -1,65 +1,87 @@
-import json
+import re
+from datetime import datetime
 
 import requests
+
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
 
-# import the wonderful Beautiful Soup and the URL grabber
 class CouncilClass(AbstractGetBinDataClass):
     """
-    Concrete classes have to implement all abstract operations of the
-    base class. They can also override some operations with a default
-    implementation.
+    Fenland District Council — uses imactivate Bins API (Azure).
+    No authentication required. Accepts postcode + house number.
     """
 
+    API_BASE = "https://bins.azurewebsites.net/api"
+
     def parse_data(self, page: str, **kwargs) -> dict:
+        user_postcode = kwargs.get("postcode")
+        user_paon = kwargs.get("paon")
         user_uprn = kwargs.get("uprn")
-        check_uprn(user_uprn)
 
-        headers = {
-            "Accept": "application/json, text/javascript, */*; q=0.01",
-            "Accept-Language": "en-GB,en;q=0.7",
-            "Connection": "keep-alive",
-            "Content-Type": "application/json; charset=utf-8",
-            "Referer": "https://www.fenland.gov.uk/article/13114/?uprn=200002981143&lat=52.665569590474&lng=0.177905443639&postcode=PE13+3SL&line1=20+Felsted+Avenue&rad=5m&layers=2%2C3%2C1",
-            "Sec-Fetch-Dest": "empty",
-            "Sec-Fetch-Mode": "cors",
-            "Sec-Fetch-Site": "same-origin",
-            "Sec-GPC": "1",
-            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36",
-            "X-Requested-With": "XMLHttpRequest",
-        }
+        if user_postcode:
+            check_postcode(user_postcode)
+        elif user_uprn:
+            check_uprn(user_uprn)
+        else:
+            raise ValueError("Postcode or UPRN required")
 
-        # It needs lat and lng for point data, but we don't need it >:)
-        params = {
-            "type": "loadlayer",
-            "layerId": "2",
-            "uprn": user_uprn,
-            "lat": "0.000000000001",
-            "lng": "0.000000000001",
-        }
-
-        requests.packages.urllib3.disable_warnings()
-        response = requests.get(
-            "https://www.fenland.gov.uk/article/13114/", params=params, headers=headers
-        )
-
-        # Returned data is just json, so we can get what we need
-        json_data = json.loads(response.text)["features"][0]["properties"]["upcoming"]
         data = {"bins": []}
 
-        for item in json_data:
-            collections_list = item["collections"]
-            for bin in collections_list:
-                bin_type = bin["desc"]
-                bin_date = datetime.strptime(
-                    bin["collectionDate"], "%Y-%m-%dT%H:%M:%SZ"
-                ).strftime(date_format)
-                dict_data = {
-                    "type": bin_type,
-                    "collectionDate": bin_date,
-                }
-                data["bins"].append(dict_data)
+        premise_id = self._resolve_premise(user_postcode, user_paon, user_uprn)
 
+        response = requests.get(
+            f"{self.API_BASE}/getcollections",
+            params={"premisesid": premise_id, "localauthority": "Fenland"},
+            timeout=30,
+        )
+        response.raise_for_status()
+        collections = response.json()
+
+        for c in collections:
+            bin_type = c.get("BinType", "")
+            date_str = c.get("CollectionDate", "")
+            if not bin_type or not date_str:
+                continue
+            data["bins"].append({
+                "type": bin_type.title(),
+                "collectionDate": datetime.strptime(
+                    date_str, "%Y-%m-%d"
+                ).strftime(date_format),
+            })
+
+        data["bins"].sort(
+            key=lambda x: datetime.strptime(x["collectionDate"], date_format)
+        )
         return data
+
+    def _resolve_premise(self, postcode, paon, uprn):
+        if not postcode:
+            raise ValueError("Postcode required for Fenland lookup")
+
+        response = requests.get(
+            f"{self.API_BASE}/getaddress",
+            params={"postcode": postcode},
+            timeout=30,
+        )
+        response.raise_for_status()
+        addresses = response.json()
+
+        if not addresses:
+            raise ValueError(f"No addresses found for {postcode}")
+
+        if len(addresses) == 1:
+            return addresses[0]["PremiseID"]
+
+        if paon:
+            paon_upper = paon.upper().strip()
+            for addr in addresses:
+                addr_text = " ".join(
+                    str(addr.get(f, "")).replace("\x00", "")
+                    for f in ["Address1", "Address2", "Street"]
+                ).upper()
+                if addr_text.startswith(paon_upper) or paon_upper in addr_text:
+                    return addr["PremiseID"]
+
+        return addresses[0]["PremiseID"]


### PR DESCRIPTION
## Summary
- Fenland's site now has aggressive Cloudflare blocking that defeats Playwright and headless Chrome
- Switched to the imactivate Bins API (bins.azurewebsites.net) which serves identical data
- Pure HTTP, no authentication, no browser needed
- Three-step flow: postcode lookup, address match, get collections
- Returns Waste, Recycling, and Garden bin types

## Testing
- PE15 0PH + "THE BUNGALOW": 9 bins returned (waste, recycling, garden)
- PE13 1JR: multiple addresses resolved, collections confirmed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Fenland bin collection lookups now accept postcode and house number in addition to UPRN for greater query flexibility.

* **Chores**
  * Backend service updated for Fenland District Council bin data retrieval with improved address resolution capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->