### PR TITLE
fix: EastDevonDC - identify scraper with a User-Agent header

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/EastDevonDC.py
+++ b/uk_bin_collection/uk_bin_collection/councils/EastDevonDC.py
@@ -7,6 +7,10 @@ from bs4 import BeautifulSoup
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
+# eastdevon.gov.uk 403s any request using the default python-requests
+# User-Agent - identify the scraper honestly instead.
+_HEADERS = {"User-Agent": get_scraper_user_agent()}
+
 
 def _match_address(addresses, uprn=None, paon=None):
     """Match an address from addressfinder results by UPRN or house number/name."""
@@ -28,15 +32,13 @@ def _match_address(addresses, uprn=None, paon=None):
                 return addr
 
     if uprn or paon:
-        raise ValueError(
-            f"Address not found for UPRN={uprn} PAON={paon}"
-        )
+        raise ValueError(f"Address not found for UPRN={uprn} PAON={paon}")
     return addresses[0]
 
 
 def _parse_calendar_page(url):
     """Parse the existing calendar page by UPRN (legacy path)."""
-    page = requests.get(url, timeout=30)
+    page = requests.get(url, headers=_HEADERS, timeout=30)
     page.raise_for_status()
     soup = BeautifulSoup(page.text, features="html.parser")
 
@@ -109,6 +111,7 @@ class CouncilClass(AbstractGetBinDataClass):
             resp = requests.get(
                 "https://eastdevon.gov.uk/addressfinder",
                 params={"qtype": "bins", "term": user_postcode},
+                headers=_HEADERS,
                 timeout=30,
             )
             resp.raise_for_status()
@@ -119,9 +122,7 @@ class CouncilClass(AbstractGetBinDataClass):
                 user_uprn = matched.get("UPRN")
 
         if not user_uprn:
-            raise ValueError(
-                "Could not resolve address. Provide a postcode or UPRN."
-            )
+            raise ValueError("Could not resolve address. Provide a postcode or UPRN.")
 
         # East Devon requires 12-digit zero-padded UPRNs
         user_uprn = str(user_uprn).zfill(12)


### PR DESCRIPTION
## Summary

One of the 17 previously-known-broken councils from the latest full-suite triage. Confirmed live: \`eastdevon.gov.uk\` returns 403 for the default python-requests User-Agent on both the addressfinder API and the calendar page, and 200 for either a browser UA or this project's own polite scraper identification string (\`uk-bin-collection/<version> (+repo url)\`, already used elsewhere via \`get_scraper_user_agent()\`). Sent that header on both requests.

## Test plan

- [x] Verified live: 403 with default UA, 200 with \`get_scraper_user_agent()\` on both requests
- [x] Verified live end-to-end: returns correct multi-week bin data
- [x] \`black --check\` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved East Devon bin collection lookups to reduce failed requests.
  * Maintained clear validation messaging when an address cannot be resolved.
  * Preserved existing address matching and calendar parsing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->