### PR TITLE
Post-#2154 triage fixes: Aberdeenshire regression (#2158), East Devon, Horsham hardening

### DIFF
--- a/ISSUE_RESOLUTION_PROGRESS.md
+++ b/ISSUE_RESOLUTION_PROGRESS.md
@@ -1,7 +1,88 @@
 # Issue Resolution Progress
 
-## Next Issue: continue nightly-suite triage (Halton/Mid & East Antrim/West Oxfordshire genuine
-Selenium timeouts, or #1560 Gateshead - now have a local Selenium grid)
+## Next Issue: individual investigation of the remaining Selenium timeouts (EastLindsey,
+Angus, Ashfield, Halton, BarkingDagenham, MidAndEastAntrim) - each needs its own
+selector/page-change archaeology, not done yet; or #1560 Gateshead - now have a local
+Selenium grid
+
+## Post-#2154-merge full-suite triage (2026-07-13)
+
+Reconfigured the local Docker Selenium grid for real concurrency (was capped at
+`SE_NODE_MAX_SESSIONS=1`, causing most of the earlier "66 failed" run to be pure
+session-contention noise) - recreated with `SE_NODE_MAX_SESSIONS=8`,
+`SE_NODE_OVERRIDE_MAX_SESSIONS=true`, `--shm-size 4g` (host has 32 CPU/32GB available
+to Docker). Ran the full 352-council suite at `-n 8` (matched to the grid's real
+capacity, not `-n logical`/32 which would just recreate the contention problem): **26
+failed, 326 passed in 5m21s** - a much cleaner signal than the previous run.
+
+**Found and fixed a self-inflicted regression** from the #2073 retry fix (shipped in
+0.168.0): `AberdeenshireCouncil`'s `parse_data()` ignores the page it's given and
+makes its own request to a working endpoint, but the generic framework fetch to an
+*unused* root URL ran first regardless - that URL happens to return a persistent 500
+on the council's own end, and the new retry logic correctly (if unfortunately) turned
+that into a hard failure, breaking every user's sensors (reported live as #2158).
+Fixed by overriding `get_data()` for that council to skip the pointless fetch - see
+[PR #2159](https://github.com/robbrad/UKBinCollectionData/pull/2159). Found 59 other
+councils with the same *shape* (page ignored, own request made, no `skip_get_url`)
+via AST scan, but cross-referenced against real failures and only Aberdeenshire is
+currently affected - the rest have `url` fields that happen to point somewhere
+healthy. Worth a slower systematic audit sometime, not urgent.
+
+Triage of the 26 failures:
+- **2 transient** (CheltenhamBoroughCouncil, BoltonCouncil) - DNS failures during the
+  run, hosts resolve fine on recheck.
+- **4 stale test fixtures** - NorthWestLeicestershire/OrkneyIslandsCouncil (missing
+  disambiguation params), SouthendOnSeaCityCouncil/TamworthBoroughCouncil (fixture
+  UPRN has no live collections). Also newly found: **IsleOfWightCouncil and
+  NewarkAndSherwoodDC's "Invalid postcode Status: 404"** turned out to be the same
+  root cause - both fixtures are missing the required `postcode` field entirely
+  (only `uprn` is set), so `check_postcode(None)` queries
+  `api.postcodes.io/postcodes/None` and legitimately 404s. Not a scraper bug; needs
+  a maintainer to supply a real postcode for the existing UPRN (couldn't resolve one
+  via free public UPRN-lookup APIs).
+- **3 fixed:**
+  - AberdeenshireCouncil (#2158) - see above, [PR #2159](https://github.com/robbrad/UKBinCollectionData/pull/2159)
+  - EastDevonDC - 403 was purely a missing User-Agent header (default
+    `python-requests/x.x` UA gets blocked; the project's own polite scraper UA
+    string works fine). [PR #2160](https://github.com/robbrad/UKBinCollectionData/pull/2160)
+  - GlasgowCityCouncil, KnowsleyMBCouncil, Hillingdon - re-ran clean on retest
+    (KnowsleyMBCouncil 3/3, GlasgowCityCouncil and Hillingdon both passed on a
+    sequential re-run with no worker contention) - these were flakes from the old
+    single-session grid, not real bugs. No code change needed.
+- **1 hardened, not fixed:** HorshamDistrictCouncil - switched to
+  `build_retry_session()` for consistency ([PR #2161](https://github.com/robbrad/UKBinCollectionData/pull/2161)),
+  but verified live it still fails after 5 retries - a sustained block/outage on
+  their end, not a transient blip. Live issue remains unfixed.
+- **16 confirmed genuinely broken, not fixed this pass:**
+  - **GedlingBoroughCouncil** - `api.gbcbincalendars.co.uk` is unstable right now:
+    3 separate live attempts gave 3 different failures (500, 500, ReadTimeout).
+    Not us; their backend.
+  - **DartfordBoroughCouncil** - the scraper's endpoint
+    (`windmz.dartford.gov.uk/ufs/...`) now 404s under a bare default IIS placeholder
+    page - the whole legacy "Universal Form Service" subsystem looks decommissioned.
+    The council's *own* current site still links to this dead endpoint, so there's
+    no alternative URL to fall back to yet. Needs the council to actually publish a
+    working replacement before this is fixable.
+  - **FyldeCouncil** - the page no longer has the `bartec-iframe` the scraper looks
+    for; the whole page has moved to a login-gated "personal waste account" system
+    with no public UPRN-based lookup visible anymore. Likely needs a much bigger
+    rework (if even feasible without real user credentials), not a quick selector
+    fix.
+  - **SwaleBoroughCouncil** - confirmed Cloudflare bot-check blocking page load
+    (the scraper's own diagnostic print already says so). Same class of problem as
+    Sunderland (#2140, fixed with undetected-chromedriver) / Haringey (#2113,
+    still unfixed - AWS WAF, not Cloudflare). Not attempted this pass.
+  - **EastLindseyDistrictCouncil, AngusCouncil, HaltonBoroughCouncil,
+    AshfieldDistrictCouncil, BarkingDagenham, MidAndEastAntrimBoroughCouncil** -
+    confirmed genuinely broken on a sequential re-run (not contention), each with a
+    generic Selenium `TimeoutException` (or `ElementNotInteractableException` /
+    `NoSuchFrameException`) - needs individual selector/page-change investigation
+    per council, not done this pass given time already spent.
+  - **HaringeyCouncil, NorthEastDerbyshireDistrictCouncil** - already deeply
+    investigated earlier this session (see "Investigated, not fixed" below);
+    unchanged.
+
+## July 2026 Release: [PR #2154](https://github.com/robbrad/UKBinCollectionData/pull/2154) (merged) + [PR #2155](https://github.com/robbrad/UKBinCollectionData/pull/2155) (follow-up)
 
 ## July 2026 Release: [PR #2154](https://github.com/robbrad/UKBinCollectionData/pull/2154) (merged) + [PR #2155](https://github.com/robbrad/UKBinCollectionData/pull/2155) (follow-up)
 
@@ -131,6 +212,9 @@ this is a maintainer decision, not made in this session.
 | 3d61f3d6 | get_bin_data.py (shared) | Use build_retry_session() for the default HTTP fetch |
 | d3af17bd | RochfordCouncil | Use end of collection-week range; harden mojibake separator parsing |
 | 16df19e8 | custom_components/sensor.py | Base bin sensor availability on coordinator.last_update_success |
+| 28627dc3 | AberdeenshireCouncil | Skip unused root-URL fetch that was breaking the whole scraper (#2158) |
+| 29a242d0 | EastDevonDC | Send scraper User-Agent header to get past a 403 block |
+| 7a5a585e | HorshamDistrictCouncil | Use build_retry_session() for resilience (hardening, not a fix) |
 | 65261e47 | LincolnCouncil | Fix NoneType error when UPRN not provided (zfill on None) [prior session] |
 
 ## Nightly integration suite triage
@@ -182,8 +266,8 @@ investigated), ForestOfDeanDistrictCouncil (Selenium, empty bins, not yet invest
 |-------|---------|------|-------|
 | #2153 | Lincoln | Bug (no repro) | Works fine with known-good test UPRN; asked reporter for error/UPRN/postcode |
 | #2127 | Lewes/Eastbourne/Seaford | Info only | Reporter already diagnosed as upstream DB outage, not a code bug |
-| #2118 | Flintshire | Enhancement | Add Brown/Garden waste entity |
-| #2079 | Slough | Bug (Selenium timeout) | Cookie banner element never appears in headless mode |
+| #2118 | Flintshire | Enhancement | Scraper already correctly extracts "Brown Bin" when present (verified live) - likely an opt-in subscription question, not a code gap. Also found an unrelated minor bug: a schedule-note row (`*New Round* - Tuesday AHP`) gets parsed as if it were a bin type. Asked reporter to confirm subscription status. |
+| #2079 | Slough | Bug (Selenium timeout) | Could not reproduce: exact production config succeeded 5/5 live runs, <1.1s each. The community-proposed fix's diagnosis (Cloudflare, zero window size) doesn't hold up - no Cloudflare signature in headers, and window-size is already hardcoded to 1920x1080 regardless of council code. Likely transient or reporter-environment-specific (e.g. cloud/CI IP). Commented asking reporter to confirm it's still happening. |
 | #1986 | Mid Suffolk | Enhancement | Expose additional future collection dates |
 | #1784 | Selenium Addon Removed | HA ecosystem | Not a code bug - HA's Selenium add-on repo was removed; needs a docs/wiki note about running `selenium/standalone-chrome` via Docker instead |
 | #1560 | Gateshead | Bug (wrong dates) | Now have a local Selenium grid available - worth revisiting next session |

--- a/uk_bin_collection/uk_bin_collection/councils/AberdeenshireCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/AberdeenshireCouncil.py
@@ -13,6 +13,15 @@ class CouncilClass(AbstractGetBinDataClass):
     implementation.
     """
 
+    @classmethod
+    def get_data(cls, url) -> str:
+        # parse_data() below ignores the fetched page entirely and makes its
+        # own request to a different, specific endpoint. The bare root URL
+        # (online.aberdeenshire.gov.uk/) this would otherwise fetch can
+        # itself return 500 even while the real data endpoint is healthy -
+        # skip the unused fetch so that doesn't take the scraper down.
+        return ""
+
     def parse_data(self, page: str, **kwargs) -> dict:
 
         user_uprn = kwargs.get("uprn")

--- a/uk_bin_collection/uk_bin_collection/councils/EastDevonDC.py
+++ b/uk_bin_collection/uk_bin_collection/councils/EastDevonDC.py
@@ -7,6 +7,10 @@ from bs4 import BeautifulSoup
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
+# eastdevon.gov.uk 403s any request using the default python-requests
+# User-Agent - identify the scraper honestly instead.
+_HEADERS = {"User-Agent": get_scraper_user_agent()}
+
 
 def _match_address(addresses, uprn=None, paon=None):
     """Match an address from addressfinder results by UPRN or house number/name."""
@@ -28,15 +32,13 @@ def _match_address(addresses, uprn=None, paon=None):
                 return addr
 
     if uprn or paon:
-        raise ValueError(
-            f"Address not found for UPRN={uprn} PAON={paon}"
-        )
+        raise ValueError(f"Address not found for UPRN={uprn} PAON={paon}")
     return addresses[0]
 
 
 def _parse_calendar_page(url):
     """Parse the existing calendar page by UPRN (legacy path)."""
-    page = requests.get(url, timeout=30)
+    page = requests.get(url, headers=_HEADERS, timeout=30)
     page.raise_for_status()
     soup = BeautifulSoup(page.text, features="html.parser")
 
@@ -109,6 +111,7 @@ class CouncilClass(AbstractGetBinDataClass):
             resp = requests.get(
                 "https://eastdevon.gov.uk/addressfinder",
                 params={"qtype": "bins", "term": user_postcode},
+                headers=_HEADERS,
                 timeout=30,
             )
             resp.raise_for_status()
@@ -119,9 +122,7 @@ class CouncilClass(AbstractGetBinDataClass):
                 user_uprn = matched.get("UPRN")
 
         if not user_uprn:
-            raise ValueError(
-                "Could not resolve address. Provide a postcode or UPRN."
-            )
+            raise ValueError("Could not resolve address. Provide a postcode or UPRN.")
 
         # East Devon requires 12-digit zero-padded UPRNs
         user_uprn = str(user_uprn).zfill(12)

--- a/uk_bin_collection/uk_bin_collection/councils/HorshamDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/HorshamDistrictCouncil.py
@@ -20,8 +20,7 @@ class CouncilClass(AbstractGetBinDataClass):
         user_paon = kwargs.get("paon")
         check_postcode(user_postcode)
 
-        s = requests.Session()
-        s.headers.update(HEADERS)
+        s = build_retry_session(headers=HEADERS, retry_methods=("GET", "POST"))
 
         r = s.post(
             f"{SAT_BASE}/cal2.asp",
@@ -94,10 +93,12 @@ class CouncilClass(AbstractGetBinDataClass):
                         continue
                     try:
                         dt = datetime.strptime(date_str, "%d/%m/%Y")
-                        bin_data["bins"].append({
-                            "type": bin_type,
-                            "collectionDate": dt.strftime(date_format),
-                        })
+                        bin_data["bins"].append(
+                            {
+                                "type": bin_type,
+                                "collectionDate": dt.strftime(date_format),
+                            }
+                        )
                     except ValueError:
                         continue
 


### PR DESCRIPTION
## Summary

Consolidates the fixes from a fresh full-suite triage run into a single PR (folds in #2159, #2160, #2161, #2162 - now closed as superseded).

- **AberdeenshireCouncil** (#2158, priority): self-inflicted regression from the #2073 retry fix (0.168.0). `parse_data()` ignores the page it's given and makes its own request to a working endpoint, but the generic framework fetch to an *unused* root URL ran first regardless - that URL returns a persistent 500 on the council's own end, and the retry logic correctly (if unfortunately) turned that into a hard failure, breaking every user's sensors. Fixed by overriding `get_data()` to skip the pointless fetch - works immediately on upgrade, no config changes needed. Verified live: root URL 500s, real data endpoint 200s with valid data, at the same moment.
- **EastDevonDC**: 403 was purely a missing User-Agent header - default `python-requests/x.x` UA gets blocked, this project's own polite scraper UA string (`get_scraper_user_agent()`) works fine. Verified live end-to-end.
- **HorshamDistrictCouncil**: switched to `build_retry_session()` for consistency with the rest of the codebase. Does **not** fix the council's current failure (verified live it still fails after 5 retries - a sustained block, not a transient blip) - this is defensive hardening only.
- **ISSUE_RESOLUTION_PROGRESS.md**: documents a fresh full-suite triage (352 councils, 26 failed / 326 passed in 5m21s after reconfiguring the local Selenium grid for real 8-way concurrency instead of the 1-session cap it had), the Aberdeenshire regression writeup, and updated findings for #2118 (Flintshire) and #2079 (Slough).

## Broader finding (not fixed here, flagging for awareness)

Found 59 councils with the same shape as Aberdeenshire's bug (`parse_data()` ignores the fetched page and makes its own request, but `skip_get_url` isn't set). Cross-referenced against real failures - only Aberdeenshire is currently affected, the rest have `url` fields pointing somewhere healthy. Worth a slower systematic audit sometime, not urgent.

## Test plan

- [x] `poetry run pytest uk_bin_collection/tests custom_components/uk_bin_collection/tests --ignore=uk_bin_collection/tests/step_defs/` - 221 passed
- [x] `black --check` clean
- [x] Live verification for each fix (see commit messages)

## Closes

Fixes #2158

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved bin collection retrieval for Aberdeenshire Council.
  - Improved address lookup and calendar requests for East Devon District Council.
  - Added more reliable request retry handling for Horsham District Council.
  - Resolved regressions affecting collection data retrieval and improved handling of known council-specific issues.

- **Documentation**
  - Updated issue-resolution progress and triage records with current fixes, remaining issues, and regression findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->