### PR TITLE
fix: #2158 AberdeenshireCouncil - stop fetching the unused root URL

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/AberdeenshireCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/AberdeenshireCouncil.py
@@ -13,6 +13,15 @@ class CouncilClass(AbstractGetBinDataClass):
     implementation.
     """
 
+    @classmethod
+    def get_data(cls, url) -> str:
+        # parse_data() below ignores the fetched page entirely and makes its
+        # own request to a different, specific endpoint. The bare root URL
+        # (online.aberdeenshire.gov.uk/) this would otherwise fetch can
+        # itself return 500 even while the real data endpoint is healthy -
+        # skip the unused fetch so that doesn't take the scraper down.
+        return ""
+
     def parse_data(self, page: str, **kwargs) -> dict:
 
         user_uprn = kwargs.get("uprn")


### PR DESCRIPTION
## Summary

Priority fix for #2158, and one of the 3 new failures found in a fresh full-suite run.

Root cause: this is a self-inflicted regression from the #2073 retry fix (PR #2155, already merged). `AberdeenshireCouncil.parse_data()` completely ignores the `page` it's given and makes its own request to a specific, working endpoint (`/Apps/Waste-Collections/Routes/Route/{uprn}`) - but the generic framework fetch to the bare root URL (`online.aberdeenshire.gov.uk/`, from `input.json`'s `url` field) ran first regardless, since this council was never marked `skip_get_url`. That root URL is currently returning a persistent HTTP 500 on the council's own end - previously harmless (a bare `requests.get()` doesn't raise on non-2xx status), but the #2073 fix's retry session correctly (and now, for this council, unfortunately) turns 5 straight 500s into a hard `RetryError`, before `parse_data()` (which never needed that page anyway) even runs.

Verified live: `online.aberdeenshire.gov.uk/` → 500, but `online.aberdeenshire.gov.uk/Apps/Waste-Collections/Routes/Route/{uprn}` → 200 with valid data, at the same moment.

Fix: override `get_data()` in `AberdeenshireCouncil.py` to skip the fetch entirely (return `""`) rather than relying on `skip_get_url` - that flag comes from each user's already-saved HA config data, which existing installs don't have, so setting it in `input.json` alone would only fix the test suite, not real users. This fix works immediately on upgrade with zero config changes needed. Verified via the actual CLI entrypoint HA uses, with no `skip_get_url` flag passed (matching existing users' saved config).

## Broader finding (not fixed here, flagging for awareness)

Found **59 councils** with this same shape - `parse_data()` ignores `page` and makes its own request, but `skip_get_url` isn't set. Most are harmless (their `url` field happens to point at a healthy resource that's just redundantly fetched), so I haven't touched them. Cross-referenced against a fresh full-suite run: only Aberdeenshire and (initially suspected, then ruled out - see below) Fylde are currently affected. Worth a slower systematic audit at some point, but not urgent since only one is actually live.

## Test plan

- [x] Verified live: root URL 500s, actual data endpoint 200s with valid data
- [x] `poetry run pytest uk_bin_collection/tests/step_defs/ -k AberdeenshireCouncil` - passed
- [x] Verified via CLI (`collect_data.py`) with no `skip_get_url` flag, matching existing users' saved config - returns correct bin data
- [x] `black --check` clean

Fixes #2158

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved waste collection information handling for Aberdeenshire Council when no root-page content is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->