### PR TITLE
fix: Vale of White Horse SSL errors and session cookies

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/ValeofWhiteHorseCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/ValeofWhiteHorseCouncil.py
@@ -18,9 +18,6 @@ class CouncilClass(AbstractGetBinDataClass):
         check_uprn(user_uprn)
 
         # UPRN is passed in via a cookie. Set cookies/params and GET the page
-        cookies = {
-            "SVBINZONE": f"VALE%3AUPRN%40{user_uprn}",
-        }
         headers = {
             "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
             "Accept-Language": "en-GB,en;q=0.7",
@@ -40,11 +37,23 @@ class CouncilClass(AbstractGetBinDataClass):
             "ebd": "0",
         }
         requests.packages.urllib3.disable_warnings()
-        response = requests.get(
+        # Azure App Gateway intermittently returns 403 on direct requests.
+        # Establishing a JSESSIONID by visiting the page first (without the
+        # SVBINZONE cookie) avoids this.
+        session = requests.Session()
+        session.headers.update(headers)
+        session.get(
+            "https://eform.whitehorsedc.gov.uk/ebase/BINZONE_DESKTOP.eb?SOVA_TAG=VALE&ebd=0&ebz=1_1780529431339",
+            verify=False,
+            timeout=15,
+        )
+        session.cookies.set("SVBINZONE", f"VALE%3AUPRN%40{user_uprn}")
+        response = session.get(
             "https://eform.whitehorsedc.gov.uk/ebase/BINZONE_DESKTOP.eb",
             params=params,
             headers=headers,
-            cookies=cookies,
+            verify=False,
+            timeout=15,
         )
 
         # Parse response text for super speedy finding


### PR DESCRIPTION
This change fixes the current SSL errors received when connecting to Vale of White Horse's BINZONE web application.

Also pulling in the fixes for session cookies applied to South Oxfordshire in https://github.com/robbrad/UKBinCollectionData/commit/bf6dd1fc476b5602f92bb281994683b77aa3a469

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of bin collection data fetching for Vale of White Horse Council by enhancing session handling and request sequencing, reducing intermittent access errors and failed requests. Bin extraction, sorting, and displayed data format remain unchanged to preserve existing user-facing behavior. Users should see fewer failed loads when viewing bin schedules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->