### PR TITLE
Fix South Kesteven binday scraper

### DIFF
--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -2324,11 +2324,13 @@
     },
     "SouthKestevenDistrictCouncil": {
         "LAD24CD": "E07000141",
-        "postcode": "PE68BL",
+        "house_number": "43",
+        "postcode": "NG31 8XG",
         "skip_get_url": true,
-        "url": "https://pre.southkesteven.gov.uk/skdcNext/tempforms/checkmybin.aspx",
+        "url": "https://www.southkesteven.gov.uk/binday",
+        "web_driver": "http://selenium:4444",
         "wiki_name": "South Kesteven District Council",
-        "wiki_note": "Provide your postcode in the `postcode` parameter. The scraper uses requests-based form submission and OCR to parse calendar images for accurate bin type determination and green bin collection patterns."
+        "wiki_note": "Provide your house number or house name in the `house_number` parameter and your postcode in the `postcode` parameter. The parser navigates the postcode bin day checker on the council's `binday` page using Selenium and parses the resulting \"Your Collections\" tables. The returned bin types are normalized to `Grey Bin`, `Food Bin`, `Black Bin`, and `Purple Bin` for Home Assistant compatibility."
     },
     "SouthLanarkshireCouncil": {
         "LAD24CD": "S12000029",

--- a/uk_bin_collection/uk_bin_collection/collect_data.py
+++ b/uk_bin_collection/uk_bin_collection/collect_data.py
@@ -63,6 +63,14 @@ class UKBinCollectionApp:
             required=False,
         )
         self.parser.add_argument(
+            "--artifact-dir",
+            "--artifact_dir",
+            dest="artifact_dir",
+            type=str,
+            help="Directory for council-specific debug artifacts when a live scrape fails",
+            required=False,
+        )
+        self.parser.add_argument(
             "--headless",
             dest="headless",
             action="store_true",
@@ -106,6 +114,7 @@ class UKBinCollectionApp:
             uprn=self.parsed_args.uprn,
             skip_get_url=self.parsed_args.skip_get_url,
             web_driver=self.parsed_args.web_driver,
+            artifact_dir=self.parsed_args.artifact_dir,
             headless=self.parsed_args.headless,
             local_browser=self.parsed_args.local_browser,
             dev_mode=self.parsed_args.dev_mode,

--- a/uk_bin_collection/uk_bin_collection/councils/SouthKestevenDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/SouthKestevenDistrictCouncil.py
@@ -1,1205 +1,355 @@
-import re
-import requests
-from datetime import datetime, timedelta
-from io import BytesIO
 import json
-import os
+from datetime import datetime
+from pathlib import Path
+from urllib.parse import urljoin
 
 from bs4 import BeautifulSoup
-
-# Optional OCR dependencies
-try:
-    import easyocr
-    import cv2
-    import numpy as np
-    from PIL import Image
-    HAS_OCR = True
-except ImportError:
-    HAS_OCR = False
+import requests
+from requests import RequestException
+from selenium.common.exceptions import NoSuchElementException, TimeoutException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.support.wait import WebDriverWait
-
-from uk_bin_collection.uk_bin_collection.common import *
+from selenium.webdriver.support.ui import Select, WebDriverWait
+from uk_bin_collection.uk_bin_collection.common import create_webdriver, date_format
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
 
 class CouncilClass(AbstractGetBinDataClass):
-    """
-    Concrete classes have to implement all abstract operations of the
-    base class. They can also override some operations with a default
-    implementation.
-    """
+    """South Kesteven District Council bin collections via the live binday flow."""
 
-    def get_collection_day_from_postcode(self, driver, postcode):
-        """Get the collection day for regular bins from the postcode checker."""
-        try:
-            # Use requests-based approach (no Selenium)
-            collection_day = self._get_collection_day_requests(postcode)
-            return collection_day
-            
-        except Exception as e:
-            print(f"Error getting collection day: {e}")
-            return None
-    
-    def _get_collection_day_requests(self, postcode):
-        """Get collection day using requests (ASP.NET WebForms)."""
-        try:
-            import requests
-            from bs4 import BeautifulSoup
-            
-            session = requests.Session()
-            # Set headers to mimic a real browser
-            session.headers.update({
-                'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36',
-                'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
-                'Accept-Language': 'en-US,en;q=0.5',
-                'Accept-Encoding': 'gzip, deflate',
-                'Connection': 'keep-alive',
-                'Upgrade-Insecure-Requests': '1',
-            })
-            
-            url = "https://pre.southkesteven.gov.uk/skdcNext/tempforms/checkmybin.aspx"
-            
-            # Get the initial form
-            response = session.get(url, timeout=30)
-            if response.status_code != 200:
-                print(f"Failed to get form: {response.status_code}")
-                return None
-                
-            soup = BeautifulSoup(response.content, 'html.parser')
-            form = soup.find('form')
-            if not form:
-                print("No form found")
-                return None
-            
-            # Extract form data
-            form_data = {}
-            for input_field in form.find_all('input'):
-                name = input_field.get('name')
-                value = input_field.get('value', '')
-                input_type = input_field.get('type', 'text')
-                if name:
-                    form_data[name] = value
-                    print(f"Form field: {name} ({input_type}) = {value[:50]}...")
-            
-            # Find the correct postcode field
-            # Look for input fields that are not hidden/system fields
-            text_inputs = []
-            for input_field in form.find_all('input'):
-                name = input_field.get('name', '')
-                input_type = input_field.get('type', 'text')
-                if input_type == 'text' and name not in ['__VIEWSTATE', '__VIEWSTATEGENERATOR', '__EVENTVALIDATION']:
-                    text_inputs.append(name)
-            
-            print(f"Found text inputs: {text_inputs}")
-            
-            if not text_inputs:
-                print("No text input fields found")
-                return None
-            
-            # Update the first text input with postcode
-            form_data[text_inputs[0]] = postcode
-            print(f"Updated {text_inputs[0]} with postcode: {postcode}")
-            
-            # Submit the form
-            action = form.get('action', '')
-            if action.startswith('./'):
-                action = action[2:]  # Remove './'
-            submit_url = url.replace('checkmybin.aspx', action) if action else url
-            
-            print(f"Submitting to: {submit_url}")
-            
-            # Add referer header
-            session.headers.update({'Referer': url})
-            
-            response = session.post(submit_url, data=form_data, timeout=30)
-            print(f"Response status: {response.status_code}")
-            
-            if response.status_code == 200:
-                soup = BeautifulSoup(response.content, 'html.parser')
-                text_content = soup.get_text()
-                
-                print("Response content preview:")
-                print(text_content[:500])
-                
-                # Look for collection day patterns
-                day_patterns = [
-                    r'bin day is (\w+)',
-                    r'collection day is (\w+)',
-                    r'(\w+) is your bin day',
-                    r'(\w+) is your collection day',
-                    r'your bin day is (\w+)',
-                    r'your collection day is (\w+)'
-                ]
-                
-                for pattern in day_patterns:
-                    match = re.search(pattern, text_content, re.IGNORECASE)
-                    if match:
-                        day = match.group(1)
-                        print(f"Found collection day: {day}")
-                        return day
-                
-                print("No collection day pattern found in response")
-                return None
-            else:
-                print(f"Form submission failed with status {response.status_code}")
-                print("Response content:")
-                print(response.text[:500])
-                return None
-            
-        except Exception as e:
-            print(f"Requests approach failed: {e}")
-            import traceback
-            traceback.print_exc()
-            return None
-    
-    def _get_collection_day_selenium(self, driver, postcode):
-        """Get collection day using Selenium (fallback)."""
-        try:
-            # Navigate to the new postcode checker
-            driver.get("https://pre.southkesteven.gov.uk/skdcNext/tempforms/checkmybin.aspx")
-            
-            # Wait for page to load
-            import time
-            time.sleep(2)
-            
-            wait = WebDriverWait(driver, 30)
-            
-            # Find and fill the regular bins postcode field with multiple selectors
-            bins_input = None
-            selectors = [
-                "//input[@placeholder='Please enter your Postcode']",
-                "//input[contains(@placeholder, 'Postcode')]",
-                "//input[@type='text']",
-                "//input[contains(@class, 'postcode')]"
-            ]
-            
-            for selector in selectors:
-                try:
-                    bins_input = wait.until(
-                        EC.presence_of_element_located((By.XPATH, selector))
-                    )
-                    break
-                except:
-                    continue
-            
-            if not bins_input:
-                print("Could not find postcode input field")
-                return None
-            
-            # Clear and fill the input
-            bins_input.clear()
-            time.sleep(0.5)
-            bins_input.send_keys(postcode)
-            time.sleep(0.5)
-            
-            # Click the Check button with multiple selectors
-            check_button = None
-            button_selectors = [
-                "//button[text()='Check']",
-                "//button[contains(text(), 'Check')]",
-                "//input[@type='submit']",
-                "//button[@type='submit']"
-            ]
-            
-            for selector in button_selectors:
-                try:
-                    check_button = wait.until(
-                        EC.element_to_be_clickable((By.XPATH, selector))
-                    )
-                    break
-                except:
-                    continue
-            
-            if not check_button:
-                print("Could not find check button")
-                return None
-            
-            # Click the button
-            check_button.click()
-            time.sleep(3)  # Wait for results
-            
-            # Wait for results and extract the collection day
-            try:
-                wait.until(EC.presence_of_element_located((By.XPATH, "//*[contains(text(), 'Bin Day is')]")))
-            except:
-                # Try alternative text patterns
-                try:
-                    wait.until(EC.presence_of_element_located((By.XPATH, "//*[contains(text(), 'collection day')]")))
-                except:
-                    pass
-            
-            soup = BeautifulSoup(driver.page_source, features="html.parser")
-            bin_day_element = soup.find(text=re.compile(r"Bin Day is \w+"))
-            
-            if bin_day_element:
-                day_match = re.search(r"Bin Day is (\w+)", bin_day_element)
-                if day_match:
-                    return day_match.group(1)
-            
-            return None
-            
-        except Exception as e:
-            print(f"Selenium approach failed: {e}")
-            return None
-
-    def get_green_bin_info_from_postcode(self, driver, postcode):
-        """Get the green bin collection info from the postcode checker."""
-        try:
-            # Use requests-based approach (no Selenium)
-            green_bin_info = self._get_green_bin_info_requests(postcode)
-            return green_bin_info
-            
-        except Exception as e:
-            print(f"Error getting green bin info: {e}")
-            return None
-    
-    def _get_green_bin_info_requests(self, postcode):
-        """Get green bin info using requests (ASP.NET WebForms)."""
-        try:
-            import requests
-            from bs4 import BeautifulSoup
-            
-            session = requests.Session()
-            # Set headers to mimic a real browser
-            session.headers.update({
-                'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36',
-                'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
-                'Accept-Language': 'en-US,en;q=0.5',
-                'Accept-Encoding': 'gzip, deflate',
-                'Connection': 'keep-alive',
-                'Upgrade-Insecure-Requests': '1',
-            })
-            
-            url = "https://pre.southkesteven.gov.uk/skdcNext/tempforms/checkmybin.aspx"
-            
-            # Get the initial form
-            response = session.get(url, timeout=30)
-            if response.status_code != 200:
-                print(f"Failed to get form for green bin: {response.status_code}")
-                return None
-                
-            soup = BeautifulSoup(response.content, 'html.parser')
-            form = soup.find('form')
-            if not form:
-                print("No form found for green bin")
-                return None
-            
-            # Extract form data
-            form_data = {}
-            for input_field in form.find_all('input'):
-                name = input_field.get('name')
-                value = input_field.get('value', '')
-                input_type = input_field.get('type', 'text')
-                if name:
-                    form_data[name] = value
-            
-            # Find the correct postcode field (second text input for green bin)
-            text_inputs = []
-            for input_field in form.find_all('input'):
-                name = input_field.get('name', '')
-                input_type = input_field.get('type', 'text')
-                if input_type == 'text' and name not in ['__VIEWSTATE', '__VIEWSTATEGENERATOR', '__EVENTVALIDATION']:
-                    text_inputs.append(name)
-            
-            print(f"Found text inputs for green bin: {text_inputs}")
-            
-            if len(text_inputs) < 2:
-                print("Not enough text input fields found for green bin")
-                return None
-            
-            # Update the second text input with postcode (green bin)
-            form_data[text_inputs[1]] = postcode
-            print(f"Updated {text_inputs[1]} with postcode: {postcode}")
-            
-            # Submit the form
-            action = form.get('action', '')
-            if action.startswith('./'):
-                action = action[2:]  # Remove './'
-            submit_url = url.replace('checkmybin.aspx', action) if action else url
-            
-            print(f"Submitting green bin form to: {submit_url}")
-            
-            # Add referer header
-            session.headers.update({'Referer': url})
-            
-            response = session.post(submit_url, data=form_data, timeout=30)
-            print(f"Green bin response status: {response.status_code}")
-            
-            if response.status_code == 200:
-                soup = BeautifulSoup(response.content, 'html.parser')
-                text_content = soup.get_text()
-                
-                print("Green bin response content preview:")
-                print(text_content[:500])
-                
-                # Look for green bin patterns
-                green_patterns = [
-                    r'green bin day is (\w+) week (\d+)',
-                    r'green bin collection day is (\w+) week (\d+)',
-                    r'(\w+) week (\d+) is your green bin day',
-                    r'green bin: (\w+) week (\d+)',
-                    r'garden waste: (\w+) week (\d+)'
-                ]
-                
-                for pattern in green_patterns:
-                    match = re.search(pattern, text_content, re.IGNORECASE)
-                    if match:
-                        day = match.group(1)
-                        week = int(match.group(2))
-                        print(f"Found green bin info: {day} week {week}")
-                        return {
-                            "day": day,
-                            "week": week
-                        }
-                
-                print("No green bin pattern found in response")
-                return None
-            else:
-                print(f"Green bin form submission failed with status {response.status_code}")
-                print("Response content:")
-                print(response.text[:500])
-                return None
-            
-        except Exception as e:
-            print(f"Requests approach failed for green bin: {e}")
-            import traceback
-            traceback.print_exc()
-            return None
-    
-    def _get_green_bin_info_selenium(self, driver, postcode):
-        """Get green bin info using Selenium (fallback)."""
-        try:
-            # Navigate to the new postcode checker
-            driver.get("https://pre.southkesteven.gov.uk/skdcNext/tempforms/checkmybin.aspx")
-            
-            # Wait for page to load
-            import time
-            time.sleep(2)
-            
-            wait = WebDriverWait(driver, 30)
-            
-            # Find and fill the green bin postcode field (second input)
-            green_bin_inputs = driver.find_elements(By.XPATH, "//input[@placeholder='Please enter your Postcode']")
-            if len(green_bin_inputs) >= 2:
-                green_bin_input = green_bin_inputs[1]  # Second input is for green bin
-                green_bin_input.clear()
-                time.sleep(0.5)
-                green_bin_input.send_keys(postcode)
-                time.sleep(0.5)
-                
-                # Click the Check button with multiple selectors
-                check_button = None
-                button_selectors = [
-                    "//button[text()='Check']",
-                    "//button[contains(text(), 'Check')]",
-                    "//input[@type='submit']",
-                    "//button[@type='submit']"
-                ]
-                
-                for selector in button_selectors:
-                    try:
-                        check_button = wait.until(
-                            EC.element_to_be_clickable((By.XPATH, selector))
-                        )
-                        break
-                    except:
-                        continue
-                
-                if not check_button:
-                    print("Could not find check button for green bin")
-                    return None
-                
-                check_button.click()
-                time.sleep(3)  # Wait for results
-                
-                # Wait for results and extract the green bin info
-                try:
-                    wait.until(EC.presence_of_element_located((By.XPATH, "//*[contains(text(), 'Green Bin Day is')]")))
-                except:
-                    # Try alternative text patterns
-                    try:
-                        wait.until(EC.presence_of_element_located((By.XPATH, "//*[contains(text(), 'green bin')]")))
-                    except:
-                        pass
-                
-                soup = BeautifulSoup(driver.page_source, features="html.parser")
-                green_bin_element = soup.find(text=re.compile(r"Green Bin Day is \w+ \w+ \d+"))
-                
-                if green_bin_element:
-                    # Extract day and week info (e.g., "Tuesday Week 2")
-                    week_match = re.search(r"Green Bin Day is (\w+) Week (\d+)", green_bin_element)
-                    if week_match:
-                        return {
-                            "day": week_match.group(1),
-                            "week": int(week_match.group(2))
-                        }
-            
-            return None
-            
-        except Exception as e:
-            print(f"Selenium approach failed for green bin: {e}")
-            return None
-
-    def get_next_collection_dates(self, collection_day, num_weeks=8):
-        """Calculate the next collection dates for a given day of the week."""
-        today = datetime.now()
-        days_of_week = {
-            "Monday": 0, "Tuesday": 1, "Wednesday": 2, "Thursday": 3,
-            "Friday": 4, "Saturday": 5, "Sunday": 6
-        }
-        
-        target_day = days_of_week.get(collection_day, 0)
-        current_weekday = today.weekday()
-        
-        # Calculate days until next collection day
-        days_until = (target_day - current_weekday) % 7
-        if days_until == 0:  # If today is the collection day, get next week's
-            days_until = 7
-            
-        next_collection = today + timedelta(days=days_until)
-        
-        # Generate collection dates for the specified number of weeks
-        collection_dates = []
-        for week in range(num_weeks):
-            collection_date = next_collection + timedelta(weeks=week)
-            collection_dates.append(collection_date.strftime("%d/%m/%Y"))
-            
-        return collection_dates
-
-    def get_green_bin_collection_dates(self, green_bin_info, num_weeks=8):
-        """Calculate green bin collection dates based on OCR-extracted calendar data."""
-        if not green_bin_info:
-            return []
-        
-        # First, try to get green bin collection dates from OCR-parsed calendar data
-        calendar_data = self.parse_calendar_images()
-        green_bin_data = calendar_data.get('green_bin_info', {})
-        
-        if green_bin_data and 'collection_dates' in green_bin_data:
-            # Use OCR-extracted collection dates
-            collection_dates = green_bin_data['collection_dates']
-            
-            # Filter to future dates and limit to requested number
-            today = datetime.now()
-            future_dates = []
-            
-            for date_str in collection_dates:
-                try:
-                    date_obj = datetime.strptime(date_str, "%d/%m/%Y")
-                    if date_obj >= today:
-                        future_dates.append(date_str)
-                        if len(future_dates) >= num_weeks:
-                            break
-                except ValueError:
-                    continue
-            
-            if future_dates:
-                print(f"Using OCR-extracted green bin collection dates: {future_dates}")
-                return future_dates
-        
-        # Fallback to mathematical calculation if OCR data not available
-        print("Using mathematical calculation for green bin collection dates")
-        return self.calculate_green_bin_dates_mathematically(green_bin_info, num_weeks)
-
-    def calculate_green_bin_dates_mathematically(self, green_bin_info, num_weeks=8):
-        """Calculate green bin collection dates using mathematical approach (fallback)."""
-        today = datetime.now()
-        days_of_week = {
-            "Monday": 0, "Tuesday": 1, "Wednesday": 2, "Thursday": 3,
-            "Friday": 4, "Saturday": 5, "Sunday": 6
-        }
-        
-        target_day = days_of_week.get(green_bin_info["day"], 1)
-        target_week = green_bin_info["week"]
-        
-        # Find the next occurrence of the target day in the target week
-        collection_dates = []
-        current_date = today
-        
-        # Look ahead for the specified number of weeks
-        for month_offset in range(num_weeks + 1):  # Look ahead enough months
-            # Start from the first day of each month
-            if month_offset == 0:
-                # Current month
-                start_date = current_date.replace(day=1)
-            else:
-                # Future months
-                next_month = current_date.month + month_offset
-                next_year = current_date.year
-                while next_month > 12:
-                    next_month -= 12
-                    next_year += 1
-                start_date = current_date.replace(year=next_year, month=next_month, day=1)
-            
-            # Find the target day in the target week of this month
-            for day in range(1, 32):  # Check all possible days
-                try:
-                    candidate_date = start_date.replace(day=day)
-                    
-                    # Check if this is the target day of the week
-                    if candidate_date.weekday() == target_day:
-                        # Determine which week of the month this is (1 or 2)
-                        week_of_month = ((candidate_date.day - 1) // 7) + 1
-                        
-                        # If this matches our target week and is in the future, add it
-                        if week_of_month == target_week and candidate_date >= current_date:
-                            collection_dates.append(candidate_date.strftime("%d/%m/%Y"))
-                            if len(collection_dates) >= num_weeks:
-                                return collection_dates
-                            break  # Found the target day for this month, move to next month
-                            
-                except ValueError:
-                    # Invalid date (e.g., Feb 30), skip
-                    continue
-                    
-        return collection_dates
-
-    def get_calendar_links(self):
-        """Get the current calendar links from the South Kesteven website."""
-        try:
-            # URL of the bin day checker page
-            bin_day_url = "https://pre.southkesteven.gov.uk/skdcNext/tempforms/checkmybin.aspx"
-            
-            print("Fetching calendar links from South Kesteven website...")
-            
-            # Get the page content
-            response = requests.get(bin_day_url, timeout=30)
-            if response.status_code != 200:
-                print(f"Failed to fetch bin day page: {response.status_code}")
-                return None, None
-            
-            # Parse the HTML to find calendar links
-            soup = BeautifulSoup(response.content, 'html.parser')
-            
-            # Look for links containing calendar-related text
-            calendar_links = {}
-            
-            # Find all links on the page
-            links = soup.find_all('a', href=True)
-            for link in links:
-                href = link.get('href', '')
-                text = link.get_text(strip=True).lower()
-                
-                # Check for regular bin calendar link
-                if 'black' in text and 'silver' in text and 'purple' in text:
-                    if href.startswith('http'):
-                        calendar_links['regular'] = href
-                    elif href.startswith('/'):
-                        calendar_links['regular'] = f"https://www.southkesteven.gov.uk{href}"
-                
-                # Check for green bin calendar link
-                elif 'green' in text and 'bin' in text:
-                    if href.startswith('http'):
-                        calendar_links['green'] = href
-                    elif href.startswith('/'):
-                        calendar_links['green'] = f"https://www.southkesteven.gov.uk{href}"
-            
-            # Also look for links with specific patterns
-            for link in links:
-                href = link.get('href', '')
-                text = link.get_text(strip=True).lower()
-                
-                # Look for calendar-related links
-                if 'calendar' in href.lower() or 'collection' in href.lower() or 'calendar' in text:
-                    if 'black' in href.lower() or 'silver' in href.lower() or 'purple' in href.lower() or 'black' in text or 'silver' in text or 'purple' in text:
-                        if href.startswith('http'):
-                            calendar_links['regular'] = href
-                        elif href.startswith('/'):
-                            calendar_links['regular'] = f"https://www.southkesteven.gov.uk{href}"
-                    elif 'green' in href.lower() or 'green' in text:
-                        if href.startswith('http'):
-                            calendar_links['green'] = href
-                        elif href.startswith('/'):
-                            calendar_links['green'] = f"https://www.southkesteven.gov.uk{href}"
-                
-                # Look for direct links to calendar images
-                if href.lower().endswith('.jpg') or href.lower().endswith('.png') or href.lower().endswith('.pdf'):
-                    if 'black' in href.lower() or 'silver' in href.lower() or 'purple' in href.lower() or 'bin' in href.lower():
-                        if href.startswith('http'):
-                            calendar_links['regular'] = href
-                        elif href.startswith('/'):
-                            calendar_links['regular'] = f"https://www.southkesteven.gov.uk{href}"
-                    elif 'green' in href.lower():
-                        if href.startswith('http'):
-                            calendar_links['green'] = href
-                        elif href.startswith('/'):
-                            calendar_links['green'] = f"https://www.southkesteven.gov.uk{href}"
-            
-            regular_url = calendar_links.get('regular')
-            green_url = calendar_links.get('green')
-            
-            if regular_url:
-                print(f"Found regular bin calendar: {regular_url}")
-            else:
-                print("Could not find regular bin calendar link")
-            
-            if green_url:
-                print(f"Found green bin calendar: {green_url}")
-            else:
-                print("Could not find green bin calendar link")
-            
-            return regular_url, green_url
-            
-        except Exception as e:
-            print(f"Error fetching calendar links: {e}")
-            return None, None
-
-    def download_calendar_images(self):
-        """Download the calendar images from South Kesteven website."""
-        try:
-            # Get the current calendar links
-            regular_calendar_url, green_calendar_url = self.get_calendar_links()
-            
-            if not regular_calendar_url and not green_calendar_url:
-                print("Could not find any calendar links")
-                return False
-            
-            print("Downloading calendar images...")
-            success = True
-            
-            # Download regular bin calendar
-            if regular_calendar_url:
-                try:
-                    regular_response = requests.get(regular_calendar_url, timeout=30)
-                    if regular_response.status_code == 200:
-                        # Validate that this is actually a calendar image
-                        if self.validate_calendar_image(regular_response.content, 'regular'):
-                            with open("south_kesteven_regular_calendar.jpg", "wb") as f:
-                                f.write(regular_response.content)
-                            print("Downloaded regular bin calendar")
-                        else:
-                            print("Downloaded file is not a valid calendar image")
-                            success = False
-                    else:
-                        print(f"Failed to download regular calendar: {regular_response.status_code}")
-                        success = False
-                except Exception as e:
-                    print(f"Error downloading regular calendar: {e}")
-                    success = False
-            else:
-                print("No regular bin calendar URL found")
-            
-            # Download green bin calendar
-            if green_calendar_url:
-                try:
-                    green_response = requests.get(green_calendar_url, timeout=30)
-                    if green_response.status_code == 200:
-                        # Validate that this is actually a calendar image
-                        if self.validate_calendar_image(green_response.content, 'green'):
-                            with open("south_kesteven_green_calendar.jpg", "wb") as f:
-                                f.write(green_response.content)
-                            print("Downloaded green bin calendar")
-                        else:
-                            print("Downloaded file is not a valid calendar image")
-                            success = False
-                    else:
-                        print(f"Failed to download green calendar: {green_response.status_code}")
-                        success = False
-                except Exception as e:
-                    print(f"Error downloading green calendar: {e}")
-                    success = False
-            else:
-                print("No green bin calendar URL found")
-                
-            return success
-            
-        except Exception as e:
-            print(f"Error downloading calendar images: {e}")
-            return False
-
-    def validate_calendar_image(self, content, calendar_type):
-        """Validate that the downloaded content is actually a calendar image."""
-        try:
-            # Check if content is not empty
-            if not content or len(content) < 1000:  # Minimum size for a valid image
-                return False
-            
-            # Check if it's a valid image file (JPEG/PNG)
-            if content.startswith(b'\xff\xd8\xff'):  # JPEG
-                return True
-            elif content.startswith(b'\x89PNG'):  # PNG
-                return True
-            elif content.startswith(b'%PDF'):  # PDF
-                return True
-            
-            # For now, accept any non-empty content as valid
-            # In a full implementation, you could add more sophisticated validation
-            return True
-            
-        except Exception as e:
-            print(f"Error validating calendar image: {e}")
-            return False
-
-    def download_calendar_images_fallback(self):
-        """Fallback method to download calendar images using alternative approaches."""
-        try:
-            print("Trying alternative calendar link discovery methods...")
-            success = True
-            
-            # Try alternative methods to find calendar links
-            alternative_urls = self.get_alternative_calendar_links()
-            
-            if not alternative_urls['regular'] and not alternative_urls['green']:
-                print("No alternative calendar links found")
-                return False
-            
-            # Try regular bin calendar
-            regular_downloaded = False
-            if alternative_urls['regular']:
-                for url in alternative_urls['regular']:
-                    try:
-                        response = requests.get(url, timeout=30)
-                        if response.status_code == 200:
-                            # Validate that this is actually a calendar image
-                            if self.validate_calendar_image(response.content, 'regular'):
-                                with open("south_kesteven_regular_calendar.jpg", "wb") as f:
-                                    f.write(response.content)
-                                print(f"Downloaded regular bin calendar from alternative source: {url}")
-                                regular_downloaded = True
-                                break
-                            else:
-                                print(f"Alternative URL returned invalid calendar image: {url}")
-                    except Exception as e:
-                        print(f"Alternative URL failed: {url} - {e}")
-                        continue
-            
-            if not regular_downloaded:
-                print("All regular bin calendar alternative URLs failed")
-                success = False
-            
-            # Try green bin calendar
-            green_downloaded = False
-            if alternative_urls['green']:
-                for url in alternative_urls['green']:
-                    try:
-                        response = requests.get(url, timeout=30)
-                        if response.status_code == 200:
-                            # Validate that this is actually a calendar image
-                            if self.validate_calendar_image(response.content, 'green'):
-                                with open("south_kesteven_green_calendar.jpg", "wb") as f:
-                                    f.write(response.content)
-                                print(f"Downloaded green bin calendar from alternative source: {url}")
-                                green_downloaded = True
-                                break
-                            else:
-                                print(f"Alternative URL returned invalid calendar image: {url}")
-                    except Exception as e:
-                        print(f"Alternative URL failed: {url} - {e}")
-                        continue
-            
-            if not green_downloaded:
-                print("All green bin calendar alternative URLs failed")
-                success = False
-            
-            return success
-            
-        except Exception as e:
-            print(f"Error in fallback download: {e}")
-            return False
-
-    def get_alternative_calendar_links(self):
-        """Try alternative methods to find calendar links."""
-        try:
-            alternative_urls = {'regular': [], 'green': []}
-            
-            # Method 1: Try the main South Kesteven website
-            main_url = "https://www.southkesteven.gov.uk/binday"
-            try:
-                response = requests.get(main_url, timeout=30)
-                if response.status_code == 200:
-                    soup = BeautifulSoup(response.content, 'html.parser')
-                    links = soup.find_all('a', href=True)
-                    
-                    for link in links:
-                        href = link.get('href', '')
-                        text = link.get_text(strip=True).lower()
-                        
-                        if 'calendar' in href.lower() or 'collection' in href.lower():
-                            if 'black' in href.lower() or 'silver' in href.lower() or 'purple' in href.lower():
-                                if href.startswith('http'):
-                                    alternative_urls['regular'].append(href)
-                                elif href.startswith('/'):
-                                    alternative_urls['regular'].append(f"https://www.southkesteven.gov.uk{href}")
-                            elif 'green' in href.lower():
-                                if href.startswith('http'):
-                                    alternative_urls['green'].append(href)
-                                elif href.startswith('/'):
-                                    alternative_urls['green'].append(f"https://www.southkesteven.gov.uk{href}")
-            except Exception as e:
-                print(f"Failed to check main website: {e}")
-            
-            # Method 2: Try searching for calendar files in common directories
-            base_urls = [
-                "https://www.southkesteven.gov.uk/sites/default/files/",
-                "https://www.southkesteven.gov.uk/files/",
-                "https://www.southkesteven.gov.uk/documents/"
-            ]
-            
-            # Common calendar file patterns
-            calendar_patterns = {
-                'regular': [
-                    "Black%2C%20Silver%2C%20Purple-lid%20bin%20collections%20calendar.jpg",
-                    "Black_Silver_Purple_bin_collections_calendar.jpg",
-                    "bin-collections-calendar.jpg",
-                    "waste-collection-calendar.jpg"
-                ],
-                'green': [
-                    "Green%20Bin%20garden%20recycling%20collection%20calendar.jpg",
-                    "Green_Bin_garden_recycling_collection_calendar.jpg",
-                    "green-bin-calendar.jpg",
-                    "garden-waste-calendar.jpg"
-                ]
-            }
-            
-            for base_url in base_urls:
-                for year in ['2025', '2024', '2023']:
-                    for month in ['08', '09', '10']:
-                        for pattern_type, patterns in calendar_patterns.items():
-                            for pattern in patterns:
-                                test_url = f"{base_url}{year}-{month}/{pattern}"
-                                alternative_urls[pattern_type].append(test_url)
-            
-            return alternative_urls
-            
-        except Exception as e:
-            print(f"Error getting alternative calendar links: {e}")
-            return {'regular': [], 'green': []}
-
-    def parse_calendar_images(self):
-        """Parse the static calendar images to extract bin collection data."""
-        try:
-            # First, try to download the calendar images with dynamic links
-            if not self.download_calendar_images():
-                print("Dynamic download failed, trying fallback links...")
-                # Try with known fallback links
-                if not self.download_calendar_images_fallback():
-                    print("All download methods failed, using fallback calendar data...")
-                    return self.get_fallback_calendar_data()
-            
-            # Now use OCR to parse the actual calendar images
-            print("Parsing calendar images with OCR...")
-            
-            # Try to parse regular bin calendar
-            regular_calendar_data = {}
-            if os.path.exists("south_kesteven_regular_calendar.jpg"):
-                regular_calendar_data = self.parse_calendar_with_ocr("south_kesteven_regular_calendar.jpg", "regular")
-            
-            # Try to parse green bin calendar
-            green_calendar_data = {}
-            if os.path.exists("south_kesteven_green_calendar.jpg"):
-                green_calendar_data = self.parse_calendar_with_ocr("south_kesteven_green_calendar.jpg", "green")
-            
-            # Combine the data
-            calendar_data = regular_calendar_data
-            
-            # Add green bin information if available
-            if green_calendar_data:
-                calendar_data['green_bin_info'] = green_calendar_data
-            
-            # If OCR didn't work, raise an error
-            if not calendar_data or not any(key.isdigit() for key in calendar_data.keys()):
-                raise ValueError("Failed to parse calendar images with OCR. Cannot determine bin types without calendar data.")
-            
-            print("Calendar data parsed from images")
-            return calendar_data
-            
-        except Exception as e:
-            print(f"Error parsing calendar images: {e}")
-            return self.get_fallback_calendar_data()
-
-    def get_fallback_calendar_data(self):
-        """Fallback calendar data if image parsing fails."""
-        return {
-            "2025": {
-                "10": {
-                    "2": "Silver bin (Recycling)",
-                    "3": "Black bin (General waste)",
-                    "4": "Purple-lidded bin (Paper & Card)"
-                }
-            }
-        }
-
-    def initialize_ocr(self):
-        """Initialize EasyOCR reader."""
-        if not HAS_OCR:
-            print("OCR dependencies not available. Install with: pip install uk_bin_collection[ocr]")
-            return None
-        try:
-            if not hasattr(self, 'ocr_reader'):
-                print("Initializing OCR reader...")
-                self.ocr_reader = easyocr.Reader(['en'])
-                print("OCR reader initialized successfully")
-            return self.ocr_reader
-        except Exception as e:
-            print(f"Failed to initialize OCR: {e}")
-            return None
-
-    def preprocess_image(self, image_path):
-        """Preprocess image for better OCR results."""
-        try:
-            # Read image
-            image = cv2.imread(image_path)
-            if image is None:
-                return None
-            
-            # Convert to grayscale
-            gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
-            
-            # Apply denoising
-            denoised = cv2.fastNlMeansDenoising(gray)
-            
-            # Apply threshold to get binary image
-            _, binary = cv2.threshold(denoised, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU)
-            
-            # Morphological operations to clean up
-            kernel = np.ones((1, 1), np.uint8)
-            cleaned = cv2.morphologyEx(binary, cv2.MORPH_CLOSE, kernel)
-            
-            return cleaned
-        except Exception as e:
-            print(f"Error preprocessing image: {e}")
-            return None
-
-    def extract_text_from_calendar(self, image_path):
-        """Extract text from calendar image using OCR."""
-        try:
-            reader = self.initialize_ocr()
-            if not reader:
-                return []
-            
-            # Preprocess image
-            processed_image = self.preprocess_image(image_path)
-            if processed_image is None:
-                return []
-            
-            # Perform OCR
-            results = reader.readtext(processed_image)
-            
-            # Extract text and confidence scores
-            extracted_text = []
-            for (bbox, text, confidence) in results:
-                if confidence > 0.5:  # Filter low confidence results
-                    extracted_text.append({
-                        'text': text.strip(),
-                        'confidence': confidence,
-                        'bbox': bbox
-                    })
-            
-            return extracted_text
-        except Exception as e:
-            print(f"Error extracting text from calendar: {e}")
-            return []
-
-    def parse_calendar_with_ocr(self, image_path, calendar_type='regular'):
-        """Parse calendar image using OCR to extract collection information."""
-        try:
-            print(f"Parsing {calendar_type} calendar with OCR...")
-            
-            # Extract text from image
-            extracted_text = self.extract_text_from_calendar(image_path)
-            
-            if not extracted_text:
-                print(f"No text extracted from {calendar_type} calendar")
-                return {}
-            
-            print(f"Extracted {len(extracted_text)} text elements from {calendar_type} calendar")
-            
-            # Parse the extracted text to find collection information
-            calendar_data = {}
-            
-            if calendar_type == 'regular':
-                calendar_data = self.parse_regular_calendar_text(extracted_text)
-            elif calendar_type == 'green':
-                calendar_data = self.parse_green_calendar_text(extracted_text)
-            
-            return calendar_data
-            
-        except Exception as e:
-            print(f"Error parsing {calendar_type} calendar with OCR: {e}")
-            return {}
-
-    def parse_regular_calendar_text(self, extracted_text):
-        """Parse regular bin calendar text to extract collection patterns."""
-        calendar_data = {}
-        
-        # Look for month names and collection patterns
-        months = ['january', 'february', 'march', 'april', 'may', 'june',
-                 'july', 'august', 'september', 'october', 'november', 'december']
-        
-        bin_types = ['black', 'silver', 'purple', 'recycling', 'general', 'waste']
-        
-        # Track all years and months found
-        found_years = set()
-        found_months = set()
-        
-        for item in extracted_text:
-            text = item['text'].lower()
-            
-            # Look for years
-            if '2025' in text:
-                found_years.add('2025')
-            if '2026' in text:
-                found_years.add('2026')
-            
-            # Look for months
-            for i, month in enumerate(months, 1):
-                if month in text:
-                    found_months.add(str(i))
-        
-        print(f"Found years: {found_years}")
-        print(f"Found months: {found_months}")
-        
-        # Create calendar data for all found years and months
-        for year in found_years:
-            calendar_data[year] = {}
-            for month in found_months:
-                calendar_data[year][month] = {
-                    "1": "Black bin (General waste)",
-                    "2": "Silver bin (Recycling)", 
-                    "3": "Purple-lidded bin (Paper & Card)",
-                    "4": "Black bin (General waste)"
-                }
-        
-        return calendar_data
-
-    def parse_green_calendar_text(self, extracted_text):
-        """Parse green bin calendar text to extract collection dates and seasonal breaks."""
-        green_bin_data = {}
-        
-        # Look for green bin collection indicators
-        green_indicators = ['green', 'garden', 'waste', 'collection']
-        break_indicators = ['break', 'suspended', 'no collection', 'winter']
-        
-        collection_dates = []
-        break_periods = []
-        
-        for item in extracted_text:
-            text = item['text'].lower()
-            
-            # Look for collection dates
-            if any(indicator in text for indicator in green_indicators):
-                # Extract dates from text
-                date_pattern = r'\b(\d{1,2})[\/\-](\d{1,2})[\/\-](\d{4})\b'
-                dates = re.findall(date_pattern, text)
-                for date in dates:
-                    collection_dates.append(f"{date[0]}/{date[1]}/{date[2]}")
-            
-            # Look for break periods
-            if any(indicator in text for indicator in break_indicators):
-                # Extract month names for break periods
-                months = ['january', 'february', 'march', 'december']
-                for month in months:
-                    if month in text:
-                        break_periods.append(month)
-        
-        # Structure the data
-        green_bin_data = {
-            'collection_dates': collection_dates,
-            'break_periods': break_periods,
-            'has_february_break': 'february' in break_periods
-        }
-        
-        return green_bin_data
-
-    def get_bin_type_from_calendar(self, collection_date, calendar_data=None):
-        """Determine the specific bin type from the parsed calendar data."""
-        try:
-            # Parse the date
-            date_obj = datetime.strptime(collection_date, "%d/%m/%Y")
-            year = str(date_obj.year)
-            month = str(date_obj.month)
-            day = date_obj.day
-            
-            # Determine which week of the month this is
-            week_of_month = str(((day - 1) // 7) + 1)
-            
-            # Use provided calendar data or get it if not provided
-            if calendar_data is None:
-                calendar_data = self.parse_calendar_images()
-            
-            # Look up the bin type from the calendar data
-            if year in calendar_data and month in calendar_data[year] and week_of_month in calendar_data[year][month]:
-                return calendar_data[year][month][week_of_month]
-            else:
-                # Raise error if not found in calendar instead of fallback
-                raise ValueError(f"No bin type found for {collection_date} (Week {week_of_month} of {month}/{year})")
-                
-        except Exception as e:
-            print(f"Error determining bin type for {collection_date}: {e}")
-            raise
+    BIN_DAY_URL = "https://www.southkesteven.gov.uk/binday"
+    CHECKER_LINK_TEXT = "Postcode bin day checker"
+    BIN_TYPE_MAP = {
+        "240 Litre Recycling": "Grey Bin",
+        "23lt Food Caddy": "Food Bin",
+        "240 Litre Refuse": "Black Bin",
+        "240 Litre Paper and Card": "Purple Bin",
+    }
+    ADDRESS_VALUE_ID = "FF5265"
+    POSTCODE_INPUT_ID = "FF5265-text"
+    SEARCH_BUTTON_ID = "FF5265-find"
+    ADDRESS_SELECT_ID = "FF5265-list"
+    ADDRESS_DISPLAY_ID = "FF5265-displayname"
+    CHANGE_BUTTON_ID = "FF5265-change"
+    SUBMIT_BUTTON_ID = "submit-button"
+    BODY_CONTENT_ID = "body-content"
+    CURRENT_SECTION_ID = "current-section-id"
+    DEFAULT_ARTIFACT_ROOT = "artifacts/SouthKestevenDistrictCouncil"
 
     def parse_data(self, page: str, **kwargs) -> dict:
+        binday_url = kwargs.get("url") or self.BIN_DAY_URL
+        postcode = kwargs.get("postcode")
+        paon = kwargs.get("paon")
+        web_driver = kwargs.get("web_driver")
+        user_agent = kwargs.get("user_agent")
+        headless = kwargs.get("headless", True)
+        artifact_root = self._get_artifact_root(kwargs.get("artifact_dir"))
+
+        if headless is None:
+            headless = True
+
+        if not postcode:
+            raise ValueError("Postcode is required for South Kesteven.")
+        if not paon:
+            raise ValueError(
+                "Property number or name (paon) is required for South Kesteven."
+            )
+
+        checker_url = self._resolve_checker_url(binday_url, page=page, user_agent=user_agent)
+
+        driver = create_webdriver(web_driver, headless, user_agent, __name__)
         try:
-            user_postcode = kwargs.get("postcode")
+            wait = WebDriverWait(driver, 30)
+            driver.get(checker_url)
 
-            # Validate postcode
-            if not user_postcode:
-                raise ValueError("Postcode is required for South Kesteven")
+            postcode_input = self._wait_for_clickable(
+                wait,
+                (By.ID, self.POSTCODE_INPUT_ID),
+                "Unable to find the postcode input on the South Kesteven checker.",
+            )
+            postcode_input.clear()
+            postcode_input.send_keys(postcode)
 
-            # No WebDriver needed - using requests-based approach
-            
-            # Get collection day for regular bins
-            collection_day = self.get_collection_day_from_postcode(None, user_postcode)
-            if not collection_day:
-                raise ValueError(f"Could not determine collection day for postcode {user_postcode}")
+            initial_section_id = self._get_current_section_id(driver)
+            initial_body_markup = self._get_body_markup(driver)
 
-            # Get green bin info
-            green_bin_info = self.get_green_bin_info_from_postcode(None, user_postcode)
+            search_button = self._wait_for_clickable(
+                wait,
+                (By.ID, self.SEARCH_BUTTON_ID),
+                "Unable to find the search button after entering the postcode.",
+            )
+            search_button.click()
 
-            bin_data = []
+            address_select = self._wait_for_address_options(wait)
+            self._select_address(address_select, paon)
+            self._wait_for_address_confirmation(wait)
 
-            # Parse the calendar data once and cache it
-            calendar_data = self.parse_calendar_images()
+            submit_button = self._wait_for_clickable(
+                wait,
+                (By.ID, self.SUBMIT_BUTTON_ID),
+                "Unable to find the submit button after selecting the address.",
+            )
+            submit_button.click()
+            self._wait_for_results_container(
+                wait,
+                initial_section_id,
+                initial_body_markup,
+            )
 
-            # Generate collection dates for regular bins (black, silver, purple)
-            regular_collection_dates = self.get_next_collection_dates(collection_day, 8)
-            
-            for date in regular_collection_dates:
-                # Parse the static calendar to determine the specific bin type
-                bin_type = self.get_bin_type_from_calendar(date, calendar_data)
-                bin_data.append({
-                    "type": bin_type,
-                    "collectionDate": date
-                })
-            
-            # Generate collection dates for green bin if available
-            if green_bin_info:
-                # For green bins, we need to find the bi-weekly collections
-                # Green bins are collected bi-weekly on the specified week pattern
-                # (e.g., "Week 2" means 2nd and 4th Thursdays of each month)
-                # Create a copy of bin_data to iterate over to avoid infinite loop
-                regular_bins = bin_data.copy()
-                for bin_entry in regular_bins:
-                    date = bin_entry["collectionDate"]
-                    date_obj = datetime.strptime(date, "%d/%m/%Y")
-                    week_of_month = ((date_obj.day - 1) // 7) + 1
-                    
-                    # If this is a Week 2 or Week 4 collection, add green bin to the same day
-                    # (bi-weekly pattern: Week 2 and Week 4 of each month)
-                    if week_of_month == green_bin_info["week"] or week_of_month == green_bin_info["week"] + 2:
-                        bin_data.append({
-                            "type": "Green bin (Garden waste)",
-                            "collectionDate": date
-                        })
-                
-                # Also add the standalone green bin collections (Week 2 of each month)
-                # but only if they don't conflict with regular bin collections
-                green_collection_dates = self.get_green_bin_collection_dates(green_bin_info, 8)
-                for date in green_collection_dates:
-                    # Check if this green bin date is not already in the bin_data
-                    already_exists = any(bin_entry["collectionDate"] == date for bin_entry in bin_data)
-                    if not already_exists:
-                        bin_data.append({
-                            "type": "Green bin (Garden waste)",
-                            "collectionDate": date
-                        })
+            return {"bins": self._parse_collection_rows(driver.page_source)}
+        except Exception as exc:
+            artifact_path = self._capture_debug_artifacts(
+                driver,
+                artifact_root,
+                {"postcode": postcode, "paon": paon, "binday_url": binday_url},
+            )
+            raise RuntimeError(
+                self._with_artifact_hint(str(exc), artifact_path)
+            ) from exc
+        finally:
+            if driver:
+                driver.quit()
 
-            result = {"bins": bin_data}
+    def _wait_for_clickable(self, wait, locator, error_message):
+        try:
+            return wait.until(EC.element_to_be_clickable(locator))
+        except TimeoutException as exc:
+            raise RuntimeError(error_message) from exc
 
-        except Exception as e:
-            print(f"An error occurred: {e}")
-            raise
-        
-        return result
+    def _wait_for_presence(self, wait, locator, error_message):
+        try:
+            return wait.until(EC.presence_of_element_located(locator))
+        except TimeoutException as exc:
+            raise RuntimeError(error_message) from exc
+
+    def _resolve_checker_url(
+        self, binday_url: str, page: str | object | None = None, user_agent: str | None = None
+    ) -> str:
+        html = self._get_binday_html(binday_url, page=page, user_agent=user_agent)
+        soup = BeautifulSoup(html, "html.parser")
+
+        for link in soup.find_all("a", href=True):
+            link_text = link.get_text(" ", strip=True).lower()
+            if self.CHECKER_LINK_TEXT.lower() in link_text:
+                return urljoin(binday_url, link["href"])
+
+        raise RuntimeError(
+            "Unable to find the postcode bin day checker link on the binday page."
+        )
+
+    def _get_binday_html(
+        self, binday_url: str, page: str | object | None = None, user_agent: str | None = None
+    ) -> str:
+        if hasattr(page, "text"):
+            html = str(page.text)
+        elif isinstance(page, str) and page.strip():
+            html = page
+        else:
+            headers = {}
+            if user_agent:
+                headers["User-Agent"] = user_agent
+            try:
+                response = requests.get(binday_url, headers=headers, timeout=30)
+                response.raise_for_status()
+            except RequestException as exc:
+                raise RuntimeError(
+                    f"Unable to load the South Kesteven binday page at {binday_url}."
+                ) from exc
+            html = response.text
+
+        if not html.strip():
+            raise RuntimeError(
+                f"Unable to load the South Kesteven binday page at {binday_url}."
+            )
+
+        return html
+
+    def _wait_for_address_options(self, wait):
+        try:
+            return wait.until(self._address_options_ready)
+        except TimeoutException as exc:
+            raise RuntimeError(
+                "Unable to find the address dropdown after searching for the postcode."
+            ) from exc
+
+    def _address_options_ready(self, driver):
+        try:
+            address_select = driver.find_element(By.ID, self.ADDRESS_SELECT_ID)
+        except NoSuchElementException:
+            return False
+
+        if not address_select.is_displayed():
+            return False
+
+        options = [option for option in Select(address_select).options if option.text.strip()]
+        return address_select if options else False
+
+    def _wait_for_address_confirmation(self, wait):
+        try:
+            return wait.until(self._address_confirmation_ready)
+        except TimeoutException as exc:
+            raise RuntimeError(
+                "Unable to confirm the selected address before submitting the lookup."
+            ) from exc
+
+    def _address_confirmation_ready(self, driver):
+        try:
+            address_value = driver.find_element(By.ID, self.ADDRESS_VALUE_ID)
+            change_button = driver.find_element(By.ID, self.CHANGE_BUTTON_ID)
+        except NoSuchElementException:
+            return False
+
+        selected_value = (address_value.get_attribute("value") or "").strip()
+        if selected_value and change_button.is_displayed():
+            return True
+
+        try:
+            display_name = driver.find_element(By.ID, self.ADDRESS_DISPLAY_ID)
+        except NoSuchElementException:
+            return False
+
+        return bool((display_name.text or "").strip()) and change_button.is_displayed()
+
+    def _wait_for_results_container(
+        self, wait, initial_section_id: str | None, initial_body_markup: str
+    ):
+        try:
+            return wait.until(
+                lambda driver: self._results_container_ready(
+                    driver,
+                    initial_section_id,
+                    initial_body_markup,
+                )
+            )
+        except TimeoutException as exc:
+            raise RuntimeError(
+                "Unable to load the collection results after submitting the address."
+            ) from exc
+
+    def _results_container_ready(
+        self, driver, initial_section_id: str | None, initial_body_markup: str
+    ):
+        try:
+            body_markup = self._get_body_markup(driver)
+        except RuntimeError:
+            return False
+
+        if not body_markup or body_markup == initial_body_markup:
+            return False
+
+        current_section_id = self._get_current_section_id(driver)
+        section_changed = bool(
+            initial_section_id and current_section_id and current_section_id != initial_section_id
+        )
+        address_form_gone = self.POSTCODE_INPUT_ID not in body_markup
+        has_collection_markup = "alloy-table" in body_markup.lower() or "your collections" in body_markup.lower()
+
+        return address_form_gone and (section_changed or has_collection_markup)
+
+    def _select_address(self, address_select, paon: str) -> None:
+        target = str(paon).strip().lower()
+        select = Select(address_select)
+
+        for option in select.options:
+            option_text = option.text.strip().lower()
+            if target in option_text:
+                select.select_by_visible_text(option.text)
+                return
+
+        raise RuntimeError(
+            f"Unable to find the property '{paon}' in the address dropdown."
+        )
+
+    def _get_current_section_id(self, driver) -> str | None:
+        try:
+            return driver.find_element(By.ID, self.CURRENT_SECTION_ID).get_attribute("value")
+        except NoSuchElementException:
+            return None
+
+    def _get_body_markup(self, driver) -> str:
+        try:
+            body_content = driver.find_element(By.ID, self.BODY_CONTENT_ID)
+        except NoSuchElementException as exc:
+            raise RuntimeError("Unable to find the body-content container on the checker page.") from exc
+
+        return body_content.get_attribute("innerHTML") or ""
+
+    def _get_artifact_root(self, artifact_dir: str | None) -> Path:
+        if artifact_dir:
+            return Path(artifact_dir)
+        return Path.cwd() / self.DEFAULT_ARTIFACT_ROOT
+
+    def _capture_debug_artifacts(
+        self, driver, artifact_root: Path, context: dict[str, str]
+    ) -> Path | None:
+        if not driver:
+            return None
+
+        timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+        artifact_path = artifact_root / timestamp
+        artifact_path.mkdir(parents=True, exist_ok=True)
+
+        metadata = {
+            "current_url": str(getattr(driver, "current_url", "")) or None,
+            **context,
+        }
+
+        screenshot_path = artifact_path / "page.png"
+        html_path = artifact_path / "page.html"
+        metadata_path = artifact_path / "metadata.json"
+
+        try:
+            html_path.write_text(driver.page_source, encoding="utf-8")
+        except Exception as exc:
+            metadata["page_html_error"] = str(exc)
+
+        try:
+            metadata["screenshot_saved"] = bool(driver.save_screenshot(str(screenshot_path)))
+        except Exception as exc:
+            metadata["screenshot_error"] = str(exc)
+
+        metadata_path.write_text(json.dumps(metadata, indent=4), encoding="utf-8")
+        return artifact_path.resolve()
+
+    def _with_artifact_hint(self, message: str, artifact_path: Path | None) -> str:
+        if artifact_path is None:
+            return message
+        return f"{message} Debug artifacts saved to: {artifact_path}"
+
+    def _normalize_bin_type(self, raw_bin_type: str) -> str:
+        return self.BIN_TYPE_MAP.get(raw_bin_type, raw_bin_type)
+
+    def _parse_collection_rows(self, page_source: str) -> list[dict]:
+        soup = BeautifulSoup(page_source, "html.parser")
+        bins = []
+
+        body_content = soup.find(id=self.BODY_CONTENT_ID) or soup
+        for table in body_content.find_all("table"):
+            for row in table.find_all("tr"):
+                cols = row.find_all("td")
+                if len(cols) < 2:
+                    continue
+
+                raw_date = cols[0].get_text(" ", strip=True).replace(",", "")
+                raw_bin_type = cols[1].get_text(" ", strip=True)
+
+                try:
+                    collection_date = datetime.strptime(
+                        raw_date, "%A %d %B %Y"
+                    ).strftime(date_format)
+                except ValueError:
+                    continue
+
+                bins.append(
+                    {
+                        "type": self._normalize_bin_type(raw_bin_type),
+                        "collectionDate": collection_date,
+                    }
+                )
+
+        if not bins:
+            raise RuntimeError(
+                "Unable to find any collection rows on the South Kesteven results page."
+            )
+
+        return bins

--- a/uk_bin_collection/uk_bin_collection/councils/tests/conftest.py
+++ b/uk_bin_collection/uk_bin_collection/councils/tests/conftest.py
@@ -2,6 +2,8 @@
 Pytest configuration for South Kesteven District Council tests.
 """
 
+import os
+
 import pytest
 
 
@@ -14,14 +16,39 @@ def pytest_configure(config):
 
 def pytest_collection_modifyitems(config, items):
     """Modify test collection to handle integration tests."""
-    # Integration tests no longer require Selenium for South Kesteven
-    # They use requests-based form submission instead
     pass
 
 
 @pytest.fixture
 def test_postcode():
     """Provide a test postcode for South Kesteven."""
-    return "PE6 8BL"
+    return os.environ.get("UKBC_TEST_POSTCODE", "NG31 8XG")
 
 
+@pytest.fixture
+def test_paon():
+    """Provide a test property number for South Kesteven."""
+    return os.environ.get("UKBC_TEST_PAON", "43")
+
+
+@pytest.fixture
+def test_url():
+    """Provide a target URL for South Kesteven local validation."""
+    return os.environ.get("UKBC_TEST_URL", "https://www.southkesteven.gov.uk/binday")
+
+
+@pytest.fixture
+def test_web_driver():
+    """Provide an optional remote Selenium WebDriver URL."""
+    return os.environ.get("UKBC_TEST_WEB_DRIVER") or None
+
+
+@pytest.fixture
+def test_headless():
+    """Provide a bool-ish headless setting from the local validation environment."""
+    return os.environ.get("UKBC_TEST_HEADLESS", "true").strip().lower() not in {
+        "0",
+        "false",
+        "no",
+        "off",
+    }

--- a/uk_bin_collection/uk_bin_collection/councils/tests/test_south_kesteven_district_council.py
+++ b/uk_bin_collection/uk_bin_collection/councils/tests/test_south_kesteven_district_council.py
@@ -1,249 +1,316 @@
-"""
-Tests for South Kesteven District Council implementation.
-"""
+"""Unit tests for the South Kesteven District Council live checker flow."""
+
+import json
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
-from datetime import datetime, timedelta
-from unittest.mock import Mock, patch, MagicMock
-from bs4 import BeautifulSoup
+from selenium.webdriver.common.by import By
 
-from uk_bin_collection.uk_bin_collection.councils.SouthKestevenDistrictCouncil import CouncilClass
+from uk_bin_collection.uk_bin_collection.councils.SouthKestevenDistrictCouncil import (
+    CouncilClass,
+)
+
+MODULE_PATH = "uk_bin_collection.uk_bin_collection.councils.SouthKestevenDistrictCouncil"
+CHECKER_URL = (
+    "https://selfservice.southkesteven.gov.uk/renderform?"
+    "t=213&k=2074C945A63DDC0D18F1EB74DA230AC3122958B1"
+)
+BINDAY_HTML = f"""
+    <html>
+        <body>
+            <a href="{CHECKER_URL}">
+                <span>Postcode bin day checker</span>
+            </a>
+        </body>
+    </html>
+"""
+RESULTS_HTML = """
+    <html>
+        <div id="body-content">
+            <h1>Your Collections</h1>
+            <table class="Alloy-table">
+                <tr>
+                    <td>Thursday 16 April, 2026</td>
+                    <td>240 Litre Refuse</td>
+                </tr>
+                <tr>
+                    <td>Thursday 23 April, 2026</td>
+                    <td>240 Litre Recycling</td>
+                </tr>
+                <tr>
+                    <td>Thursday 30 April, 2026</td>
+                    <td>23lt Food Caddy</td>
+                </tr>
+                <tr>
+                    <td>Thursday 07 May, 2026</td>
+                    <td>240 Litre Paper and Card</td>
+                </tr>
+            </table>
+        </div>
+    </html>
+"""
+UNKNOWN_RESULTS_HTML = """
+    <html>
+        <div id="body-content">
+            <h1>Your Collections</h1>
+            <table class="Alloy-table">
+                <tr>
+                    <td>Thursday 30 April, 2026</td>
+                    <td>Glass Box Collection</td>
+                </tr>
+            </table>
+        </div>
+    </html>
+"""
 
 
-class TestSouthKestevenDistrictCouncil:
-    """Test cases for South Kesteven District Council implementation."""
+@pytest.fixture
+def council():
+    return CouncilClass()
 
-    def setup_method(self):
-        """Set up test fixtures."""
-        self.council = CouncilClass()
 
-    def test_get_next_collection_dates_monday(self):
-        """Test collection date calculation for Monday collections."""
-        # Mock today as a Wednesday (weekday 2)
-        with patch('uk_bin_collection.uk_bin_collection.councils.SouthKestevenDistrictCouncil.datetime') as mock_datetime:
-            mock_datetime.now.return_value = datetime(2024, 1, 10)  # Wednesday
-            mock_datetime.side_effect = lambda *args, **kw: datetime(*args, **kw)
-            
-            dates = self.council.get_next_collection_dates("Monday", 4)
-            
-            # Should return next 4 Mondays: Jan 15, 22, 29, Feb 5
-            expected_dates = ["15/01/2024", "22/01/2024", "29/01/2024", "05/02/2024"]
-            assert dates == expected_dates
+def make_option(text: str) -> MagicMock:
+    option = MagicMock()
+    option.text = text
+    return option
 
-    def test_get_next_collection_dates_friday(self):
-        """Test collection date calculation for Friday collections."""
-        # Mock today as a Monday (weekday 0)
-        with patch('uk_bin_collection.uk_bin_collection.councils.SouthKestevenDistrictCouncil.datetime') as mock_datetime:
-            mock_datetime.now.return_value = datetime(2024, 1, 8)  # Monday
-            mock_datetime.side_effect = lambda *args, **kw: datetime(*args, **kw)
-            
-            dates = self.council.get_next_collection_dates("Friday", 3)
-            
-            # Should return next 3 Fridays: Jan 12, 19, 26
-            expected_dates = ["12/01/2024", "19/01/2024", "26/01/2024"]
-            assert dates == expected_dates
 
-    def test_get_next_collection_dates_same_day(self):
-        """Test collection date calculation when today is the collection day."""
-        # Mock today as a Tuesday (weekday 1)
-        with patch('uk_bin_collection.uk_bin_collection.councils.SouthKestevenDistrictCouncil.datetime') as mock_datetime:
-            mock_datetime.now.return_value = datetime(2024, 1, 9)  # Tuesday
-            mock_datetime.side_effect = lambda *args, **kw: datetime(*args, **kw)
-            
-            dates = self.council.get_next_collection_dates("Tuesday", 3)
-            
-            # Should return next 3 Tuesdays: Jan 16, 23, 30 (not today)
-            expected_dates = ["16/01/2024", "23/01/2024", "30/01/2024"]
-            assert dates == expected_dates
+def test_parse_data_requires_postcode(council):
+    with pytest.raises(ValueError, match="Postcode is required for South Kesteven."):
+        council.parse_data("", paon="43")
 
-    def test_get_green_bin_collection_dates_week_1(self):
-        """Test green bin collection date calculation for Week 1."""
-        green_bin_info = {"day": "Tuesday", "week": 1}
-        
-        # Mock today as January 1, 2024 (Monday, Week 1)
-        with patch('uk_bin_collection.uk_bin_collection.councils.SouthKestevenDistrictCouncil.datetime') as mock_datetime:
-            mock_datetime.now.return_value = datetime(2024, 1, 1)  # Monday
-            mock_datetime.side_effect = lambda *args, **kw: datetime(*args, **kw)
-            
-            dates = self.council.get_green_bin_collection_dates(green_bin_info, 3)
-            
-            # Should return Tuesdays in Week 1: Jan 2, Feb 6, Mar 5
-            expected_dates = ["02/01/2024", "06/02/2024", "05/03/2024"]
-            assert dates == expected_dates
 
-    def test_get_green_bin_collection_dates_week_2(self):
-        """Test green bin collection date calculation for Week 2."""
-        green_bin_info = {"day": "Tuesday", "week": 2}
-        
-        # Mock today as January 1, 2024 (Monday, Week 1)
-        with patch('uk_bin_collection.uk_bin_collection.councils.SouthKestevenDistrictCouncil.datetime') as mock_datetime:
-            mock_datetime.now.return_value = datetime(2024, 1, 1)  # Monday
-            mock_datetime.side_effect = lambda *args, **kw: datetime(*args, **kw)
-            
-            dates = self.council.get_green_bin_collection_dates(green_bin_info, 3)
-            
-            # Should return Tuesdays in Week 2: Jan 9, Feb 13, Mar 12
-            expected_dates = ["09/01/2024", "13/02/2024", "12/03/2024"]
-            assert dates == expected_dates
+def test_parse_data_requires_paon(council):
+    with pytest.raises(
+        ValueError,
+        match="Property number or name \\(paon\\) is required for South Kesteven.",
+    ):
+        council.parse_data("", postcode="NG31 8XG")
 
-    def test_get_green_bin_collection_dates_no_info(self):
-        """Test green bin collection date calculation with no info."""
-        dates = self.council.get_green_bin_collection_dates(None, 3)
-        assert dates == []
 
-    def test_get_collection_day_from_postcode_success(self):
-        """Test successful collection day extraction from postcode."""
-        # Mock the requests-based approach
-        with patch.object(self.council, '_get_collection_day_requests') as mock_requests:
-            mock_requests.return_value = "Monday"
-            
-            result = self.council.get_collection_day_from_postcode(None, "PE6 8BL")
-            
-            assert result == "Monday"
-            mock_requests.assert_called_once_with("PE6 8BL")
+def test_resolve_checker_url_extracts_live_cta_link(council):
+    checker_url = council._resolve_checker_url(council.BIN_DAY_URL, page=BINDAY_HTML)
 
-    def test_get_collection_day_from_postcode_failure(self):
-        """Test collection day extraction failure."""
-        # Mock the requests-based approach to return None
-        with patch.object(self.council, '_get_collection_day_requests') as mock_requests:
-            mock_requests.return_value = None
-            
-            result = self.council.get_collection_day_from_postcode(None, "INVALID")
-            
-            assert result is None
-            mock_requests.assert_called_once_with("INVALID")
+    assert checker_url == CHECKER_URL
 
-    def test_get_green_bin_info_from_postcode_success(self):
-        """Test successful green bin info extraction from postcode."""
-        # Mock the requests-based approach
-        with patch.object(self.council, '_get_green_bin_info_requests') as mock_requests:
-            mock_requests.return_value = {"day": "Tuesday", "week": 2}
-            
-            result = self.council.get_green_bin_info_from_postcode(None, "PE6 8BL")
-            
-            expected = {"day": "Tuesday", "week": 2}
-            assert result == expected
-            mock_requests.assert_called_once_with("PE6 8BL")
 
-    def test_get_green_bin_info_from_postcode_failure(self):
-        """Test green bin info extraction failure."""
-        # Mock the requests-based approach to return None
-        with patch.object(self.council, '_get_green_bin_info_requests') as mock_requests:
-            mock_requests.return_value = None
-            
-            result = self.council.get_green_bin_info_from_postcode(None, "INVALID")
-            
-            assert result is None
-            mock_requests.assert_called_once_with("INVALID")
+def test_address_options_ready_requires_visible_populated_dropdown(council):
+    mock_driver = MagicMock()
+    hidden_select = MagicMock()
+    hidden_select.is_displayed.return_value = False
+    mock_driver.find_element.return_value = hidden_select
 
-    def test_parse_data_success_with_green_bin(self):
-        """Test successful parse_data with both regular and green bin collections."""
-        # Mock the collection day lookup and calendar parsing
-        with patch.object(self.council, 'get_collection_day_from_postcode') as mock_get_day:
-            with patch.object(self.council, 'get_green_bin_info_from_postcode') as mock_get_green:
-                with patch.object(self.council, 'get_next_collection_dates') as mock_get_dates:
-                    with patch.object(self.council, 'get_green_bin_collection_dates') as mock_get_green_dates:
-                        with patch.object(self.council, 'parse_calendar_images') as mock_calendar:
-                            with patch.object(self.council, 'get_bin_type_from_calendar') as mock_bin_type:
-    
-                                mock_get_day.return_value = "Monday"
-                                mock_get_green.return_value = {"day": "Tuesday", "week": 2}
-                                mock_get_dates.return_value = ["15/01/2025", "22/01/2025"]
-                                mock_get_green_dates.return_value = ["09/01/2025", "13/02/2025"]
-                                mock_calendar.return_value = {"2025": {"1": {"1": "Black bin", "2": "Silver bin"}}}
-                                mock_bin_type.return_value = "Black bin (General waste)"
-    
-                                result = self.council.parse_data("", postcode="PE6 8BL")
-    
-                                expected = {
-                                    "bins": [
-                                        {"type": "Black bin (General waste)", "collectionDate": "15/01/2025"},
-                                        {"type": "Black bin (General waste)", "collectionDate": "22/01/2025"},
-                                        {"type": "Green bin (Garden waste)", "collectionDate": "22/01/2025"},
-                                        {"type": "Green bin (Garden waste)", "collectionDate": "09/01/2025"},
-                                        {"type": "Green bin (Garden waste)", "collectionDate": "13/02/2025"}
-                                    ]
-                                }
-                                assert result == expected
+    assert council._address_options_ready(mock_driver) is False
 
-    def test_parse_data_success_without_green_bin(self):
-        """Test successful parse_data with only regular bin collections."""
-        with patch.object(self.council, 'get_collection_day_from_postcode') as mock_get_day:
-            with patch.object(self.council, 'get_green_bin_info_from_postcode') as mock_get_green:
-                with patch.object(self.council, 'get_next_collection_dates') as mock_get_dates:
-                    with patch.object(self.council, 'parse_calendar_images') as mock_calendar:
-                        with patch.object(self.council, 'get_bin_type_from_calendar') as mock_bin_type:
-    
-                            mock_get_day.return_value = "Friday"
-                            mock_get_green.return_value = None  # No green bin service
-                            mock_get_dates.return_value = ["12/01/2025", "19/01/2025"]
-                            mock_calendar.return_value = {"2025": {"1": {"1": "Black bin", "2": "Silver bin"}}}
-                            mock_bin_type.return_value = "Black bin (General waste)"
-    
-                            result = self.council.parse_data("", postcode="PE6 8BL")
-    
-                            expected = {
-                                "bins": [
-                                    {"type": "Black bin (General waste)", "collectionDate": "12/01/2025"},
-                                    {"type": "Black bin (General waste)", "collectionDate": "19/01/2025"}
-                                ]
-                            }
-                            assert result == expected
+    visible_select = MagicMock()
+    visible_select.is_displayed.return_value = True
+    mock_driver.find_element.return_value = visible_select
 
-    def test_parse_data_no_postcode(self):
-        """Test parse_data with no postcode provided."""
-        with pytest.raises(ValueError, match="Postcode is required for South Kesteven"):
-            self.council.parse_data("", web_driver="http://localhost:4444")
+    with patch(f"{MODULE_PATH}.Select") as mock_select_cls:
+        mock_select_cls.return_value.options = [make_option("43 Pembroke Avenue, Grantham")]
 
-    def test_parse_data_collection_day_failure(self):
-        """Test parse_data when collection day lookup fails."""
-        with patch.object(self.council, 'get_collection_day_from_postcode') as mock_get_day:
-            mock_get_day.return_value = None
-        
-            with pytest.raises(ValueError, match="Could not determine collection day for postcode INVALID"):
-                self.council.parse_data("", postcode="INVALID")
+        assert council._address_options_ready(mock_driver) is visible_select
 
-    def test_parse_data_exception_handling(self):
-        """Test parse_data exception handling."""
-        # Mock an exception during collection day lookup
-        with patch.object(self.council, 'get_collection_day_from_postcode') as mock_get_day:
-            mock_get_day.side_effect = Exception("Network error")
-        
-            with pytest.raises(Exception, match="Network error"):
-                self.council.parse_data("", postcode="PE6 8BL")
 
-    def test_week_of_month_calculation(self):
-        """Test the week of month calculation logic."""
-        # Test various dates to ensure week calculation is correct
-        test_cases = [
-            (datetime(2024, 1, 1), 1),   # Jan 1 - Week 1
-            (datetime(2024, 1, 7), 1),   # Jan 7 - Week 1
-            (datetime(2024, 1, 8), 2),   # Jan 8 - Week 2
-            (datetime(2024, 1, 14), 2),  # Jan 14 - Week 2
-            (datetime(2024, 1, 15), 3),  # Jan 15 - Week 3
-            (datetime(2024, 1, 21), 3),  # Jan 21 - Week 3
-            (datetime(2024, 1, 22), 4),  # Jan 22 - Week 4
-            (datetime(2024, 1, 28), 4),  # Jan 28 - Week 4
-            (datetime(2024, 1, 29), 5),  # Jan 29 - Week 5
-            (datetime(2024, 1, 31), 5),  # Jan 31 - Week 5
-        ]
-        
-        for date, expected_week in test_cases:
-            week_of_month = ((date.day - 1) // 7) + 1
-            assert week_of_month == expected_week, f"Date {date} should be week {expected_week}, got {week_of_month}"
+def test_select_address_raises_when_property_not_found(council):
+    mock_select = MagicMock()
+    mock_select.options = [
+        make_option("41 Pembroke Avenue, Grantham, NG31 8XG"),
+        make_option("45 Pembroke Avenue, Grantham, NG31 8XG"),
+    ]
 
-    def test_days_of_week_mapping(self):
-        """Test the days of week mapping is correct."""
-        days_of_week = {
-            "Monday": 0, "Tuesday": 1, "Wednesday": 2, "Thursday": 3,
-            "Friday": 4, "Saturday": 5, "Sunday": 6
+    with patch(f"{MODULE_PATH}.Select", return_value=mock_select):
+        with pytest.raises(
+            RuntimeError,
+            match="Unable to find the property '99' in the address dropdown.",
+        ):
+            council._select_address(MagicMock(), "99")
+
+
+def test_parse_collection_rows_parses_multiple_bins(council):
+    result = council._parse_collection_rows(RESULTS_HTML)
+
+    assert result == [
+        {
+            "type": "Black Bin",
+            "collectionDate": "16/04/2026",
+        },
+        {
+            "type": "Grey Bin",
+            "collectionDate": "23/04/2026",
+        },
+        {
+            "type": "Food Bin",
+            "collectionDate": "30/04/2026",
+        },
+        {
+            "type": "Purple Bin",
+            "collectionDate": "07/05/2026",
+        },
+    ]
+
+
+def test_parse_collection_rows_leaves_unknown_bin_labels_unchanged(council):
+    result = council._parse_collection_rows(UNKNOWN_RESULTS_HTML)
+
+    assert result == [
+        {
+            "type": "Glass Box Collection",
+            "collectionDate": "30/04/2026",
         }
-        
-        # Test that our mapping matches Python's weekday() method
-        test_date = datetime(2024, 1, 8)  # Monday
-        for day_name, expected_weekday in days_of_week.items():
-            # Find a date that falls on this weekday
-            days_to_add = (expected_weekday - test_date.weekday()) % 7
-            test_date_for_day = test_date + timedelta(days=days_to_add)
-            
-            assert test_date_for_day.weekday() == expected_weekday, f"{day_name} should map to weekday {expected_weekday}"
+    ]
+
+
+def test_capture_debug_artifacts_writes_files(council, tmp_path):
+    mock_driver = MagicMock()
+    mock_driver.current_url = CHECKER_URL
+    mock_driver.page_source = "<html><body>debug</body></html>"
+    mock_driver.save_screenshot.return_value = True
+
+    artifact_path = council._capture_debug_artifacts(
+        mock_driver,
+        tmp_path,
+        {"postcode": "NG31 8XG", "paon": "43"},
+    )
+
+    assert artifact_path is not None
+    assert (artifact_path / "page.html").read_text(encoding="utf-8") == mock_driver.page_source
+    metadata = json.loads((artifact_path / "metadata.json").read_text(encoding="utf-8"))
+    assert metadata["current_url"] == CHECKER_URL
+    assert metadata["postcode"] == "NG31 8XG"
+    assert metadata["screenshot_saved"] is True
+
+
+def test_parse_data_uses_live_checker_url_and_form_ids(council):
+    mock_driver = MagicMock()
+    mock_driver.page_source = RESULTS_HTML
+
+    current_section = MagicMock()
+    current_section.get_attribute.return_value = "488"
+    body_content = MagicMock()
+    body_content.get_attribute.return_value = "<div>Collection Address</div>"
+
+    def find_element_side_effect(by, value):
+        if (by, value) == (By.ID, council.CURRENT_SECTION_ID):
+            return current_section
+        if (by, value) == (By.ID, council.BODY_CONTENT_ID):
+            return body_content
+        raise AssertionError(f"Unexpected find_element lookup: {(by, value)}")
+
+    mock_driver.find_element.side_effect = find_element_side_effect
+
+    postcode_input = MagicMock()
+    search_button = MagicMock()
+    submit_button = MagicMock()
+    address_select = MagicMock()
+
+    matched_option = make_option("43 Pembroke Avenue, Grantham, NG31 8XG")
+    mock_select = MagicMock()
+    mock_select.options = [
+        make_option("41 Pembroke Avenue, Grantham, NG31 8XG"),
+        matched_option,
+    ]
+
+    with patch(f"{MODULE_PATH}.create_webdriver", return_value=mock_driver), patch(
+        f"{MODULE_PATH}.WebDriverWait", return_value=MagicMock()
+    ), patch.object(
+        council, "_resolve_checker_url", return_value=CHECKER_URL
+    ), patch.object(
+        council,
+        "_wait_for_clickable",
+        side_effect=[postcode_input, search_button, submit_button],
+    ) as wait_clickable, patch.object(
+        council, "_wait_for_address_options", return_value=address_select
+    ) as wait_for_address, patch.object(
+        council, "_wait_for_address_confirmation"
+    ) as wait_for_confirmation, patch.object(
+        council, "_wait_for_results_container"
+    ) as wait_for_results, patch(
+        f"{MODULE_PATH}.Select", return_value=mock_select
+    ):
+        result = council.parse_data("", postcode="NG31 8XG", paon="43")
+
+    assert result["bins"][0]["type"] == "Black Bin"
+    assert result["bins"][0]["collectionDate"] == "16/04/2026"
+    mock_driver.get.assert_called_once_with(CHECKER_URL)
+    postcode_input.clear.assert_called_once()
+    postcode_input.send_keys.assert_called_once_with("NG31 8XG")
+    search_button.click.assert_called_once()
+    submit_button.click.assert_called_once()
+    wait_clickable.assert_any_call(
+        ANY,
+        (By.ID, council.POSTCODE_INPUT_ID),
+        "Unable to find the postcode input on the South Kesteven checker.",
+    )
+    wait_clickable.assert_any_call(
+        ANY,
+        (By.ID, council.SUBMIT_BUTTON_ID),
+        "Unable to find the submit button after selecting the address.",
+    )
+    wait_for_address.assert_called_once()
+    wait_for_confirmation.assert_called_once()
+    wait_for_results.assert_called_once_with(
+        ANY,
+        "488",
+        "<div>Collection Address</div>",
+    )
+    mock_select.select_by_visible_text.assert_called_once_with(matched_option.text)
+    mock_driver.quit.assert_called_once()
+
+
+def test_parse_data_appends_artifact_path_on_failure(council, tmp_path):
+    mock_driver = MagicMock()
+    mock_driver.current_url = CHECKER_URL
+    mock_driver.page_source = "<html><body>lookup failed</body></html>"
+    mock_driver.save_screenshot.return_value = True
+
+    current_section = MagicMock()
+    current_section.get_attribute.return_value = "488"
+    body_content = MagicMock()
+    body_content.get_attribute.return_value = "<div>Collection Address</div>"
+
+    def find_element_side_effect(by, value):
+        if (by, value) == (By.ID, council.CURRENT_SECTION_ID):
+            return current_section
+        if (by, value) == (By.ID, council.BODY_CONTENT_ID):
+            return body_content
+        raise AssertionError(f"Unexpected find_element lookup: {(by, value)}")
+
+    mock_driver.find_element.side_effect = find_element_side_effect
+
+    postcode_input = MagicMock()
+    search_button = MagicMock()
+
+    with patch(f"{MODULE_PATH}.create_webdriver", return_value=mock_driver), patch(
+        f"{MODULE_PATH}.WebDriverWait", return_value=MagicMock()
+    ), patch.object(
+        council, "_resolve_checker_url", return_value=CHECKER_URL
+    ), patch.object(
+        council,
+        "_wait_for_clickable",
+        side_effect=[postcode_input, search_button],
+    ), patch.object(
+        council,
+        "_wait_for_address_options",
+        side_effect=RuntimeError(
+            "Unable to find the address dropdown after searching for the postcode."
+        ),
+    ):
+        with pytest.raises(
+            RuntimeError,
+            match="Unable to find the address dropdown after searching for the postcode.",
+        ) as exc_info:
+            council.parse_data(
+                "",
+                postcode="NG31 8XG",
+                paon="43",
+                artifact_dir=str(tmp_path),
+            )
+
+    assert "Debug artifacts saved to:" in str(exc_info.value)
+    created_artifacts = list(tmp_path.iterdir())
+    assert created_artifacts
+    artifact_run_dir = next(path for path in created_artifacts if path.is_dir())
+    assert (artifact_run_dir / "page.html").exists()
+    assert (artifact_run_dir / "metadata.json").exists()
+    mock_driver.quit.assert_called_once()

--- a/uk_bin_collection/uk_bin_collection/councils/tests/test_south_kesteven_integration.py
+++ b/uk_bin_collection/uk_bin_collection/councils/tests/test_south_kesteven_integration.py
@@ -1,145 +1,68 @@
-"""
-Integration tests for South Kesteven District Council implementation.
-These tests use requests-based form submission (no Selenium required).
-"""
+"""Integration tests for the South Kesteven binday Selenium flow."""
 
 import pytest
-import os
-from unittest.mock import patch
+from selenium.common.exceptions import WebDriverException
+from urllib3.exceptions import MaxRetryError
 
-from uk_bin_collection.uk_bin_collection.councils.SouthKestevenDistrictCouncil import CouncilClass
-
+from uk_bin_collection.uk_bin_collection.councils.SouthKestevenDistrictCouncil import (
+    CouncilClass,
+)
 
 class TestSouthKestevenIntegration:
     """Integration tests for South Kesteven District Council."""
 
+    EXPECTED_BIN_TYPES = {"Grey Bin", "Food Bin", "Black Bin", "Purple Bin"}
+
     def setup_method(self):
-        """Set up test fixtures."""
         self.council = CouncilClass()
-        # Use a test postcode that should work
-        self.test_postcode = "PE6 8BL"
 
     @pytest.mark.integration
-    def test_real_postcode_lookup(self):
-        """Test real postcode lookup with requests-based form submission."""
+    def test_real_binday_lookup(
+        self, test_postcode, test_paon, test_url, test_web_driver, test_headless, tmp_path
+    ):
         try:
             result = self.council.parse_data(
-                "", 
-                postcode=self.test_postcode
+                "",
+                url=test_url,
+                postcode=test_postcode,
+                paon=test_paon,
+                web_driver=test_web_driver,
+                headless=test_headless,
+                artifact_dir=str(tmp_path),
             )
-            
-            # Verify the result structure
-            assert "bins" in result
-            assert isinstance(result["bins"], list)
-            assert len(result["bins"]) > 0
-            
-            # Verify each bin entry has required fields
-            for bin_entry in result["bins"]:
-                assert "type" in bin_entry
-                assert "collectionDate" in bin_entry
-                # Updated to include the specific bin types we now return
-                assert bin_entry["type"] in [
-                    "General Waste", "Garden Waste", "Green bin (Garden waste)",
-                    "Black bin (General waste)", "Silver bin (Recycling)", 
-                    "Purple-lidded bin (Paper & Card)"
-                ]
-                
-                # Verify date format (DD/MM/YYYY)
-                date_parts = bin_entry["collectionDate"].split("/")
-                assert len(date_parts) == 3
-                assert len(date_parts[0]) == 2  # Day
-                assert len(date_parts[1]) == 2  # Month
-                assert len(date_parts[2]) == 4  # Year
-                
-        except Exception as e:
-            pytest.skip(f"Integration test failed (likely due to network issues): {e}")
+        except (MaxRetryError, WebDriverException) as exc:
+            pytest.skip(f"Selenium unavailable for integration test: {exc}")
+
+        assert "bins" in result
+        assert isinstance(result["bins"], list)
+        assert result["bins"]
+        assert {bin_entry["type"] for bin_entry in result["bins"]} <= self.EXPECTED_BIN_TYPES
+
+        for bin_entry in result["bins"]:
+            assert "type" in bin_entry
+            assert "collectionDate" in bin_entry
+            date_parts = bin_entry["collectionDate"].split("/")
+            assert len(date_parts) == 3
+            assert len(date_parts[0]) == 2
+            assert len(date_parts[1]) == 2
+            assert len(date_parts[2]) == 4
 
     @pytest.mark.integration
-    def test_invalid_postcode_handling(self):
-        """Test handling of invalid postcodes."""
+    def test_unknown_property_is_reported(
+        self, test_postcode, test_url, test_web_driver, test_headless, tmp_path
+    ):
         try:
-            with pytest.raises(ValueError, match="Could not determine collection day"):
+            with pytest.raises(
+                RuntimeError, match="Unable to find the property 'NOT_A_REAL_PROPERTY'"
+            ):
                 self.council.parse_data(
-                    "", 
-                    postcode="INVALID_POSTCODE"
+                    "",
+                    url=test_url,
+                    postcode=test_postcode,
+                    paon="NOT_A_REAL_PROPERTY",
+                    web_driver=test_web_driver,
+                    headless=test_headless,
+                    artifact_dir=str(tmp_path),
                 )
-        except Exception as e:
-            pytest.skip(f"Integration test failed (likely due to network issues): {e}")
-
-    @pytest.mark.integration
-    def test_collection_day_extraction(self):
-        """Test extraction of collection day using requests-based approach."""
-        try:
-            collection_day = self.council.get_collection_day_from_postcode(None, self.test_postcode)
-            assert collection_day is not None
-            assert collection_day in ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
-                
-        except Exception as e:
-            pytest.skip(f"Integration test failed (likely due to network issues): {e}")
-
-    @pytest.mark.integration
-    def test_green_bin_info_extraction(self):
-        """Test extraction of green bin information using requests-based approach."""
-        try:
-            green_bin_info = self.council.get_green_bin_info_from_postcode(None, self.test_postcode)
-            
-            if green_bin_info:  # Green bin service might not be available for all postcodes
-                assert "day" in green_bin_info
-                assert "week" in green_bin_info
-                assert green_bin_info["day"] in ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
-                assert green_bin_info["week"] in [1, 2]
-                
-        except Exception as e:
-            pytest.skip(f"Integration test failed (likely due to network issues): {e}")
-
-    def test_collection_date_calculation_accuracy(self):
-        """Test that collection date calculations are accurate."""
-        from datetime import datetime, timedelta
-        
-        # Test with a known date
-        test_date = datetime(2024, 1, 10)  # Wednesday, January 10, 2024
-        
-        with patch('uk_bin_collection.uk_bin_collection.councils.SouthKestevenDistrictCouncil.datetime') as mock_datetime:
-            mock_datetime.now.return_value = test_date
-            mock_datetime.side_effect = lambda *args, **kw: datetime(*args, **kw)
-            
-            # Test Monday collections
-            monday_dates = self.council.get_next_collection_dates("Monday", 2)
-            expected_monday_1 = (test_date + timedelta(days=5)).strftime("%d/%m/%Y")  # Jan 15
-            expected_monday_2 = (test_date + timedelta(days=12)).strftime("%d/%m/%Y")  # Jan 22
-            
-            assert monday_dates[0] == expected_monday_1
-            assert monday_dates[1] == expected_monday_2
-            
-            # Test Friday collections
-            friday_dates = self.council.get_next_collection_dates("Friday", 2)
-            expected_friday_1 = (test_date + timedelta(days=2)).strftime("%d/%m/%Y")  # Jan 12
-            expected_friday_2 = (test_date + timedelta(days=9)).strftime("%d/%m/%Y")  # Jan 19
-            
-            assert friday_dates[0] == expected_friday_1
-            assert friday_dates[1] == expected_friday_2
-
-    def test_green_bin_week_calculation_accuracy(self):
-        """Test that green bin week calculations are accurate."""
-        from datetime import datetime
-        
-        # Test with January 2024 (known calendar)
-        test_date = datetime(2024, 1, 1)  # Monday, January 1, 2024
-        
-        with patch('uk_bin_collection.uk_bin_collection.councils.SouthKestevenDistrictCouncil.datetime') as mock_datetime:
-            mock_datetime.now.return_value = test_date
-            mock_datetime.side_effect = lambda *args, **kw: datetime(*args, **kw)
-            
-            # Test Week 1 Tuesday (should be January 2)
-            green_bin_info = {"day": "Tuesday", "week": 1}
-            dates = self.council.get_green_bin_collection_dates(green_bin_info, 1)
-            
-            assert len(dates) == 1
-            assert dates[0] == "02/01/2024"  # January 2, 2024 is a Tuesday in Week 1
-            
-            # Test Week 2 Tuesday (should be January 9)
-            green_bin_info = {"day": "Tuesday", "week": 2}
-            dates = self.council.get_green_bin_collection_dates(green_bin_info, 1)
-            
-            assert len(dates) == 1
-            assert dates[0] == "09/01/2024"  # January 9, 2024 is a Tuesday in Week 2
+        except (MaxRetryError, WebDriverException) as exc:
+            pytest.skip(f"Selenium unavailable for integration test: {exc}")


### PR DESCRIPTION
## Summary

- Updates the South Kesteven scraper to use the current live binday flow and normalize the returned bin names.
- Adds `--artifact-dir` support to the data collection CLI so targeted council validation can retain debugging artifacts when needed.
- Adds South Kesteven fixture coverage and targeted tests for the scraper behavior.

## Why

The previous South Kesteven implementation no longer matched the live council collection service, which made the returned collection dates and bin labels unreliable.

## Validation

- `python -m pytest --basetemp=C:\Users\mattm\AppData\Local\Temp\CodexPytestSkdcBindayPr --confcutdir=uk_bin_collection\uk_bin_collection\councils\tests uk_bin_collection\uk_bin_collection\councils\tests\test_south_kesteven_district_council.py`
- `python -m compileall uk_bin_collection/uk_bin_collection/councils/SouthKestevenDistrictCouncil.py uk_bin_collection/uk_bin_collection/collect_data.py`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional `--artifact-dir` CLI argument to save debug artifacts when collection encounters errors
  * Enhanced South Kesteven District Council collection with improved live checker lookup and validation

* **Improvements**
  * Better error diagnostics with captured page state and debugging information on collection failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Related to #1907.

This PR addresses the South Kesteven issue discussed here:
https://github.com/robbrad/UKBinCollectionData/issues/1907#issuecomment-4636334567