### PR TITLE
fix: update input.json for East Ayrshire Council

### DIFF
--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -769,12 +769,14 @@
         "wiki_note": "Pass the UPRN. You can find it using [FindMyAddress](https://www.findmyaddress.co.uk/search)."
     },
     "EastAyrshireCouncil": {
-        "LAD24CD": "S12000008",
-        "uprn": "127074727",
+        "house_number": "57 Whatriggs Road",
+        "postcode": "KA1 3RB",
+        "skip_get_url": true,
         "url": "https://www.east-ayrshire.gov.uk",
         "wiki_command_url_override": "https://www.east-ayrshire.gov.uk",
         "wiki_name": "East Ayrshire",
-        "wiki_note": "You will need to use [FindMyAddress](https://www.findmyaddress.co.uk/search) to find the UPRN."
+        "wiki_note": "Pass postcode and house number or full address. Uses the ReCollect API.",
+        "LAD24CD": "S12000008"
     },
     "EastCambridgeshireCouncil": {
         "LAD24CD": "E07000009",


### PR DESCRIPTION
The changes to input.json from #2081 were not applied so the config flow was still asking for the UPRN and failing because the council script now expects a full address.

This PR updates input.json to match the changes in #2081.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated East Ayrshire Council service to accept postcode and house number input instead of requiring UPRN, improving accessibility for users in that area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->