### PR TITLE
Fix: Wigan Borough Council - updated Search.aspx endpoint and date div class name (#2136)

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/WiganBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/WiganBoroughCouncil.py
@@ -31,7 +31,7 @@ class CouncilClass(AbstractGetBinDataClass):
         s = requests.Session()
 
         # Get our initial session running
-        response = s.get("https://apps.wigan.gov.uk/MyNeighbourhood/")
+        response = s.get("https://apps.wigan.gov.uk/MyNeighbourhood/MyArea.aspx")
 
         soup = BeautifulSoup(response.text, features="html.parser")
         soup.prettify()
@@ -49,8 +49,10 @@ class CouncilClass(AbstractGetBinDataClass):
             "ctl00$ContentPlaceHolder1$btnPostcodeSearch": ("Search"),
         }
 
-        # Use the above to get to the next page with address selection
-        response = s.post("https://apps.wigan.gov.uk/MyNeighbourhood/", payload)
+        # Use the above to get to the next page with address selection.
+        # Note: the postcode form's action now points at Search.aspx
+        # rather than posting back to MyArea.aspx itself.
+        response = s.post("https://apps.wigan.gov.uk/MyNeighbourhood/Search.aspx", payload)
 
         soup = BeautifulSoup(response.text, features="html.parser")
         soup.prettify()
@@ -72,7 +74,7 @@ class CouncilClass(AbstractGetBinDataClass):
         }
 
         # Get the final page with the actual dates
-        response = s.post("https://apps.wigan.gov.uk/MyNeighbourhood/", payload)
+        response = s.post("https://apps.wigan.gov.uk/MyNeighbourhood/Search.aspx", payload)
 
         soup = BeautifulSoup(response.text, features="html.parser")
         soup.prettify()
@@ -82,9 +84,17 @@ class CouncilClass(AbstractGetBinDataClass):
         # Get the dates.
         for bins in soup.find_all("div", {"class": "BinsRecycling"}):
             bin_type = bins.find("h2").text
-            binCollection = bins.find("div", {"class": "dateWrap-next"}).get_text(
-                strip=True
-            )
+            date_wrap = bins.find("div", {"class": "dateWrapper-next"})
+            if date_wrap is None:
+                # Fall back to the old class name in case the council
+                # reverts, and raise a clearer error if neither is found.
+                date_wrap = bins.find("div", {"class": "dateWrap-next"})
+            if date_wrap is None:
+                raise ValueError(
+                    f"Could not find next-collection date for bin type "
+                    f"'{bin_type}' - Wigan's page markup may have changed again."
+                )
+            binCollection = date_wrap.get_text(strip=True)
             binData = datetime.strptime(
                 re.sub(r"(\d)(st|nd|rd|th)", r"\1", binCollection), "%A%d%b%Y"
             )


### PR DESCRIPTION
Wigan's My Neighbourhood site changed in two ways that broke the scraper:

- The postcode-search and address-selection postbacks now target Search.aspx instead of posting back to MyArea.aspx itself.
- The "next collection" date div was renamed from dateWrap-next to dateWrapper-next (contents are now nested spans rather than a flat text node, but get_text(strip=True) still concatenates them into the same "Friday17thJul2026"-style string the existing regex and strptime already handle, so no parsing changes were needed there).

Updates both POST endpoints to Search.aspx, and updates the date lookup to use dateWrapper-next with a fallback to the old class name plus a clearer ValueError if neither is found, so a future markup change fails loudly instead of raising an opaque AttributeError.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated postcode lookup and collection-date retrieval to match the council’s latest web pages.
  * Improved fallback handling for bin collection date sections, so results are more resilient when the page layout changes.
  * Added a clearer error when the expected date information cannot be found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->