### PR TITLE
fix: guard milton keynes scraper against api error responses

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/MiltonKeynesCityCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/MiltonKeynesCityCouncil.py
@@ -56,9 +56,12 @@ class CouncilClass(AbstractGetBinDataClass):
         r.raise_for_status()
 
         data = r.json()
-        rows_data = data["integration"]["transformed"]["rows_data"]
-        if not isinstance(rows_data, dict):
-            raise ValueError("Invalid data returned from API")
+        if data.get("status") == "error":
+            msg = data.get("error", {}).get("message", "Unknown API error")
+            raise ValueError(f"Milton Keynes API error: {msg}")
+        rows_data = data.get("integration", {}).get("transformed", {}).get("rows_data")
+        if not rows_data or not isinstance(rows_data, dict):
+            raise ValueError("No collection data returned from API")
 
         # Extract each service's relevant details for the bin schedule
         for item in rows_data.values():


### PR DESCRIPTION
## Summary
- When the council backend is down, the API returns `{status: "error", error: {message: "..."}}`
- The scraper crashed with `KeyError` because `data["integration"]["transformed"]["rows_data"]` doesn't exist in error responses
- Now checks for `status == "error"` first and raises a clean `ValueError` with the API's error message
- Uses safe `.get()` chain so missing keys produce a clear "no data" error instead of a traceback

## Testing
- MK10 9NQ / UPRN 25102973: returns 4 bin types correctly when backend is up
- When backend returns error status: raises `ValueError("Milton Keynes API error: ...")` instead of `KeyError`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for Milton Keynes council data processing to provide clearer error messages when API issues occur and prevent processing of invalid data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->