### PR TITLE
Convert Warrington Council to use plain JSON parser

### DIFF
--- a/uk_bin_collection/uk_bin_collection/common.py
+++ b/uk_bin_collection/uk_bin_collection/common.py
@@ -353,7 +353,7 @@ def create_webdriver(
             driver = webdriver.Remote(command_executor=web_driver, options=options)
         else:
             driver = webdriver.Chrome(
-                service=ChromeService(options=options)
+                service=ChromeService(ChromeDriverManager().install()), options=options
             )
         
         # Set window position to ensure it's visible on screen

--- a/uk_bin_collection/uk_bin_collection/common.py
+++ b/uk_bin_collection/uk_bin_collection/common.py
@@ -353,7 +353,7 @@ def create_webdriver(
             driver = webdriver.Remote(command_executor=web_driver, options=options)
         else:
             driver = webdriver.Chrome(
-                service=ChromeService(ChromeDriverManager().install()), options=options
+                service=ChromeService(options=options)
             )
         
         # Set window position to ensure it's visible on screen

--- a/uk_bin_collection/uk_bin_collection/councils/WarringtonBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/WarringtonBoroughCouncil.py
@@ -1,5 +1,7 @@
-from datetime import datetime
 import requests
+from datetime import datetime
+
+from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinData
 
 HEADERS = {
     "User-Agent": (
@@ -10,7 +12,8 @@ HEADERS = {
     "Referer": "https://www.warrington.gov.uk/bin-collections",
 }
 
-class CouncilClass:
+
+class CouncilClass(AbstractGetBinData):
     def parse_data(self, page, **kwargs):
         url = kwargs.get("url")
 
@@ -32,11 +35,9 @@ class CouncilClass:
             if not timestamp:
                 continue
 
-            collection_date = datetime.fromtimestamp(timestamp).strftime("%d/%m/%Y")
-
             entries.append({
                 "type": label,
-                "collectionDate": collection_date,
+                "collectionDate": datetime.fromtimestamp(timestamp).strftime("%d/%m/%Y"),
             })
 
         return entries

--- a/uk_bin_collection/uk_bin_collection/councils/WarringtonBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/WarringtonBoroughCouncil.py
@@ -20,8 +20,6 @@ class CouncilClass(AbstractGetBinDataClass):
         check_uprn(user_uprn)
 
         uri = f"https://www.warrington.gov.uk/bin-collections/get-jobs/{user_uprn}"
-        if not isinstance(schedule, list):
-            raise ValueError("Unexpected Warrington response: missing/invalid 'schedule'")
 
         response = requests.get(uri, headers=HEADERS, timeout=30)
         response.raise_for_status()

--- a/uk_bin_collection/uk_bin_collection/councils/WarringtonBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/WarringtonBoroughCouncil.py
@@ -1,56 +1,42 @@
-import json
-import time
 from datetime import datetime
+import requests
 
-from bs4 import BeautifulSoup
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.support.wait import WebDriverWait
+HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/120 Safari/537.36"
+    ),
+    "Accept": "application/json, text/plain, */*",
+    "Referer": "https://www.warrington.gov.uk/bin-collections",
+}
 
-from uk_bin_collection.uk_bin_collection.common import *
-from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
+class CouncilClass:
+    def parse_data(self, page, **kwargs):
+        url = kwargs.get("url")
 
+        response = requests.get(url, headers=HEADERS, timeout=30)
+        response.raise_for_status()
+        data = response.json()
 
-class CouncilClass(AbstractGetBinDataClass):
-    def parse_data(self, page: str, **kwargs) -> dict:
-        user_uprn = kwargs.get("uprn")
-        check_uprn(user_uprn)
-        bindata = {"bins": []}
+        bins = {
+            "green": "Green",
+            "blue": "Blue",
+            "foodwaste": "Food Waste",
+            "black": "Black",
+        }
 
-        uri = f"https://www.warrington.gov.uk/bin-collections/get-jobs/{user_uprn}"
+        entries = []
 
-        web_driver = kwargs.get("web_driver")
-        headless = kwargs.get("headless")
+        for key, label in bins.items():
+            timestamp = data.get(key)
+            if not timestamp:
+                continue
 
-        driver = create_webdriver(web_driver, headless, None, __name__)
-        try:
-            driver.get(uri)
-            # Wait for Cloudflare challenge to resolve and JSON to appear
-            WebDriverWait(driver, 30).until(
-                EC.presence_of_element_located((By.TAG_NAME, "pre"))
-            )
-            time.sleep(2)
+            collection_date = datetime.fromtimestamp(timestamp).strftime("%d/%m/%Y")
 
-            soup = BeautifulSoup(driver.page_source, "html.parser")
-            pre = soup.find("pre")
-            if not pre:
-                raise ValueError("No JSON data found on page after Cloudflare challenge")
-
-            bin_collection = json.loads(pre.text)
-        finally:
-            driver.quit()
-
-        for collection in bin_collection.get("schedule", []):
-            bin_type = collection["Name"]
-            collection_date = collection["ScheduledStart"]
-            bindata["bins"].append({
-                "type": bin_type,
-                "collectionDate": datetime.strptime(
-                    collection_date, "%Y-%m-%dT%H:%M:%S"
-                ).strftime(date_format),
+            entries.append({
+                "type": label,
+                "collectionDate": collection_date,
             })
 
-        bindata["bins"].sort(
-            key=lambda x: datetime.strptime(x.get("collectionDate"), date_format)
-        )
-        return bindata
+        return entries

--- a/uk_bin_collection/uk_bin_collection/councils/WarringtonBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/WarringtonBoroughCouncil.py
@@ -20,14 +20,19 @@ class CouncilClass(AbstractGetBinDataClass):
         check_uprn(user_uprn)
 
         uri = f"https://www.warrington.gov.uk/bin-collections/get-jobs/{user_uprn}"
+        if not isinstance(schedule, list):
+            raise ValueError("Unexpected Warrington response: missing/invalid 'schedule'")
 
         response = requests.get(uri, headers=HEADERS, timeout=30)
         response.raise_for_status()
         bin_collection = response.json()
 
         bindata = {"bins": []}
+        schedule = bin_collection.get("schedule")
+        if not isinstance(schedule, list):
+            raise ValueError("Unexpected Warrington response: missing/invalid 'schedule'")
 
-        for collection in bin_collection.get("schedule", []):
+        for collection in schedule:
             bindata["bins"].append({
                 "type": collection["Name"],
                 "collectionDate": datetime.strptime(

--- a/uk_bin_collection/uk_bin_collection/councils/WarringtonBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/WarringtonBoroughCouncil.py
@@ -1,7 +1,8 @@
 import requests
 from datetime import datetime
 
-from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinData
+from uk_bin_collection.uk_bin_collection.common import check_uprn, date_format
+from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
 HEADERS = {
     "User-Agent": (
@@ -13,31 +14,30 @@ HEADERS = {
 }
 
 
-class CouncilClass(AbstractGetBinData):
-    def parse_data(self, page, **kwargs):
-        url = kwargs.get("url")
+class CouncilClass(AbstractGetBinDataClass):
+    def parse_data(self, page: str, **kwargs) -> dict:
+        user_uprn = kwargs.get("uprn")
+        check_uprn(user_uprn)
 
-        response = requests.get(url, headers=HEADERS, timeout=30)
+        uri = f"https://www.warrington.gov.uk/bin-collections/get-jobs/{user_uprn}"
+
+        response = requests.get(uri, headers=HEADERS, timeout=30)
         response.raise_for_status()
-        data = response.json()
+        bin_collection = response.json()
 
-        bins = {
-            "green": "Green",
-            "blue": "Blue",
-            "foodwaste": "Food Waste",
-            "black": "Black",
-        }
+        bindata = {"bins": []}
 
-        entries = []
-
-        for key, label in bins.items():
-            timestamp = data.get(key)
-            if not timestamp:
-                continue
-
-            entries.append({
-                "type": label,
-                "collectionDate": datetime.fromtimestamp(timestamp).strftime("%d/%m/%Y"),
+        for collection in bin_collection.get("schedule", []):
+            bindata["bins"].append({
+                "type": collection["Name"],
+                "collectionDate": datetime.strptime(
+                    collection["ScheduledStart"],
+                    "%Y-%m-%dT%H:%M:%S",
+                ).strftime(date_format),
             })
 
-        return entries
+        bindata["bins"].sort(
+            key=lambda x: datetime.strptime(x["collectionDate"], date_format)
+        )
+
+        return bindata


### PR DESCRIPTION
The Warrington Council data consumer was broken. Warrington Council return formatted JSON for the API now (perhaps they changed), so this PR switches out the previous Selenium browser for a simple JSON parser.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Improved Warrington Borough Council bin collection data retrieval
  * Enhanced validation of collection schedule information and date handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->