### PR TITLE
fix: update Rugby Borough Council scraper

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/RugbyBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/RugbyBoroughCouncil.py
@@ -19,7 +19,9 @@ class CouncilClass(AbstractGetBinDataClass):
             "https://apps.cloud9technologies.com/rugby/citizenmobile/webapi/"
             f"wastecollections/{user_uprn}"
         )
-        json_data = requests.get(api_url).json()
+        response = requests.get(api_url, timeout=30)
+        response.raise_for_status()
+        json_data = response.json()
 
         waste_collection_dates = json_data["wasteCollectionDates"]
 

--- a/uk_bin_collection/uk_bin_collection/councils/RugbyBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/RugbyBoroughCouncil.py
@@ -1,16 +1,9 @@
-import time
-
-from bs4 import BeautifulSoup
-from selenium.webdriver.common.by import By
-from selenium.webdriver.common.keys import Keys
-from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.support.ui import Select, WebDriverWait
+import requests
 
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
 
-# import the wonderful Beautiful Soup and the URL grabber
 class CouncilClass(AbstractGetBinDataClass):
     """
     Concrete classes have to implement all abstract operations of the
@@ -19,129 +12,33 @@ class CouncilClass(AbstractGetBinDataClass):
     """
 
     def parse_data(self, page: str, **kwargs) -> dict:
-        driver = None
-        try:
-            user_postcode = kwargs.get("postcode")
-            if not user_postcode:
-                raise ValueError("No postcode provided.")
-            check_postcode(user_postcode)
+        user_uprn = kwargs.get("uprn")
+        check_uprn(user_uprn)
 
-            user_uprn = kwargs.get("uprn")
-            check_uprn(user_uprn)
+        api_url = (
+            "https://apps.cloud9technologies.com/rugby/citizenmobile/webapi/"
+            f"wastecollections/{user_uprn}"
+        )
+        json_data = requests.get(api_url).json()
 
-            headless = kwargs.get("headless")
-            web_driver = kwargs.get("web_driver")
-            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
-            driver = create_webdriver(web_driver, headless, user_agent, __name__)
-            page = "https://www.rugby.gov.uk/check-your-next-bin-day"
+        waste_collection_dates = json_data["wasteCollectionDates"]
 
-            driver.get(page)
+        data = {"bins": []}
 
-            wait = WebDriverWait(driver, 60)
-            accept_cookies_button = wait.until(
-                EC.element_to_be_clickable(
-                    (
-                        By.ID,
-                        "ccc-recommended-settings",
-                    )
-                )
-            )
-            accept_cookies_button.click()
+        for key, collection in waste_collection_dates.items():
+            if not key.startswith("container") or not collection:
+                continue
 
-            postcode_input = WebDriverWait(driver, 10).until(
-                EC.presence_of_element_located(
-                    (
-                        By.XPATH,
-                        '//*[@id="_com_placecube_digitalplace_local_waste_portlet_CollectionDayFinderPortlet_postcode"]',
-                    )
-                )
-            )
-            postcode_input.send_keys(user_postcode + Keys.TAB + Keys.ENTER)
+            collection_date = datetime.fromisoformat(collection["collectionDate"])
 
-            time.sleep(5)
-            # Wait for address box to be visible
-            select_address_input = WebDriverWait(driver, 10).until(
-                EC.presence_of_element_located(
-                    (
-                        By.ID,
-                        "_com_placecube_digitalplace_local_waste_portlet_CollectionDayFinderPortlet_uprn",
-                    )
-                )
-            )
+            dict_data = {
+                "type": collection["containerDescription"],
+                "collectionDate": collection_date.strftime(date_format),
+            }
+            data["bins"].append(dict_data)
 
-            # Select address based
-            select = Select(select_address_input)
-            for option in select.options:
-                if option.get_attribute("value") == str(user_uprn):
-                    select.select_by_value(str(user_uprn))
-                    break
-            else:
-                raise ValueError(f"UPRN {user_uprn} not found in address options")
+        data["bins"].sort(
+            key=lambda x: datetime.strptime(x.get("collectionDate"), date_format)
+        )
 
