### PR TITLE
fix: #2127 detect EnvironmentFirst DB outage, raise a clear error

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/EastbourneBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/EastbourneBoroughCouncil.py
@@ -28,6 +28,17 @@ class CouncilClass(AbstractGetBinDataClass):
             raise ValueError(f"Error getting identifier: {str(e)}")
 
         page = requests.get(url)
+        if "mysqli_sql_exception" in page.text or "Fatal error" in page.text:
+            # The site occasionally returns HTTP 200 with a PHP fatal error
+            # in the body instead of any markup, when EnvironmentFirst's own
+            # database is unreachable - see #2127. That's an outage on their
+            # end, not something a UPRN retry can fix, so raise a clear
+            # message rather than silently returning no bins.
+            raise ConnectionError(
+                "EnvironmentFirst's bin lookup service is returning a server "
+                "error (their database is unreachable) - this is an outage "
+                "on their end, not this scraper. Try again later."
+            )
         soup = BeautifulSoup(page.text, features="html.parser")
         soup.prettify()
 
@@ -44,9 +55,7 @@ class CouncilClass(AbstractGetBinDataClass):
         # Some properties also have an introductory paragraph between the address
         # and the dates. Identify each row by the surrounding label rather than by
         # a fixed index — paragraph counts have shifted twice in 12 months.
-        date_pattern = re.compile(
-            r"(\d{1,2}(?:st|nd|rd|th)?\s+[A-Za-z]+\s+\d{4})"
-        )
+        date_pattern = re.compile(r"(\d{1,2}(?:st|nd|rd|th)?\s+[A-Za-z]+\s+\d{4})")
 
         for p in collect_div.find_all("p"):
             strong = p.find("strong")
@@ -66,9 +75,9 @@ class CouncilClass(AbstractGetBinDataClass):
                 continue
             cleaned = remove_ordinal_indicator_from_date_string(match.group(1))
             try:
-                collection_date = datetime.strptime(
-                    cleaned, "%d %B %Y"
-                ).strftime(date_format)
+                collection_date = datetime.strptime(cleaned, "%d %B %Y").strftime(
+                    date_format
+                )
             except ValueError:
                 continue
             data["bins"].append(

--- a/uk_bin_collection/uk_bin_collection/councils/LewesDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/LewesDistrictCouncil.py
@@ -28,6 +28,17 @@ class CouncilClass(AbstractGetBinDataClass):
             raise ValueError(f"Error getting identifier: {str(e)}")
 
         page = requests.get(url)
+        if "mysqli_sql_exception" in page.text or "Fatal error" in page.text:
+            # The site occasionally returns HTTP 200 with a PHP fatal error
+            # in the body instead of any markup, when EnvironmentFirst's own
+            # database is unreachable - see #2127. That's an outage on their
+            # end, not something a UPRN retry can fix, so raise a clear
+            # message rather than silently returning no bins.
+            raise ConnectionError(
+                "EnvironmentFirst's bin lookup service is returning a server "
+                "error (their database is unreachable) - this is an outage "
+                "on their end, not this scraper. Try again later."
+            )
         soup = BeautifulSoup(page.text, features="html.parser")
         soup.prettify()
 
@@ -36,9 +47,7 @@ class CouncilClass(AbstractGetBinDataClass):
         if collect_div is None:
             return data
 
-        date_pattern = re.compile(
-            r"(\d{1,2}(?:st|nd|rd|th)?\s+[A-Za-z]+\s+\d{4})"
-        )
+        date_pattern = re.compile(r"(\d{1,2}(?:st|nd|rd|th)?\s+[A-Za-z]+\s+\d{4})")
 
         for p in collect_div.find_all("p"):
             strong = p.find("strong")
@@ -58,9 +67,9 @@ class CouncilClass(AbstractGetBinDataClass):
                 continue
             cleaned = remove_ordinal_indicator_from_date_string(match.group(1))
             try:
-                collection_date = datetime.strptime(
-                    cleaned, "%d %B %Y"
-                ).strftime(date_format)
+                collection_date = datetime.strptime(cleaned, "%d %B %Y").strftime(
+                    date_format
+                )
             except ValueError:
                 continue
             data["bins"].append(


### PR DESCRIPTION
## Summary

Implements the low-priority improvement suggested by the reporter in #2127. The outage they diagnosed has since self-healed (confirmed live), but the underlying gap remains: `LewesDistrictCouncil`/`EastbourneBoroughCouncil` (same script, shared by both councils via `environmentfirst.co.uk`) silently returned an empty bins list whenever the site returned an HTTP 200 with a raw PHP fatal error (`mysqli_sql_exception`) in the body instead of markup - indistinguishable from "no bins found" or a stale UPRN.

Now detects that error body and raises a clear `ConnectionError` explaining it's an upstream outage, not a scraper bug - so anyone hitting this in the future gets an actionable message instead of a silent empty result.

## Side effect for Lewes/Eastbourne users

During this specific type of outage, behaviour changes from "quietly keep showing the last known good collection dates" to "go `unavailable` with a clear log message". That's arguably more honest (you're no longer looking at silently-stale dates), but it is a visible behaviour change for anyone on these two councils during a future EnvironmentFirst outage - HA sensors will go `unavailable` instead of holding the last cached date. Scoped only to `LewesDistrictCouncil`/`EastbourneBoroughCouncil`; no other council is affected.

## Test plan

- [x] Verified live that a mocked DB-outage response now raises the clear error for both councils
- [x] Verified live against the (currently healthy) real site that normal responses are unaffected
- [x] `poetry run pytest uk_bin_collection/tests custom_components/uk_bin_collection/tests --ignore=uk_bin_collection/tests/step_defs/` - 219 passed
- [x] `black --check` clean

Fixes #2127
