### PR TITLE
feat: LondonBoroughLewisham - replace Selenium scraper with requests-based API client

### DIFF
--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -1523,13 +1523,11 @@
     },
     "LondonBoroughLewisham": {
         "LAD24CD": "E09000023",
-        "postcode": "SE12 9QF",
         "skip_get_url": true,
         "uprn": "100021954849",
         "url": "https://www.lewisham.gov.uk",
-        "web_driver": "http://selenium:4444",
         "wiki_name": "Lewisham",
-        "wiki_note": "Pass the UPRN and postcode. To get the UPRN, you can use [FindMyAddress](https://www.findmyaddress.co.uk/search)."
+        "wiki_note": "Pass the UPRN. To get the UPRN, you can use [FindMyAddress](https://www.findmyaddress.co.uk/search)."
     },
     "LondonBoroughOfRichmondUponThames": {
         "LAD24CD": "E09000027",

--- a/uk_bin_collection/tests/test_common_functions.py
+++ b/uk_bin_collection/tests/test_common_functions.py
@@ -463,3 +463,50 @@ def test_get_next_day_of_week(today_str, day_name, expected):
         mock_datetime.side_effect = lambda *args, **kw: datetime(*args, **kw)
         result = get_next_day_of_week(day_name, date_format="%m/%d/%Y")
         assert result == expected
+
+
+def test_build_retry_session_defaults():
+    session = build_retry_session()
+    adapter = session.get_adapter("https://example.com")
+    retry = adapter.max_retries
+    assert retry.total == 5
+    assert retry.backoff_factor == 1.5
+    assert retry.status_forcelist == (429, 500, 502, 503, 504)
+    assert retry.allowed_methods == ("GET",)
+
+
+def test_build_retry_session_custom_headers_and_methods():
+    session = build_retry_session(
+        headers={"User-Agent": "test-agent"}, retry_methods=("POST",)
+    )
+    assert session.headers["User-Agent"] == "test-agent"
+    adapter = session.get_adapter("https://example.com")
+    assert adapter.max_retries.allowed_methods == ("POST",)
+
+
+def test_get_scraper_user_agent_uses_installed_version():
+    with patch("uk_bin_collection.common._pkg_version", return_value="1.2.3"):
+        result = get_scraper_user_agent()
+    assert result == (
+        "uk-bin-collection/1.2.3 (+https://github.com/robbrad/UKBinCollectionData)"
+    )
+
+
+def test_get_scraper_user_agent_falls_back_when_not_installed():
+    with patch(
+        "uk_bin_collection.common._pkg_version", side_effect=PackageNotFoundError
+    ):
+        result = get_scraper_user_agent()
+    assert result == (
+        "uk-bin-collection/1.0 (+https://github.com/robbrad/UKBinCollectionData)"
+    )
+
+
+def test_get_scraper_user_agent_custom_fallback():
+    with patch(
+        "uk_bin_collection.common._pkg_version", side_effect=PackageNotFoundError
+    ):
+        result = get_scraper_user_agent(fallback_version="dev")
+    assert result == (
+        "uk-bin-collection/dev (+https://github.com/robbrad/UKBinCollectionData)"
+    )

--- a/uk_bin_collection/uk_bin_collection/common.py
+++ b/uk_bin_collection/uk_bin_collection/common.py
@@ -4,14 +4,17 @@ import os
 import re
 from datetime import datetime, timedelta
 from enum import Enum
+from importlib.metadata import PackageNotFoundError, version as _pkg_version
 
 import holidays
 import pandas as pd
 import requests
 from dateutil.parser import parse
+from requests.adapters import HTTPAdapter
 from selenium import webdriver
 from selenium.webdriver.chrome.service import Service as ChromeService
 from urllib3.exceptions import MaxRetryError
+from urllib3.util.retry import Retry
 from webdriver_manager.chrome import ChromeDriverManager
 
 date_format = "%d/%m/%Y"
@@ -259,6 +262,10 @@ def update_input_json(council: str, url: str, input_file_path: str, **kwargs):
     try:
         data = load_data(input_file_path)
         council_data = data.get(council, {"wiki_name": council})
+        # kwargs holds every CLI flag (postcode, uprn, web_driver, ...), but a flag
+        # not passed on this run still shows up here as None. Without this filter,
+        # that None would overwrite the real value already saved from a previous run.
+        kwargs = {k: v for k, v in kwargs.items() if v is not None}
         council_data.update({"url": url, **kwargs})
         data[council] = council_data
 
@@ -267,6 +274,42 @@ def update_input_json(council: str, url: str, input_file_path: str, **kwargs):
         print(f"Error updating the JSON file: {e}")
     except json.JSONDecodeError:
         print("Failed to decode JSON, check the integrity of the input file.")
+
+
+def get_scraper_user_agent(fallback_version="1.0"):
+    """
+    Build a polite User-Agent string of the form "uk-bin-collection/<version> (+repo url)"
+    for requests-based scrapers, using the installed package's real version where
+    available. Falls back to fallback_version if the package isn't installed with
+    metadata (e.g. running directly from source without `pip install`/`poetry install`),
+    since importlib.metadata.version() would otherwise raise in that case.
+        :param fallback_version: Version string to use when package metadata isn't available
+    """
+    try:
+        pkg_version = _pkg_version("uk_bin_collection")
+    except PackageNotFoundError:
+        pkg_version = fallback_version
+    return f"uk-bin-collection/{pkg_version} (+https://github.com/robbrad/UKBinCollectionData)"
+
+
+def build_retry_session(headers=None, retry_methods=("GET",)):
+    """
+    Build a requests.Session with retry/backoff configured for transient failures.
+        :param headers: Optional dict of headers to set on the session
+        :param retry_methods: HTTP methods the retry adapter should apply to
+    """
+    session = requests.Session()
+    if headers:
+        session.headers.update(headers)
+    retry = Retry(
+        total=5,
+        backoff_factor=1.5,
+        status_forcelist=(429, 500, 502, 503, 504),
+        allowed_methods=retry_methods,
+        respect_retry_after_header=True,
+    )
+    session.mount("https://", HTTPAdapter(max_retries=retry))
+    return session
 
 
 def load_data(file_path):
@@ -355,10 +398,10 @@ def create_webdriver(
             driver = webdriver.Chrome(
                 service=ChromeService(ChromeDriverManager().install()), options=options
             )
-        
+
         # Set window position to ensure it's visible on screen
         driver.set_window_position(0, 0)
-        
+
         return driver
     except MaxRetryError as e:
         print(f"Failed to create WebDriver: {e}")

--- a/uk_bin_collection/uk_bin_collection/councils/LondonBoroughLewisham.py
+++ b/uk_bin_collection/uk_bin_collection/councils/LondonBoroughLewisham.py
@@ -1,16 +1,30 @@
-import re
-import time
+import html
 
 from bs4 import BeautifulSoup
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.support.ui import Select, WebDriverWait
 
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
+BASE_URL = "https://lewisham.gov.uk"
+COLLECTION_PAGE_URL = (
+    f"{BASE_URL}/myservices/recycling-and-rubbish/your-bins/collection"
+)
+ROUNDS_INFORMATION_PATH = "/api/roundsinformation"
+# Identifies the "rounds information" widget on the collection page in Lewisham's
+# CMS (Sitecore). The site's JS calls this same endpoint+id to render the
+# schedule text, so we call it directly instead of driving a browser.
+ROUNDS_INFORMATION_ITEM_GUID = "{23423835-d2a6-41b1-9637-29e5e8cc2df7}"
 
-# import the wonderful Beautiful Soup and the URL grabber
+_DAY_PATTERN = re.compile(
+    r"on\s*(?P<day>Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday)",
+    re.IGNORECASE,
+)
+_NEXT_DATE_PATTERN = re.compile(
+    r"your\s+next\s+collection\s+date\s+is\s*(?P<date>\d{2}/\d{2}/\d{4})",
+    re.IGNORECASE,
+)
+
+
 class CouncilClass(AbstractGetBinDataClass):
     """
     Concrete classes have to implement all abstract operations of the
@@ -19,122 +33,86 @@ class CouncilClass(AbstractGetBinDataClass):
     """
 
     def parse_data(self, page: str, **kwargs) -> dict:
-
         user_uprn = kwargs.get("uprn")
-        user_postcode = kwargs.get("postcode")
-        web_driver = kwargs.get("web_driver")
-        headless = kwargs.get("headless")
-        check_uprn(user_uprn)
+        if not user_uprn:
+            raise ValueError(
+                "Could not resolve UPRN. Provide a valid UPRN, e.g. via FindMyAddress."
+            )
+
+        session = build_retry_session(
+            headers={
+                "User-Agent": get_scraper_user_agent(),
+                "Accept": "application/json, text/html, */*",
+                "Accept-Language": "en-GB,en;q=0.9",
+                "X-Requested-With": "XMLHttpRequest",
+                "Referer": COLLECTION_PAGE_URL,
+            },
+            retry_methods=("POST",),
+        )
+
+        resp = session.post(
+            f"{BASE_URL}{ROUNDS_INFORMATION_PATH}",
+            params={"item": ROUNDS_INFORMATION_ITEM_GUID, "uprn": user_uprn},
+            timeout=30,
+        )
+        resp.raise_for_status()
+
+        # The API response body is itself a JSON string containing an HTML fragment,
+        # e.g. "<strong>Food waste</strong>&nbsp;is collected <span ...>WEEKLY</span>
+        # on Thursday...". json.loads unwraps that outer string; html.unescape then
+        # decodes entities like &nbsp; so the regexes below can match plain text.
+        try:
+            raw_html = json.loads(resp.text)
+        except json.JSONDecodeError as ex:
+            raise ValueError(
+                "Unexpected response from Lewisham roundsinformation API (not JSON)."
+            ) from ex
+
+        normalised = html.unescape(raw_html).replace("\xa0", " ")
+        soup = BeautifulSoup(normalised, "html.parser")
+
+        # Each bin type is a <strong> tag; the day/frequency/date for that bin
+        # follows as plain text and <span> markup up until the next <strong> tag.
+        strong_tags = soup.find_all("strong")
+        if not strong_tags:
+            raise ValueError("No collection entries found for this UPRN.")
+
         bindata = {"bins": []}
+        for strong in strong_tags:
+            bin_type = strong.get_text(strip=True)
 
-        # Initialize the WebDriver (Chrome in this case)
-        with create_webdriver(
-            web_driver,
-            headless,
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36",
-            __name__,
-        ) as driver:
-
-            # Step 1: Navigate to the form page
-            driver.get(
-                "https://lewisham.gov.uk/myservices/recycling-and-rubbish/your-bins/collection"
-            )
-
-            try:
-                cookie_accept_button = WebDriverWait(driver, 5).until(
-                    EC.element_to_be_clickable(
-                        (By.ID, "CybotCookiebotDialogBodyLevelButtonLevelOptinAllowAll")
-                    )
+            segment = ""
+            for sibling in strong.next_siblings:
+                if getattr(sibling, "name", None) == "strong":
+                    break
+                # Tags have get_text(); loose text nodes (NavigableString) don't.
+                segment += (
+                    sibling.get_text() if hasattr(sibling, "get_text") else str(sibling)
                 )
-                cookie_accept_button.click()
-            except Exception:
-                print("No cookie consent banner found or already dismissed.")
 
-            # Wait for the form to load
-            WebDriverWait(driver, 10).until(
-                EC.presence_of_element_located((By.CLASS_NAME, "address-finder"))
-            )
+            date_match = _NEXT_DATE_PATTERN.search(segment)
+            day_match = _DAY_PATTERN.search(segment)
 
-            # Step 2: Locate the input field for the postcode
-            postcode_input = driver.find_element(
-                By.CLASS_NAME, "js-address-finder-input"
-            )
-
-            # Enter the postcode
-            postcode_input.send_keys(
-                user_postcode
-            )  # Replace with your desired postcode
-            time.sleep(1)  # Optional: Wait for the UI to react
-
-            # Step 4: Click the "Find address" button with retry logic
-            find_button = WebDriverWait(driver, 10).until(
-                EC.element_to_be_clickable(
-                    (By.CLASS_NAME, "js-address-finder-step-address")
+            if date_match:
+                # An explicit "your next collection date is dd/mm/yyyy" was given.
+                next_collection_date = date_match.group("date")
+            elif day_match:
+                # No explicit date (e.g. fortnightly collections without one) -
+                # fall back to the next occurrence of the named weekday. .title()
+                # normalises case, since get_next_day_of_week does an exact match.
+                next_collection_date = get_next_day_of_week(
+                    day_match.group("day").title(), date_format
                 )
-            )
-            find_button.click()
-
-            # Wait for the address selector to appear and options to load
-            WebDriverWait(driver, 10).until(
-                lambda d: len(
-                    d.find_element(By.ID, "address-selector").find_elements(
-                        By.TAG_NAME, "option"
-                    )
-                )
-                > 1
-            )
-
-            # Select the dropdown and print available options
-            address_selector = driver.find_element(By.ID, "address-selector")
-
-            # Use Select class to interact with the dropdown
-            select = Select(address_selector)
-            if len(select.options) > 1:
-                select.select_by_value(user_uprn)
             else:
-                print("No additional addresses available to select")
+                raise ValueError(
+                    f"Could not determine a collection day or date for '{bin_type}'."
+                )
 
-            # Wait until the URL contains the expected substring
-            WebDriverWait(driver, 10).until(
-                EC.url_contains("/find-your-collection-day-result")
+            bindata["bins"].append(
+                {"type": bin_type, "collectionDate": next_collection_date}
             )
 
-            # Parse the HTML
-            soup = BeautifulSoup(driver.page_source, "html.parser")
-
-            # Extract the main container
-            collection_result = soup.find("div", class_="js-find-collection-result")
-
-            # Extract each collection type and its frequency/day
-            for strong_tag in collection_result.find_all("strong"):
-                bin_type = strong_tag.text.strip()  # e.g., "Food waste"
-                # Extract the sibling text
-                schedule_text = (
-                    strong_tag.next_sibling.next_sibling.next_sibling.text.strip()
-                    .replace("\n", " ")
-                    .replace("\t", " ")
-                )
-
-                # Extract the day using regex
-                print(schedule_text)
-                day_match = re.search(r"on\s*(\w+day)", schedule_text)
-                print(day_match)
-                day = day_match.group(1) if day_match else None
-
-                # Extract the next collection date using regex
-                date_match = re.search(
-                    r"Your next collection date is\s*(\d{2}/\d{2}/\d{4})(.?)",
-                    schedule_text,
-                )
-                if date_match:
-                    next_collection_date = date_match.group(1)
-                else:
-                    next_collection_date = get_next_day_of_week(day, date_format)
-
-                dict_data = {
-                    "type": bin_type,
-                    "collectionDate": next_collection_date,
-                }
-                bindata["bins"].append(dict_data)
-
-            return bindata
+        bindata["bins"].sort(
+            key=lambda x: datetime.strptime(x["collectionDate"], date_format)
+        )
+        return bindata

--- a/wiki/Councils.md
+++ b/wiki/Councils.md
@@ -2399,15 +2399,13 @@ Note: Pass the UPRN. You can find it using [FindMyAddress](https://www.findmyadd
 
 ### Lewisham
 ```commandline
-python collect_data.py LondonBoroughLewisham https://www.lewisham.gov.uk -s -u XXXXXXXX -p "XXXX XXX" -w http://HOST:PORT/
+python collect_data.py LondonBoroughLewisham https://www.lewisham.gov.uk -s -u XXXXXXXX
 ```
 Additional parameters:
 - `-s` - skip get URL
 - `-u` - UPRN
-- `-p` - postcode
-- `-w` - remote Selenium web driver URL (required for Home Assistant)
 
-Note: Pass the UPRN and postcode. To get the UPRN, you can use [FindMyAddress](https://www.findmyaddress.co.uk/search).
+Note: Pass the UPRN. To get the UPRN, you can use [FindMyAddress](https://www.findmyaddress.co.uk/search).
 
 ---
 


### PR DESCRIPTION
Relates to #2142. Lewisham's site is backed by a stateless JSON API, so scraping no longer needs a browser/Selenium grid.

  - Rewrites LondonBoroughLewisham.py to call the API directly instead of driving Chrome
  - Adds shared build_retry_session() and get_scraper_user_agent() helpers to common.py
  - Updates tests/input.json and wiki/Councils.md (drops the now-unused web_driver/postcode config)
  - Adds unit tests for the new common.py helpers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lewisham collection lookups now work with just a UPRN, simplifying the input needed to fetch bin data.

* **Bug Fixes**
  * Improved handling of saved input values so missing values no longer overwrite existing data.
  * Added more resilient network requests for better reliability during data retrieval.

* **Documentation**
  * Updated usage guidance to reflect the simpler Lewisham command and required input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->