-            select_address_input.send_keys(Keys.TAB + Keys.ENTER)
-
-            # Wait for the specified table to be present
-            target_table = WebDriverWait(driver, 10).until(
-                EC.presence_of_element_located(
-                    (
-                        By.XPATH,
-                        '//*[@id="portlet_com_placecube_digitalplace_local_waste_portlet_CollectionDayFinderPortlet"]/div/div/div/div/table',
-                    )
-                )
-            )
-
-            soup = BeautifulSoup(driver.page_source, "html.parser")
-
-            # Initialize bin data dictionary
-            bin_data = {"bins": []}
-
-            # Find the table
-            table = soup.find("table", class_="table")
-            if table:
-                # Find all rows in tbody
-                rows = table.find("tbody").find_all("tr")
-
-                for row in rows:
-                    # Get all cells in the row
-                    cells = row.find_all("td")
-                    if len(cells) >= 4:  # Ensure we have enough cells
-                        bin_type = cells[0].text.strip()
-                        next_collection = cells[1].text.strip()
-                        following_collection = cells[3].text.strip()
-
-                        # Parse the dates
-                        for collection_date in [next_collection, following_collection]:
-                            try:
-                                # Convert date from "Friday 09 May 2025" format
-                                parsed_date = datetime.strptime(
-                                    collection_date, "%A %d %b %Y"
-                                )
-                                formatted_date = parsed_date.strftime("%d/%m/%Y")
-
-                                bin_info = {
-                                    "type": bin_type,
-                                    "collectionDate": formatted_date,
-                                }
-                                bin_data["bins"].append(bin_info)
-                            except ValueError as e:
-                                print(f"Error parsing date {collection_date}: {e}")
-            else:
-                raise ValueError("Collection data table not found")
-
-            # Sort the collections by date
-            bin_data["bins"].sort(
-                key=lambda x: datetime.strptime(x["collectionDate"], "%d/%m/%Y")
-            )
-
-            #print(bin_data)
-
-        except Exception as e:
-            # Here you can log the exception if needed
-            print(f"An error occurred: {e}")
-            # Optionally, re-raise the exception if you want it to propagate
-            raise
-        finally:
-            # This block ensures that the driver is closed regardless of an exception
-            if driver:
-                driver.quit()
-        return bin_data
+        return data


### PR DESCRIPTION
## Summary

Updates the Rugby Borough Council module to use the Cloud9 waste collections API now used by the live Rugby Borough Council bin day page.

Rugby no longer exposes the old Liferay `CollectionDayFinderPortlet` form that the previous Selenium scraper depended on. The live page now embeds a Cloud9 web component:

```html
<c9-waste-collections client-id="rugby"></c9-waste-collections>
```

That component calls:

```text
https://apps.cloud9technologies.com/rugby/citizenmobile/webapi/wastecollections/{uprn}
```

This PR replaces the broken Selenium selector flow with the same API endpoint used by the live page.

## Fixes

Fixes #2147

## Testing

Tested locally with a public Rugby UPRN example:

```bash
python uk_bin_collection/uk_bin_collection/collect_data.py \
  RugbyBoroughCouncil \
  "https://www.rugby.gov.uk/check-your-next-bin-day" \
  -p "CV22 5EA" \
  -u "100070193903" \
  -w "http://localhost:4444/wd/hub"
```

Output:

```json
{
    "bins": [
        {
            "type": "Blue-lid recycling bin",
            "collectionDate": "10/07/2026"
        },
        {
            "type": "Food caddy",
            "collectionDate": "15/07/2026"
        },
        {
            "type": "Black refuse bin",
            "collectionDate": "17/07/2026"
        }
    ]
}
```

Also ran:

```bash
python -m py_compile uk_bin_collection/uk_bin_collection/councils/RugbyBoroughCouncil.py
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Waste collection dates for Rugby Borough Council are now retrieved directly from a live data source for faster, more reliable updates.
  * Bin collection entries are displayed in chronological order for easier planning.

* **Bug Fixes**
  * Improved formatting and handling of collection dates to ensure consistent, correct schedules.
  * Reduced reliance on browser-based page loading, helping prevent scraping-related failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->