### PR TITLE
fix: update east hampshire to new ishare endpoint

### DIFF
--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -736,6 +736,15 @@
         "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN.",
         "LAD24CD": "S12000008"
     },
+    "EastHampshireDC": {
+        "paon": "3",
+        "postcode": "GU31 4AU",
+        "skip_get_url": true,
+        "url": "https://maps.easthants.gov.uk",
+        "wiki_name": "East Hampshire",
+        "wiki_note": "Pass the postcode and house number/name in their respective parameters.",
+        "LAD24CD": "E07000085"
+    },
     "EastbourneBoroughCouncil": {
         "uprn": "100060011258",
         "url": "https://www.lewes-eastbourne.gov.uk/article/1158/When-is-my-bin-collection-day",
@@ -879,7 +888,7 @@
         "url": "https://environmentfirst.co.uk/house.php?uprn=100060055444",
         "wiki_command_url_override": "https://environmentfirst.co.uk/house.php?uprn=XXXXXXXXXX",
         "wiki_name": "Environment First",
-        "wiki_note": "For properties with collections managed by Environment First, such as Lewes and Eastbourne. Replace the XXXXXXXXXX with the UPRN of your property\u2014you can use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find this."
+        "wiki_note": "For properties with collections managed by Environment First, such as Lewes and Eastbourne. Replace the XXXXXXXXXX with the UPRN of your property—you can use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find this."
     },
     "EppingForestDistrictCouncil": {
         "postcode": "IG9 6EP",
@@ -1754,14 +1763,14 @@
         "LAD24CD": "E06000012"
     },
     "NorthHertfordshireDistrictCouncil": {
-            "house_number": "Stewards Flat",
-            "postcode": "SG5 1PZ",
-            "skip_get_url": true,
-            "url": "https://waste.nc.north-herts.gov.uk/w/webpage/find-bin-collection-day-input-address",
-            "web_driver": "http://selenium:4444",
-            "wiki_name": "North Hertfordshire",
-            "wiki_note": "Pass a postcode (with space) and house_number/name. The scraper performs the Liberty Create typeahead lookup and matches house_number as a case-insensitive substring.",
-            "LAD24CD": "E07000099"
+        "house_number": "Stewards Flat",
+        "postcode": "SG5 1PZ",
+        "skip_get_url": true,
+        "url": "https://waste.nc.north-herts.gov.uk/w/webpage/find-bin-collection-day-input-address",
+        "web_driver": "http://selenium:4444",
+        "wiki_name": "North Hertfordshire",
+        "wiki_note": "Pass a postcode (with space) and house_number/name. The scraper performs the Liberty Create typeahead lookup and matches house_number as a case-insensitive substring.",
+        "LAD24CD": "E07000099"
     },
     "NorthKestevenDistrictCouncil": {
         "skip_get_url": true,

--- a/uk_bin_collection/uk_bin_collection/councils/EastHampshireDC.py
+++ b/uk_bin_collection/uk_bin_collection/councils/EastHampshireDC.py
@@ -1,0 +1,143 @@
+import os
+import re
+import json
+import time
+import hashlib
+from datetime import datetime
+
+import pdfplumber
+import requests
+
+from uk_bin_collection.uk_bin_collection.common import *
+from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
+
+ISHARE_BASE = "https://maps.easthants.gov.uk"
+PDF_CACHE_DIR = "/home/mark/pdf-scrapers/easthants"
+PDF_CACHE_MAX_AGE = 86400 * 7
+HEADERS = {"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"}
+
+MONTHS = {
+    "JAN": 1, "FEB": 2, "MAR": 3, "APR": 4, "MAY": 5, "JUN": 6,
+    "JUL": 7, "AUG": 8, "SEP": 9, "OCT": 10, "NOV": 11, "DEC": 12,
+}
+
+
+class CouncilClass(AbstractGetBinDataClass):
+    def parse_data(self, page: str, **kwargs) -> dict:
+        data = {"bins": []}
+        user_postcode = kwargs.get("postcode")
+        user_paon = kwargs.get("paon")
+        check_postcode(user_postcode)
+
+        uid = self._get_property_uid(user_postcode, user_paon)
+        cal_num, pdf_url = self._get_calendar(uid)
+
+        if not pdf_url:
+            raise ValueError(f"No calendar found for property {uid}")
+
+        dates = self._parse_pdf(pdf_url)
+        now = datetime.now()
+        for bin_type, dt in dates:
+            if dt >= now:
+                data["bins"].append({
+                    "type": bin_type,
+                    "collectionDate": dt.strftime(date_format),
+                })
+
+        data["bins"].sort(
+            key=lambda x: datetime.strptime(x["collectionDate"], date_format)
+        )
+        return data
+
+    def _get_property_uid(self, postcode, paon):
+        r = requests.get(
+            f"{ISHARE_BASE}/getdata.aspx",
+            params={
+                "service": "Location",
+                "RequestType": "LocationSearch",
+                "location": postcode,
+                "pagesize": "50",
+                "startnum": "1",
+                "mapsource": "EHDC/MyHouse",
+            },
+            headers=HEADERS,
+            timeout=30,
+        )
+        r.raise_for_status()
+        result = r.json()
+        rows = result.get("data", [])
+
+        if not rows:
+            raise ValueError(f"No properties found for {postcode}")
+
+        if paon:
+            paon_upper = paon.upper()
+            for row in rows:
+                name = row[7].upper() if len(row) > 7 else ""
+                if name.startswith(paon_upper) or paon_upper in name:
+                    return row[0]
+
+        return rows[0][0]
+
+    def _get_calendar(self, uid):
+        r = requests.get(
+            f"{ISHARE_BASE}/getdata.aspx",
+            params={
+                "RequestType": "LocalInfo",
+                "ms": "EHDC/MyHouse",
+                "format": "JSONP",
+                "uid": uid,
+                "group": "Waste and Recycling|Bin Calendar",
+            },
+            headers=HEADERS,
+            timeout=30,
+        )
+        r.raise_for_status()
+        match = re.match(r"[^(]+\((.+)\);\s*$", r.text, re.S)
+        if not match:
+            return None, None
+
+        data = json.loads(match.group(1))
+        cal_str = data.get("Results", {}).get("Bin_Calendar", {}).get("_Calendar", "")
+        if "|" in cal_str:
+            pdf_url, cal_num = cal_str.rsplit("|", 1)
+            return cal_num, pdf_url
+        return None, None
+
+    def _parse_pdf(self, pdf_url):
+        os.makedirs(PDF_CACHE_DIR, exist_ok=True)
+        cache_path = os.path.join(
+            PDF_CACHE_DIR, hashlib.md5(pdf_url.encode()).hexdigest() + ".pdf"
+        )
+
+        if not os.path.exists(cache_path) or (time.time() - os.path.getmtime(cache_path)) > PDF_CACHE_MAX_AGE:
+            r = requests.get(pdf_url, headers=HEADERS, timeout=30)
+            r.raise_for_status()
+            with open(cache_path, "wb") as f:
+                f.write(r.content)
+
+        dates = []
+        current_year = datetime.now().year
+
+        with pdfplumber.open(cache_path) as pdf:
+            for pg in pdf.pages:
+                text = pg.extract_text() or ""
+                lines = text.split("\n")
+                current_month = None
+                for line in lines:
+                    line_upper = line.strip().upper()
+                    for month_name, month_num in MONTHS.items():
+                        if line_upper.startswith(month_name) or f" {month_name}" in line_upper:
+                            current_month = month_num
+                            break
+                    if current_month:
+                        day_matches = re.findall(r"\b(\d{1,2})\b", line)
+                        for day_str in day_matches:
+                            day = int(day_str)
+                            if 1 <= day <= 31:
+                                try:
+                                    dt = datetime(current_year, current_month, day)
+                                    dates.append(("Waste Collection", dt))
+                                except ValueError:
+                                    pass
+        return dates


### PR DESCRIPTION
## Summary
- The old iShareLIVE.web/ws/LocationSearch.asmx endpoint was decommissioned (returns 404)
- iShare service moved to /getdata.aspx with mapsource parameter
- New three-step flow: property UID lookup, calendar number resolution, PDF download and parse
- Requires User-Agent header (403 without it)
- Caches PDFs locally for 7 days to reduce load on the council server

## Testing
- GU31 4AU + "3 Stableway": Calendar 13, dates returned from PDF
- GU34 2JN + "51 Wooteys Way": Calendar 4, confirmed working

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for East Hampshire District Council bin collection lookups—enter postcode and property details to get upcoming collection dates.

* **Tests / Configuration**
  * Updated sample test/config data to include East Hampshire and revised guidance text for an environment entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->