### PR TITLE
chore: HorshamDistrictCouncil - use retry session for resilience

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/HorshamDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/HorshamDistrictCouncil.py
@@ -20,8 +20,7 @@ class CouncilClass(AbstractGetBinDataClass):
         user_paon = kwargs.get("paon")
         check_postcode(user_postcode)
 
-        s = requests.Session()
-        s.headers.update(HEADERS)
+        s = build_retry_session(headers=HEADERS, retry_methods=("GET", "POST"))
 
         r = s.post(
             f"{SAT_BASE}/cal2.asp",
@@ -94,10 +93,12 @@ class CouncilClass(AbstractGetBinDataClass):
                         continue
                     try:
                         dt = datetime.strptime(date_str, "%d/%m/%Y")
-                        bin_data["bins"].append({
-                            "type": bin_type,
-                            "collectionDate": dt.strftime(date_format),
-                        })
+                        bin_data["bins"].append(
+                            {
+                                "type": bin_type,
+                                "collectionDate": dt.strftime(date_format),
+                            }
+                        )
                     except ValueError:
                         continue
 


### PR DESCRIPTION
## Summary

Minor hardening found while triaging the full council suite - Horsham's scraper used a plain \`requests.Session()\` with no retry logic, and is currently hitting \`ConnectionResetError\`. Switched to the existing \`build_retry_session()\` helper for consistency with the rest of the codebase.

**Note:** this does not fix the council's current failure - verified live that it still fails after 5 retries, so this is a sustained block/outage on their end, not a transient blip retries can paper over. Keeping this as defensive hardening for future transient issues; the live failure needs separate investigation (not done here).

## Test plan

- [x] `black --check` clean
- [x] Confirmed no behavior change for the success path (same headers, same request shape)