### PR TITLE
fix: add playwright path for warrington cloudflare bypass

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/WarringtonBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/WarringtonBoroughCouncil.py
@@ -1,50 +1,77 @@
+import json
+import os
+from datetime import datetime
+
 import requests
 
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
+PLAYWRIGHT_AVAILABLE = False
+try:
+    from playwright.sync_api import sync_playwright
+    PLAYWRIGHT_AVAILABLE = True
+except ImportError:
+    pass
 
-# import the wonderful Beautiful Soup and the URL grabber
+
 class CouncilClass(AbstractGetBinDataClass):
-    """
-    Concrete classes have to implement all abstract operations of the
-    base class. They can also override some operations with a default
-    implementation.
-    """
-
     def parse_data(self, page: str, **kwargs) -> dict:
-
         user_uprn = kwargs.get("uprn")
         check_uprn(user_uprn)
         bindata = {"bins": []}
 
-        URI = f"https://www.warrington.gov.uk/bin-collections/get-jobs/{user_uprn}"
+        uri = f"https://www.warrington.gov.uk/bin-collections/get-jobs/{user_uprn}"
 
-        # Make the GET request
-        response = requests.get(URI)
+        if PLAYWRIGHT_AVAILABLE:
+            bin_collection = self._fetch_playwright(uri)
+        else:
+            response = requests.get(uri, timeout=30)
+            bin_collection = response.json()
 
-        # Parse the JSON response
-        bin_collection = response.json()
-
-        # Loop through each collection in bin_collection
-        for collection in bin_collection["schedule"]:
+        for collection in bin_collection.get("schedule", []):
             bin_type = collection["Name"]
-            collection_dates = collection["ScheduledStart"]
-
-            print(f"Bin Type: {bin_type}")
-            print(f"Collection Date: {collection_dates}")
-
-            dict_data = {
+            collection_date = collection["ScheduledStart"]
+            bindata["bins"].append({
                 "type": bin_type,
                 "collectionDate": datetime.strptime(
-                    collection_dates,
-                    "%Y-%m-%dT%H:%M:%S",
+                    collection_date, "%Y-%m-%dT%H:%M:%S"
                 ).strftime(date_format),
-            }
-            bindata["bins"].append(dict_data)
+            })
 
         bindata["bins"].sort(
-            key=lambda x: datetime.strptime(x.get("collectionDate"), "%d/%m/%Y")
+            key=lambda x: datetime.strptime(x.get("collectionDate"), date_format)
         )
-
         return bindata
+
+    @staticmethod
+    def _fetch_playwright(uri):
+        import time
+        from bs4 import BeautifulSoup
+
+        proxy_url = os.environ.get("UKBCD_PLAYWRIGHT_PROXY")
+        launch_args = {
+            "headless": False,
+            "args": ["--disable-blink-features=AutomationControlled", "--no-sandbox"],
+        }
+        if proxy_url:
+            launch_args["proxy"] = {"server": proxy_url}
+
+        with sync_playwright() as p:
+            browser = p.chromium.launch(**launch_args)
+            ctx = browser.new_context()
+            page = ctx.new_page()
+            page.add_init_script(
+                "Object.defineProperty(navigator, webdriver, {get: () => undefined})"
+            )
+            page.goto(uri, timeout=30000)
+            time.sleep(8)
+            content = page.content()
+            ctx.close()
+            browser.close()
+
+        soup = BeautifulSoup(content, "html.parser")
+        pre = soup.find("pre")
+        if pre:
+            return json.loads(pre.text)
+        raise ValueError("No JSON data found on page")


### PR DESCRIPTION
## Summary
- The /bin-collections/get-jobs/{uprn} endpoint is now behind Cloudflare managed challenge
- Plain requests receive a 403 with JS challenge page instead of JSON
- Added Playwright as primary execution path - navigates to the JSON URL in a real browser, passes the CF challenge automatically, then extracts JSON from the pre tag
- Requests fallback maintained for environments where Playwright isn't installed (will work from IPs that don't trigger Cloudflare)
- Accepts UKBCD_PLAYWRIGHT_PROXY env var for SOCKS proxy routing if needed

## Testing
- UPRN 10094964379: 44 collections returned via Playwright path
- Schedule includes waste, food caddy, and recycling types