### PR TITLE
fix: add rotation fallback for south kesteven calendar lookup

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/SouthKestevenDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/SouthKestevenDistrictCouncil.py
@@ -1123,8 +1123,18 @@ class CouncilClass(AbstractGetBinDataClass):
             if year in calendar_data and month in calendar_data[year] and week_of_month in calendar_data[year][month]:
                 return calendar_data[year][month][week_of_month]
             else:
-                # Raise error if not found in calendar instead of fallback
-                raise ValueError(f"No bin type found for {collection_date} (Week {week_of_month} of {month}/{year})")
+                # Fallback: 3-week rotation derived from known anchor
+                # Oct 2025 week 2 (day 8-14) = Silver, week 3 = Black, week 4 = Purple
+                # Anchor: 2025-10-13 (start of week 2) = Silver (index 0)
+                ROTATION = [
+                    "Silver bin (Recycling)",
+                    "Black bin (General waste)",
+                    "Purple-lidded bin (Paper & Card)",
+                ]
+                anchor = datetime(2025, 10, 13)
+                days_diff = (date_obj - anchor).days
+                weeks_diff = days_diff // 7
+                return ROTATION[weeks_diff % 3]
                 
         except Exception as e:
             print(f"Error determining bin type for {collection_date}: {e}")


### PR DESCRIPTION
## Summary
- When OCR dependencies are unavailable and the hardcoded fallback calendar table doesn't cover the requested date, the scraper raises `ValueError` instead of returning bin data
- Adds a 3-week rotation calculation as a final fallback, anchored to a known data point (Oct 2025 week 2 = Silver)
- Rotation order: Silver (Recycling) -> Black (General waste) -> Purple-lidded (Paper & Card)
- Verified against the published 2026/27 calendar image from southkesteven.gov.uk/binday

## Testing
- NG31 8DL: previously raised `ValueError: No bin type found for 08/06/2026 (Week 2 of 6/2026)`, now returns correct bin types
- Cross-checked June and July 2026 output against the council's published calendar PNG - all dates match

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced reliability of bin collection schedules for South Kesteven District Council. The system now gracefully handles missing calendar data by applying a proven rotation pattern, ensuring residents always have access to their collection information without service disruptions or errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->