### PR TITLE
Fix 6 broken councils, systematic 79-council skip_get_url audit, 2 hardening/cleanup fixes

### DIFF
--- a/ISSUE_RESOLUTION_PROGRESS.md
+++ b/ISSUE_RESOLUTION_PROGRESS.md
@@ -1,9 +1,73 @@
 # Issue Resolution Progress
 
-## Next Issue: individual investigation of the remaining Selenium timeouts (EastLindsey,
-Angus, Ashfield, Halton, BarkingDagenham, MidAndEastAntrim) - each needs its own
-selector/page-change archaeology, not done yet; or #1560 Gateshead - now have a local
-Selenium grid
+## Next Issue: FyldeCouncil needs a full rewrite for its new login-gated "personal
+waste account" system (if feasible without real user credentials), or GedlingBoroughCouncil's
+upstream API needs re-checking for stability, or continue the 59-council
+"page-ignoring" audit (see below)
+
+## Deep-dive triage round 2 (2026-07-13, PR #2165)
+
+Worked through every council flagged as "genuinely broken, needs individual
+investigation" from the previous triage pass, plus Gateshead (#1560) and re-checks
+on a couple of previously-confirmed-broken ones.
+
+**6 real fixes:**
+- **EastLindseyDistrictCouncil**: form element ids are year-versioned
+  (`WASTECOLLECTIONDAYS202526`); the council rolled to `202627`. Matched on the
+  stable id suffix instead of hardcoding a year, so this won't break again at the
+  next rollover.
+- **AngusCouncil**: AchieveForms form rebuilt - `searchString`→`search`,
+  `customerAddress`→`select_NewAddress`, plus a new required "Show Calendar" button
+  click. Results markup unchanged.
+- **BarkingDagenham**: a promotional overlay (`.prefix-overlay`) sits on top of the
+  page and intercepts clicks/typing on everything below it, including the cookie
+  banner - `ElementNotInteractableException` on the postcode field. Now dismisses
+  both overlays explicitly.
+- **MidAndEastAntrimBoroughCouncil**: the embedded iframe widget is gone entirely -
+  moved to a linked-out WhiteSpace WRP portal (same platform as 8 other councils
+  already in this repo, e.g. WaverleyBoroughCouncil). Rewrote as pure HTTP, no
+  Selenium needed. **Breaking change**: now takes postcode + house number as
+  separate parameters instead of the whole address crammed into postcode (a quirk
+  of the old iframe's free-text search that no longer applies).
+- **SwaleBoroughCouncil**: not a Cloudflare block - the old fallback message was a
+  guess, not a diagnosis (verified the page loads completely normally). The Squiz
+  Matrix form was rebuilt with new field ids; results page structure unchanged.
+- **DartfordBoroughCouncil**: the site silently serves a stripped-down page with no
+  results table for requests without a browser-like User-Agent - the scraper sent
+  none, always got the empty variant, and silently returned zero bins instead of
+  erroring. Sent the project's UA string and made a missing table a hard error.
+  This was never actually a dead backend, as the earlier triage pass (using a
+  UA-less request) concluded - worth remembering when re-checking "confirmed dead
+  backend" verdicts, since a missing User-Agent can look identical to a genuine
+  outage.
+
+**Hardening only, live issue not resolved:**
+- **HorshamDistrictCouncil**: switched to `build_retry_session()` for consistency,
+  but verified live it still fails after 5 retries - a sustained connection reset,
+  not a transient blip.
+- **GatesheadCouncil** (#1560): removed a stray unconditional debug file write
+  (`debug_page.html` to cwd on every run) and a stale error message referencing it.
+  Could not reproduce the reported "stuck date" symptom live - scraper currently
+  produces correctly advancing dates. Commented on the issue asking for more detail.
+
+**Confirmed not fixable here:**
+- **HaltonBoroughCouncil**: genuine Google reCAPTCHA v2 - confirmed blocked even
+  with `undetected-chromedriver` against a real local, non-headless Chrome. Same
+  class of problem as Haringey (#2113).
+- **AshfieldDistrictCouncil**: a genuine client-side JS error on the council's own
+  portal (`Cannot read properties of null (reading 'id')`) leaves the page stuck on
+  "Loading..." for every visitor, not just automation.
+- **GedlingBoroughCouncil**: re-checked, still unstable (3 different failures across
+  3 live attempts this pass too).
+- **FyldeCouncil**: re-checked, still on the login-gated "personal waste account"
+  system with no public lookup.
+
+**Broader finding from Aberdeenshire's regression (see PR #2159/#2163):** while
+fixing that, found 59 other councils sharing the same shape (scraper ignores the
+fetched page and makes its own request, but `skip_get_url` isn't set) via an AST
+scan of the whole `councils/` directory. Only Aberdeenshire is currently affected;
+the rest have `url` fields pointing somewhere healthy today, so this is a latent
+risk, not an active bug. Worth a slow systematic audit at some point.
 
 ## Post-#2154-merge full-suite triage (2026-07-13)
 

--- a/ISSUE_RESOLUTION_PROGRESS.md
+++ b/ISSUE_RESOLUTION_PROGRESS.md
@@ -2,8 +2,7 @@
 
 ## Next Issue: FyldeCouncil needs a full rewrite for its new login-gated "personal
 waste account" system (if feasible without real user credentials), or GedlingBoroughCouncil's
-upstream API needs re-checking for stability, or continue the 59-council
-"page-ignoring" audit (see below)
+upstream API needs re-checking for stability
 
 ## Deep-dive triage round 2 (2026-07-13, PR #2165)
 
@@ -62,12 +61,21 @@ on a couple of previously-confirmed-broken ones.
 - **FyldeCouncil**: re-checked, still on the login-gated "personal waste account"
   system with no public lookup.
 
-**Broader finding from Aberdeenshire's regression (see PR #2159/#2163):** while
-fixing that, found 59 other councils sharing the same shape (scraper ignores the
-fetched page and makes its own request, but `skip_get_url` isn't set) via an AST
-scan of the whole `councils/` directory. Only Aberdeenshire is currently affected;
-the rest have `url` fields pointing somewhere healthy today, so this is a latent
-risk, not an active bug. Worth a slow systematic audit at some point.
+**Systematic audit completed (2026-07-13, same PR #2165):** followed up on the
+Aberdeenshire "page-ignoring" risk class rather than leaving it as noted latent
+risk. Re-ran the AST scan (fixed a bug in the first pass - it missed councils that
+reassign `page = requests.get(...)` immediately, which discards the framework's
+fetch just as completely as never referencing `page` at all) and found **79**
+councils with the same shape, not 59. Spot-checked a sample and confirmed the
+overwhelming majority are a single shared AchieveForms/apibroker template
+(`SESSION_URL` + `API_URL`, e.g. Bolsover, Dudley, Aberdeen City) that never needed
+the framework's fetch. Marked all 79 `skip_get_url: true`, closing off the
+regression risk class entirely. Verified via a full live BDD run of all 79 (had to
+route around an unrelated pytest-xdist worker-crash flake under parallel execution
+by using a plain Python driver script calling `pytest.main()` directly instead of
+the `-k "A or B or ..."` shell expression, which also turned out to be silently
+truncating itself under Windows Git Bash) - 78 passed, 1 failed (FyldeCouncil, the
+same pre-existing unrelated failure documented above).
 
 ## Post-#2154-merge full-suite triage (2026-07-13)
 

--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -1,6 +1,7 @@
 {
     "AberdeenCityCouncil": {
         "LAD24CD": "S12000033",
+        "skip_get_url": true,
         "uprn": "9051156186",
         "url": "https://www.aberdeencity.gov.uk",
         "wiki_name": "Aberdeen City",
@@ -23,6 +24,7 @@
     },
     "AmberValleyBoroughCouncil": {
         "LAD24CD": "E07000032",
+        "skip_get_url": true,
         "uprn": "100030026621",
         "url": "https://ambervalley.gov.uk",
         "wiki_name": "Amber Valley",
@@ -47,6 +49,7 @@
     },
     "ArdsAndNorthDownCouncil": {
         "LAD24CD": "N09000011",
+        "skip_get_url": true,
         "uprn": "187136177",
         "url": "https://www.ardsandnorthdown.gov.uk",
         "wiki_command_url_override": "https://www.ardsandnorthdown.gov.uk",
@@ -65,6 +68,7 @@
     },
     "ArmaghBanbridgeCraigavonCouncil": {
         "LAD24CD": "N09000002",
+        "skip_get_url": true,
         "uprn": "185625284",
         "url": "https://www.armaghbanbridgecraigavon.gov.uk/",
         "wiki_command_url_override": "https://www.armaghbanbridgecraigavon.gov.uk/",
@@ -226,6 +230,7 @@
     },
     "BlabyDistrictCouncil": {
         "LAD24CD": "E07000129",
+        "skip_get_url": true,
         "uprn": "100030401782",
         "url": "https://www.blaby.gov.uk",
         "wiki_command_url_override": "https://www.blaby.gov.uk",
@@ -262,6 +267,7 @@
     },
     "BolsoverCouncil": {
         "LAD24CD": "E07000033",
+        "skip_get_url": true,
         "uprn": "100030066827",
         "url": "https://bolsover.gov.uk",
         "wiki_name": "Bolsover",
@@ -315,6 +321,7 @@
     },
     "BrecklandCouncil": {
         "LAD24CD": "E07000143",
+        "skip_get_url": true,
         "uprn": "100091495479",
         "url": "https://www.breckland.gov.uk",
         "wiki_command_url_override": "https://www.breckland.gov.uk",
@@ -325,6 +332,7 @@
         "LAD24CD": "E09000005",
         "house_number": "25",
         "postcode": "HA3 0QU",
+        "skip_get_url": true,
         "url": "https://recyclingservices.brent.gov.uk/waste",
         "wiki_name": "Brent",
         "wiki_note": "Pass the house number and postcode in their respective parameters."
@@ -373,6 +381,7 @@
     },
     "BromsgroveDistrictCouncil": {
         "LAD24CD": "E07000234",
+        "skip_get_url": true,
         "uprn": "100120584652",
         "url": "https://www.bromsgrove.gov.uk",
         "wiki_command_url_override": "https://www.bromsgrove.gov.uk",
@@ -401,6 +410,7 @@
     },
     "BuckinghamshireCouncil": {
         "LAD24CD": "E06000060",
+        "skip_get_url": true,
         "uprn": "100081093078",
         "url": "https://www.buckinghamshire.gov.uk/waste-and-recycling/find-out-when-its-your-bin-collection/",
         "wiki_name": "Buckinghamshire",
@@ -408,6 +418,7 @@
     },
     "BurnleyBoroughCouncil": {
         "LAD24CD": "E07000117",
+        "skip_get_url": true,
         "uprn": "100010347165",
         "url": "https://www.burnley.gov.uk",
         "wiki_name": "Burnley",
@@ -441,6 +452,7 @@
     },
     "CambridgeCityCouncil": {
         "LAD24CD": "E07000008",
+        "skip_get_url": true,
         "uprn": "200004159750",
         "url": "https://www.cambridge.gov.uk/",
         "wiki_name": "Cambridge",
@@ -457,6 +469,7 @@
     },
     "CanterburyCityCouncil": {
         "LAD24CD": "E07000106",
+        "skip_get_url": true,
         "uprn": "10094583181",
         "url": "https://www.canterbury.gov.uk",
         "wiki_command_url_override": "https://www.canterbury.gov.uk",
@@ -473,6 +486,7 @@
     },
     "CarmarthenshireCountyCouncil": {
         "LAD24CD": "W06000010",
+        "skip_get_url": true,
         "uprn": "10004859302",
         "url": "https://www.carmarthenshire.gov.wales",
         "wiki_command_url_override": "https://www.carmarthenshire.gov.wales",
@@ -524,6 +538,7 @@
     },
     "CherwellDistrictCouncil": {
         "LAD24CD": "E07000177",
+        "skip_get_url": true,
         "uprn": "100121292407",
         "url": "https://www.cherwell.gov.uk",
         "wiki_name": "Cherwell",
@@ -599,6 +614,7 @@
     },
     "ConwyCountyBorough": {
         "LAD24CD": "W06000003",
+        "skip_get_url": true,
         "uprn": "100100429249",
         "url": "https://www.conwy.gov.uk",
         "wiki_name": "Conwy",
@@ -650,6 +666,7 @@
     },
     "CumberlandCouncil": {
         "LAD24CD": "E06000063",
+        "skip_get_url": true,
         "uprn": "10009457328",
         "url": "https://www.cumberland.gov.uk/bins-recycling-and-street-cleaning/waste-collections/bin-collection-schedule",
         "wiki_name": "Cumberland",
@@ -682,6 +699,7 @@
     },
     "DenbighshireCouncil": {
         "LAD24CD": "W06000004",
+        "skip_get_url": true,
         "uprn": "200004299351",
         "url": "https://www.denbighshire.gov.uk/",
         "wiki_name": "Denbighshire",
@@ -689,6 +707,7 @@
     },
     "DerbyCityCouncil": {
         "LAD24CD": "E06000015",
+        "skip_get_url": true,
         "uprn": "10010684240",
         "url": "https://www.derby.gov.uk",
         "wiki_name": "Derby",
@@ -730,6 +749,7 @@
     },
     "DudleyCouncil": {
         "LAD24CD": "E08000027",
+        "skip_get_url": true,
         "uprn": "90014244",
         "url": "https://my.dudley.gov.uk",
         "wiki_command_url_override": "https://my.dudley.gov.uk",
@@ -748,6 +768,7 @@
     },
     "DundeeCityCouncil": {
         "LAD24CD": "S12000042",
+        "skip_get_url": true,
         "uprn": "9059043390",
         "url": "https://www.dundeecity.gov.uk/",
         "wiki_name": "Dundee City",
@@ -799,6 +820,7 @@
     },
     "EastDunbartonshireCouncil": {
         "LAD24CD": "S12000045",
+        "skip_get_url": true,
         "uprn": "132027197",
         "url": "https://www.eastdunbarton.gov.uk/",
         "wiki_name": "East Dunbartonshire",
@@ -911,6 +933,7 @@
     },
     "ElmbridgeBoroughCouncil": {
         "LAD24CD": "E07000207",
+        "skip_get_url": true,
         "uprn": "10013119164",
         "url": "https://www.elmbridge.gov.uk",
         "wiki_command_url_override": "https://www.elmbridge.gov.uk",
@@ -962,6 +985,7 @@
     },
     "ExeterCityCouncil": {
         "LAD24CD": "E07000041",
+        "skip_get_url": true,
         "uprn": "100040212270",
         "url": "https://www.exeter.gov.uk",
         "wiki_name": "Exeter",
@@ -969,6 +993,7 @@
     },
     "FalkirkCouncil": {
         "LAD24CD": "S12000014",
+        "skip_get_url": true,
         "uprn": "136065818",
         "url": "https://www.falkirk.gov.uk",
         "wiki_command_url_override": "https://www.falkirk.gov.uk",
@@ -1012,6 +1037,7 @@
     },
     "FlintshireCountyCouncil": {
         "LAD24CD": "W06000005",
+        "skip_get_url": true,
         "uprn": "100100213710",
         "url": "https://digital.flintshire.gov.uk",
         "wiki_command_url_override": "https://digital.flintshire.gov.uk",
@@ -1038,6 +1064,7 @@
     },
     "FyldeCouncil": {
         "LAD24CD": "E07000119",
+        "skip_get_url": true,
         "uprn": "100010402452",
         "url": "https://www.fylde.gov.uk",
         "wiki_command_url_override": "https://www.fylde.gov.uk",
@@ -1082,6 +1109,7 @@
         "wiki_note": "Pass the house number, postcode, and UPRN in their respective parameters. This parser requires a Selenium webdriver."
     },
     "GooglePublicCalendarCouncil": {
+        "skip_get_url": true,
         "supported_councils": [
             "Trafford",
             "Clackmannanshire",
@@ -1162,6 +1190,7 @@
     },
     "GwyneddCouncil": {
         "LAD24CD": "W06000002",
+        "skip_get_url": true,
         "uprn": "10070350463",
         "url": "https://diogel.gwynedd.llyw.cymru",
         "wiki_name": "Gwynedd",
@@ -1171,6 +1200,7 @@
         "LAD24CD": "E09000012",
         "house_number": "101",
         "postcode": "N16 9AS",
+        "skip_get_url": true,
         "url": "https://www.hackney.gov.uk",
         "wiki_name": "Hackney",
         "wiki_note": "Pass the postcode and house number in their respective arguments, both wrapped in quotes."
@@ -1187,6 +1217,7 @@
     },
     "HarboroughDistrictCouncil": {
         "LAD24CD": "E07000131",
+        "skip_get_url": true,
         "uprn": "100030489072",
         "url": "https://www.harborough.gov.uk",
         "wiki_command_url_override": "https://www.harborough.gov.uk",
@@ -1203,6 +1234,7 @@
     },
     "HarlowCouncil": {
         "LAD24CD": "E07000073",
+        "skip_get_url": true,
         "uprn": "10003713342",
         "url": "https://harlow.gov.uk",
         "wiki_command_url_override": "https://harlow.gov.uk",
@@ -1227,6 +1259,7 @@
     },
     "HartlepoolBoroughCouncil": {
         "LAD24CD": "E06000001",
+        "skip_get_url": true,
         "uprn": "100110019551",
         "url": "https://www.hartlepool.gov.uk",
         "wiki_name": "Hartlepool",
@@ -1234,6 +1267,7 @@
     },
     "HastingsBoroughCouncil": {
         "LAD24CD": "E07000062",
+        "skip_get_url": true,
         "uprn": "100060038877",
         "url": "https://www.hastings.gov.uk",
         "wiki_command_url_override": "https://www.hastings.gov.uk",
@@ -1270,6 +1304,7 @@
     },
     "HighlandCouncil": {
         "LAD24CD": "S12000017",
+        "skip_get_url": true,
         "uprn": "130072429",
         "url": "https://www.highland.gov.uk",
         "wiki_command_url_override": "https://www.highland.gov.uk",
@@ -1288,6 +1323,7 @@
     },
     "HinckleyandBosworthBoroughCouncil": {
         "LAD24CD": "E07000132",
+        "skip_get_url": true,
         "uprn": "100030533512",
         "url": "https://www.hinckley-bosworth.gov.uk",
         "wiki_name": "Hinckley and Bosworth",
@@ -1339,6 +1375,7 @@
     "IpswichBoroughCouncil": {
         "LAD24CD": "E07000202",
         "house_number": "Siloam Place",
+        "skip_get_url": true,
         "url": "https://app.ipswich.gov.uk/bin-collection/",
         "wiki_name": "Ipswich",
         "wiki_note": "Provide only the street name (no house number) as the PAON"
@@ -1361,6 +1398,7 @@
     "IslingtonCouncil": {
         "LAD24CD": "E09000019",
         "postcode": "N1 1XR",
+        "skip_get_url": true,
         "uprn": "5300094897",
         "url": "https://www.islington.gov.uk/your-area",
         "wiki_command_url_override": "https://www.islington.gov.uk/your-area",
@@ -1369,6 +1407,7 @@
     },
     "KingsLynnandWestNorfolkBC": {
         "LAD24CD": "E07000146",
+        "skip_get_url": true,
         "uprn": "10023636886",
         "url": "https://www.west-norfolk.gov.uk/",
         "wiki_name": "Kings Lynn and West Norfolk",
@@ -1419,6 +1458,7 @@
     },
     "LeicesterCityCouncil": {
         "LAD24CD": "E06000016",
+        "skip_get_url": true,
         "uprn": "2465027976",
         "url": "https://biffaleicester.co.uk",
         "wiki_name": "Leicester",
@@ -1434,6 +1474,7 @@
     },
     "LichfieldDistrictCouncil": {
         "LAD24CD": "E07000194",
+        "skip_get_url": true,
         "uprn": "100031694085",
         "url": "https://www.lichfielddc.gov.uk",
         "wiki_command_url_override": "https://www.lichfielddc.gov.uk",
@@ -1444,6 +1485,7 @@
         "LAD24CD": "E07000138",
         "house_number": "2",
         "postcode": "LN1 3AE",
+        "skip_get_url": true,
         "uprn": "000235056871",
         "url": "https://lincoln.gov.uk",
         "wiki_command_url_override": "https://lincoln.gov.uk",
@@ -1488,6 +1530,7 @@
     "LondonBoroughHammersmithandFulham": {
         "LAD24CD": "E09000013",
         "postcode": "W12 0BQ",
+        "skip_get_url": true,
         "url": "https://www.lbhf.gov.uk/",
         "wiki_command_url_override": "https://www.lbhf.gov.uk/",
         "wiki_name": "Hammersmith & Fulham",
@@ -1495,6 +1538,7 @@
     },
     "LondonBoroughHarrow": {
         "LAD24CD": "E09000015",
+        "skip_get_url": true,
         "uprn": "100021298754",
         "url": "https://www.harrow.gov.uk",
         "wiki_command_url_override": "https://www.harrow.gov.uk",
@@ -1503,6 +1547,7 @@
     },
     "LondonBoroughHavering": {
         "LAD24CD": "E09000016",
+        "skip_get_url": true,
         "uprn": "100021380730",
         "url": "https://www.havering.gov.uk",
         "wiki_name": "Havering",
@@ -1562,6 +1607,7 @@
     },
     "LutonBoroughCouncil": {
         "LAD24CD": "E06000032",
+        "skip_get_url": true,
         "uprn": "100080155778",
         "url": "https://myforms.luton.gov.uk",
         "wiki_command_url_override": "https://myforms.luton.gov.uk",
@@ -1620,6 +1666,7 @@
     },
     "MeltonBoroughCouncil": {
         "LAD24CD": "E07000133",
+        "skip_get_url": true,
         "uprn": "100030540956",
         "url": "https://my.melton.gov.uk/collections",
         "wiki_name": "Melton",
@@ -1652,6 +1699,7 @@
     },
     "MidDevonCouncil": {
         "LAD24CD": "E07000042",
+        "skip_get_url": true,
         "uprn": "200003997770",
         "url": "https://www.middevon.gov.uk",
         "wiki_command_url_override": "https://www.middevon.gov.uk",
@@ -1707,6 +1755,7 @@
     },
     "MiltonKeynesCityCouncil": {
         "LAD24CD": "E06000042",
+        "skip_get_url": true,
         "uprn": "25109551",
         "url": "https://mycouncil.milton-keynes.gov.uk/en/service/Waste_Collection_Round_Checker",
         "wiki_name": "Milton Keynes",
@@ -1723,6 +1772,7 @@
     },
     "MonmouthshireCountyCouncil": {
         "LAD24CD": "W06000021",
+        "skip_get_url": true,
         "uprn": "100100266220",
         "url": "https://maps.monmouthshire.gov.uk",
         "wiki_name": "Monmouthshire",
@@ -1732,6 +1782,7 @@
         "LAD24CD": "S12000020",
         "house_number": "41 Mayne Road",
         "postcode": "IV30 1NZ",
+        "skip_get_url": true,
         "uprn": "45438",
         "url": "https://bindayfinder.moray.gov.uk/",
         "wiki_name": "Moray",
@@ -1776,6 +1827,7 @@
     },
     "NewcastleUnderLymeCouncil": {
         "LAD24CD": "E07000195",
+        "skip_get_url": true,
         "uprn": "100031725433",
         "url": "https://www.newcastle-staffs.gov.uk",
         "wiki_name": "Newcastle-under-Lyme",
@@ -1799,6 +1851,7 @@
     },
     "NorthAyrshireCouncil": {
         "LAD24CD": "S12000021",
+        "skip_get_url": true,
         "uprn": "126045552",
         "url": "https://www.north-ayrshire.gov.uk/",
         "wiki_command_url_override": "https://www.north-ayrshire.gov.uk/",
@@ -1828,6 +1881,7 @@
     },
     "NorthEastLincs": {
         "LAD24CD": "E06000012",
+        "skip_get_url": true,
         "uprn": "11062649",
         "url": "https://www.nelincs.gov.uk/refuse-collection-schedule/?view=timeline&uprn=11062649",
         "wiki_command_url_override": "https://www.nelincs.gov.uk/refuse-collection-schedule/?view=timeline&uprn=XXXXXXXX",
@@ -1945,6 +1999,7 @@
         "LAD24CD": "E07000148",
         "house_number": "2",
         "postcode": "NR2 3TT",
+        "skip_get_url": true,
         "url": "https://bnr-wrp.whitespacews.com",
         "wiki_command_url_override": "https://bnr-wrp.whitespacews.com",
         "wiki_name": "Norwich",
@@ -1968,6 +2023,7 @@
     },
     "OadbyAndWigstonBoroughCouncil": {
         "LAD24CD": "E07000135",
+        "skip_get_url": true,
         "uprn": "10010149102",
         "url": "https://my.oadby-wigston.gov.uk",
         "wiki_name": "Oadby and Wigston",
@@ -1988,6 +2044,7 @@
     "OxfordCityCouncil": {
         "LAD24CD": "E07000178",
         "postcode": "OX3 7QF",
+        "skip_get_url": true,
         "uprn": "100120820551",
         "url": "https://www.oxford.gov.uk/xfp/form/142",
         "wiki_command_url_override": "https://www.oxford.gov.uk/xfp/form/142",
@@ -2003,6 +2060,7 @@
     },
     "PerthAndKinrossCouncil": {
         "LAD24CD": "S12000048",
+        "skip_get_url": true,
         "uprn": "124032322",
         "url": "https://www.pkc.gov.uk",
         "wiki_command_url_override": "https://www.pkc.gov.uk",
@@ -2021,6 +2079,7 @@
     },
     "PlymouthCouncil": {
         "LAD24CD": "E06000026",
+        "skip_get_url": true,
         "uprn": "100040420582",
         "url": "https://www.plymouth.gov.uk",
         "wiki_command_url_override": "https://www.plymouth.gov.uk",
@@ -2074,6 +2133,7 @@
     },
     "RedditchBoroughCouncil": {
         "LAD24CD": "E07000236",
+        "skip_get_url": true,
         "uprn": "10094557691",
         "url": "https://redditchbc.gov.uk",
         "wiki_command_url_override": "https://redditchbc.gov.uk",
@@ -2122,6 +2182,7 @@
     },
     "RotherDistrictCouncil": {
         "LAD24CD": "E07000064",
+        "skip_get_url": true,
         "uprn": "100061937338",
         "url": "https://www.rother.gov.uk",
         "wiki_name": "Rother",
@@ -2175,6 +2236,7 @@
     },
     "RushmoorCouncil": {
         "LAD24CD": "E07000092",
+        "skip_get_url": true,
         "uprn": "100060545034",
         "url": "https://www.rushmoor.gov.uk",
         "wiki_name": "Rushmoor",
@@ -2208,6 +2270,7 @@
         "LAD24CD": "E08000014",
         "house_number": "1",
         "postcode": "L20 6GG",
+        "skip_get_url": true,
         "url": "https://www.sefton.gov.uk",
         "wiki_name": "Sefton",
         "wiki_note": "Pass the postcode and house number in their respective arguments, both wrapped in quotes."
@@ -2309,6 +2372,7 @@
     },
     "SouthHamsDistrictCouncil": {
         "LAD24CD": "E07000044",
+        "skip_get_url": true,
         "uprn": "10004742851",
         "url": "https://www.southhams.gov.uk",
         "wiki_name": "South Hams",
@@ -2361,6 +2425,7 @@
     "SouthRibbleCouncil": {
         "LAD24CD": "E07000126",
         "postcode": "PR266QW",
+        "skip_get_url": true,
         "uprn": "10013243496",
         "url": "https://forms.chorleysouthribble.gov.uk/xfp/form/70",
         "wiki_command_url_override": "https://forms.chorleysouthribble.gov.uk/xfp/form/70",
@@ -2369,6 +2434,7 @@
     },
     "SouthStaffordshireDistrictCouncil": {
         "LAD24CD": "E07000196",
+        "skip_get_url": true,
         "uprn": "100031802117",
         "url": "https://www.sstaffs.gov.uk/where-i-live?objectId=100031802117",
         "wiki_name": "South Staffordshire",
@@ -2399,6 +2465,7 @@
     },
     "SouthwarkCouncil": {
         "LAD24CD": "E09000028",
+        "skip_get_url": true,
         "uprn": "200003469271",
         "url": "https://services.southwark.gov.uk/bins/lookup/",
         "wiki_command_url_override": "https://services.southwark.gov.uk/bins/lookup/XXXXXXXX",
@@ -2450,6 +2517,7 @@
     },
     "StevenageBoroughCouncil": {
         "LAD24CD": "E07000243",
+        "skip_get_url": true,
         "uprn": "100080878852",
         "url": "https://www.stevenage.gov.uk",
         "wiki_name": "Stevenage",
@@ -2543,6 +2611,7 @@
     },
     "SwindonBoroughCouncil": {
         "LAD24CD": "E06000030",
+        "skip_get_url": true,
         "uprn": "10022793351",
         "url": "https://www.swindon.gov.uk",
         "wiki_name": "Swindon",
@@ -2689,6 +2758,7 @@
     },
     "TunbridgeWellsCouncil": {
         "LAD24CD": "E07000116",
+        "skip_get_url": true,
         "uprn": "10090058289",
         "url": "https://tunbridgewells.gov.uk",
         "wiki_command_url_override": "https://tunbridgewells.gov.uk",
@@ -2737,6 +2807,7 @@
     },
     "WalsallCouncil": {
         "LAD24CD": "E08000030",
+        "skip_get_url": true,
         "uprn": "100071080513",
         "url": "https://cag.walsall.gov.uk/",
         "wiki_command_url_override": "https://cag.walsall.gov.uk/",
@@ -2756,6 +2827,7 @@
     },
     "WandsworthCouncil": {
         "LAD24CD": "E09000032",
+        "skip_get_url": true,
         "uprn": "100022684035",
         "url": "https://www.wandsworth.gov.uk",
         "wiki_command_url_override": "https://www.wandsworth.gov.uk",
@@ -2764,6 +2836,7 @@
     },
     "WarringtonBoroughCouncil": {
         "LAD24CD": "E06000007",
+        "skip_get_url": true,
         "uprn": "10094964379",
         "url": "https://www.warrington.gov.uk",
         "wiki_command_url_override": "https://www.warrington.gov.uk",
@@ -2779,6 +2852,7 @@
     },
     "WatfordBoroughCouncil": {
         "LAD24CD": "E07000103",
+        "skip_get_url": true,
         "uprn": "100080942183",
         "url": "https://www.watford.gov.uk",
         "wiki_command_url_override": "https://www.watford.gov.uk",
@@ -2832,6 +2906,7 @@
     },
     "WestDunbartonshireCouncil": {
         "LAD24CD": "S12000039",
+        "skip_get_url": true,
         "uprn": "129001383",
         "url": "https://www.west-dunbarton.gov.uk/",
         "wiki_name": "West Dunbartonshire",
@@ -2840,6 +2915,7 @@
     "WestLancashireBoroughCouncil": {
         "LAD24CD": "E07000127",
         "postcode": "WN8 0HR",
+        "skip_get_url": true,
         "uprn": "10012343339",
         "url": "https://www.westlancs.gov.uk",
         "wiki_name": "West Lancashire",
@@ -2868,6 +2944,7 @@
         "LAD24CD": "E06000064",
         "house_number": "23",
         "postcode": "LA9 4QU",
+        "skip_get_url": true,
         "uprn": "100110698636",
         "url": "https://www.westmorlandandfurness.gov.uk/",
         "wiki_command_url_override": "https://www.westmorlandandfurness.gov.uk/",
@@ -2978,6 +3055,7 @@
         "LAD24CD": "E08000031",
         "house_number": "32",
         "postcode": "WV3 9NZ",
+        "skip_get_url": true,
         "uprn": "100071205205",
         "url": "https://www.wolverhampton.gov.uk",
         "wiki_name": "Wolverhampton",
@@ -2985,6 +3063,7 @@
     },
     "WorcesterCityCouncil": {
         "LAD24CD": "E07000237",
+        "skip_get_url": true,
         "uprn": "100120650345",
         "url": "https://www.Worcester.gov.uk",
         "wiki_command_url_override": "https://www.Worcester.gov.uk",

--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -1643,12 +1643,12 @@
     },
     "MidAndEastAntrimBoroughCouncil": {
         "LAD24CD": "N09000008",
-        "postcode": "100 Galgorm Road",
+        "house_number": "29A",
+        "postcode": "BT42 1AA",
         "skip_get_url": true,
         "url": "https://www.midandeastantrim.gov.uk/resident/waste-recycling/collection-dates/",
-        "web_driver": "http://selenium:4444",
         "wiki_name": "Mid and East Antrim",
-        "wiki_note": "Pass the house name/number plus the name of the street with the postcode parameter, wrapped in double quotes. Check the address on the website first. This version will only pick the first SHOW button returned by the search or if it is fully unique."
+        "wiki_note": "Pass the postcode and house name/number in their respective parameters. No Selenium needed."
     },
     "MidDevonCouncil": {
         "LAD24CD": "E07000042",

--- a/uk_bin_collection/uk_bin_collection/councils/AngusCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/AngusCouncil.py
@@ -3,7 +3,6 @@ from datetime import datetime
 
 from bs4 import BeautifulSoup
 from selenium.webdriver.common.by import By
-from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import Select, WebDriverWait
 from selenium.common.exceptions import TimeoutException, NoSuchElementException
@@ -27,64 +26,74 @@ class CouncilClass(AbstractGetBinDataClass):
             headless = kwargs.get("headless")
             web_driver = kwargs.get("web_driver")
             driver = create_webdriver(web_driver, headless, None, __name__)
-            
+
             # Go directly to the form URL
             driver.get("https://myangus.angus.gov.uk/service/Bin_collection_dates_V3")
 
             wait = WebDriverWait(driver, 20)
-            
+
             # Wait for iframe to be present and switch to it
-            iframe = wait.until(EC.presence_of_element_located((By.ID, "fillform-frame-1")))
+            iframe = wait.until(
+                EC.presence_of_element_located((By.ID, "fillform-frame-1"))
+            )
             driver.switch_to.frame(iframe)
 
             # Wait for page to load
             import time
+
             time.sleep(3)
 
-            # Try to find the postcode input with different selectors
+            # Try to find the postcode/address input with different selectors
             try:
-                postcode_input = wait.until(EC.element_to_be_clickable((By.ID, "searchString")))
+                postcode_input = wait.until(
+                    EC.element_to_be_clickable((By.ID, "search"))
+                )
             except TimeoutException:
                 # Try alternative selectors
                 try:
-                    postcode_input = driver.find_element(By.NAME, "searchString")
+                    postcode_input = driver.find_element(By.NAME, "search")
                 except NoSuchElementException:
                     try:
-                        postcode_input = driver.find_element(By.CSS_SELECTOR, "input[type='text']")
+                        postcode_input = driver.find_element(
+                            By.CSS_SELECTOR, "input[type='text']"
+                        )
                     except NoSuchElementException:
                         # Print page source for debugging
                         print("Page source:", driver.page_source[:1000])
                         raise ValueError("Could not find postcode input field")
             postcode_input.clear()
             postcode_input.send_keys(user_postcode)
-            
-            # Find and click the search button
-            try:
-                submit_btn = driver.find_element(By.XPATH, "//button[contains(text(), 'Search')]")
-                submit_btn.click()
-            except:
-                try:
-                    submit_btn = driver.find_element(By.XPATH, "//input[@type='submit']")
-                    submit_btn.click()
-                except:
-                    postcode_input.send_keys(Keys.TAB)
-                    postcode_input.send_keys(Keys.ENTER)
 
             # Wait for address dropdown to be present
-            address_dropdown = wait.until(EC.presence_of_element_located((By.ID, "customerAddress")))
-            
+            address_dropdown = wait.until(
+                EC.presence_of_element_located((By.ID, "select_NewAddress"))
+            )
+
             # Wait for dropdown options to populate with extended timeout
             try:
                 WebDriverWait(driver, 30).until(
-                    lambda d: len(d.find_element(By.ID, "customerAddress").find_elements(By.TAG_NAME, "option")) > 1
+                    lambda d: len(
+                        d.find_element(By.ID, "select_NewAddress").find_elements(
+                            By.TAG_NAME, "option"
+                        )
+                    )
+                    > 1
                 )
             except TimeoutException:
                 options = address_dropdown.find_elements(By.TAG_NAME, "option")
-                raise ValueError(f"Dropdown only has {len(options)} options after 30s wait")
-            
+                raise ValueError(
+                    f"Dropdown only has {len(options)} options after 30s wait"
+                )
+
             # Select the UPRN from dropdown
             dropdown = Select(address_dropdown)
             dropdown.select_by_value(user_uprn)
+
+            # Click the button that reveals the collection calendar
+            show_calendar_btn = wait.until(
+                EC.element_to_be_clickable((By.ID, "btnShowCalendar"))
+            )
+            driver.execute_script("arguments[0].click();", show_calendar_btn)
 
             # Wait for results to appear
             wait.until(
@@ -92,9 +101,10 @@ class CouncilClass(AbstractGetBinDataClass):
                     (By.CSS_SELECTOR, "span.fieldInput.content.html.non-input")
                 )
             )
-            
+
             # Wait additional time for JavaScript to populate the data
             import time
+
             time.sleep(15)  # Wait 15 seconds for dynamic content to load
 
             # Parse the results
@@ -109,8 +119,7 @@ class CouncilClass(AbstractGetBinDataClass):
                 try:
                     # Look for date in <u> tags
                     date_tag = next(
-                        (u for u in span.find_all("u") if u and u.text.strip()),
-                        None
+                        (u for u in span.find_all("u") if u and u.text.strip()), None
                     )
                     bin_type_tag = span.find("b")
 
@@ -120,9 +129,13 @@ class CouncilClass(AbstractGetBinDataClass):
                         full_date_str = re.sub(r"\s+", " ", full_date_str)
 
                         try:
-                            parsed_date = datetime.strptime(full_date_str, "%A %d %B %Y")
+                            parsed_date = datetime.strptime(
+                                full_date_str, "%A %d %B %Y"
+                            )
                             if parsed_date.date() < current_date.date():
-                                parsed_date = parsed_date.replace(year=current_date.year + 1)
+                                parsed_date = parsed_date.replace(
+                                    year=current_date.year + 1
+                                )
                             current_formatted_date = parsed_date.strftime("%d/%m/%Y")
                         except ValueError:
                             continue
@@ -138,21 +151,22 @@ class CouncilClass(AbstractGetBinDataClass):
                     try:
                         overrides_dict = get_seasonal_overrides()
                         if current_formatted_date in overrides_dict:
-                            current_formatted_date = overrides_dict[current_formatted_date]
+                            current_formatted_date = overrides_dict[
+                                current_formatted_date
+                            ]
                     except Exception:
                         pass
 
-                    bin_data["bins"].append({
-                        "type": bin_type,
-                        "collectionDate": current_formatted_date
-                    })
+                    bin_data["bins"].append(
+                        {"type": bin_type, "collectionDate": current_formatted_date}
+                    )
 
                 except Exception:
                     continue
 
             if not bin_data["bins"]:
                 raise ValueError("No bin data found.")
-            
+
             return bin_data
 
         except Exception as e:

--- a/uk_bin_collection/uk_bin_collection/councils/BarkingDagenham.py
+++ b/uk_bin_collection/uk_bin_collection/councils/BarkingDagenham.py
@@ -45,10 +45,34 @@ class CouncilClass(AbstractGetBinDataClass):
                 lambda d: d.execute_script("return document.readyState") == "complete"
             )
 
-            # Close popup if it exists
-            driver.switch_to.active_element.send_keys(Keys.ESCAPE)
-
             wait = WebDriverWait(driver, 10)
+
+            # Dismiss the promotional overlay if it appears - it sits on top
+            # of the page and intercepts clicks/typing on everything below
+            # it, including the cookie banner's own buttons.
+            try:
+                dismiss_btn = WebDriverWait(driver, 5).until(
+                    EC.element_to_be_clickable(
+                        (By.CSS_SELECTOR, ".prefix-overlay-action-dismiss")
+                    )
+                )
+                dismiss_btn.click()
+            except TimeoutException:
+                pass
+
+            # Dismiss the EU cookie compliance banner if it appears.
+            try:
+                agree_btn = WebDriverWait(driver, 5).until(
+                    EC.element_to_be_clickable(
+                        (
+                            By.CSS_SELECTOR,
+                            ".agree-button.eu-cookie-compliance-secondary-button",
+                        )
+                    )
+                )
+                agree_btn.click()
+            except TimeoutException:
+                pass
 
             # Enter postcode
             print("Looking for postcode input...")

--- a/uk_bin_collection/uk_bin_collection/councils/DartfordBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/DartfordBoroughCouncil.py
@@ -24,8 +24,10 @@ class CouncilClass(AbstractGetBinDataClass):
         except Exception as e:
             raise ValueError(f"Error getting identifier: {str(e)}")
 
-        # Make a BS4 object
-        page = requests.get(url)
+        # The site serves a stripped-down page with no results table for
+        # requests without a browser-like User-Agent.
+        headers = {"User-Agent": get_scraper_user_agent()}
+        page = requests.get(url, headers=headers)
         soup = BeautifulSoup(page.text, features="html.parser")
         soup.prettify()
 
@@ -35,21 +37,23 @@ class CouncilClass(AbstractGetBinDataClass):
         # Find the table containing the bin collection data
         table = soup.find("table", {"class": "eb-EVDNdR1G-tableContent"})
 
-        if table:
-            rows = table.find_all("tr", class_="eb-EVDNdR1G-tableRow")
+        if not table:
+            raise ValueError("Could not find bin collections table in page source")
 
-            for row in rows:
-                columns = row.find_all("td")
-                if len(columns) >= 4:
-                    collection_type = columns[1].get_text(strip=True)
-                    collection_date = columns[3].get_text(strip=True)
+        rows = table.find_all("tr", class_="eb-EVDNdR1G-tableRow")
 
-                    # Validate collection_date format
-                    if re.match(r"\d{2}/\d{2}/\d{4}", collection_date):
-                        bin_entry = {
-                            "type": collection_type,
-                            "collectionDate": collection_date,
-                        }
-                        bin_data["bins"].append(bin_entry)
+        for row in rows:
+            columns = row.find_all("td")
+            if len(columns) >= 4:
+                collection_type = columns[1].get_text(strip=True)
+                collection_date = columns[3].get_text(strip=True)
+
+                # Validate collection_date format
+                if re.match(r"\d{2}/\d{2}/\d{4}", collection_date):
+                    bin_entry = {
+                        "type": collection_type,
+                        "collectionDate": collection_date,
+                    }
+                    bin_data["bins"].append(bin_entry)
 
         return bin_data

--- a/uk_bin_collection/uk_bin_collection/councils/EastLindseyDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/EastLindseyDistrictCouncil.py
@@ -31,10 +31,14 @@ class CouncilClass(AbstractGetBinDataClass):
             driver = create_webdriver(web_driver, headless, user_agent, __name__)
             driver.get("https://www.e-lindsey.gov.uk/mywastecollections")
 
+            # The form's element ids are prefixed with the service year (e.g.
+            # WASTECOLLECTIONDAYS202526), which the council rolls forward
+            # each year - match on the stable suffix instead of hardcoding
+            # a year that will go stale.
             # Wait for the postcode field to appear then populate it
             inputElement_postcode = WebDriverWait(driver, 30).until(
                 EC.presence_of_element_located(
-                    (By.ID, "WASTECOLLECTIONDAYS202526_LOOKUP_ADDRESSLOOKUPPOSTCODE")
+                    (By.CSS_SELECTOR, "[id$='_LOOKUP_ADDRESSLOOKUPPOSTCODE']")
                 )
             )
             inputElement_postcode.send_keys(user_postcode)
@@ -42,7 +46,7 @@ class CouncilClass(AbstractGetBinDataClass):
             # Click search button
             findAddress = WebDriverWait(driver, 10).until(
                 EC.presence_of_element_located(
-                    (By.ID, "WASTECOLLECTIONDAYS202526_LOOKUP_ADDRESSLOOKUPSEARCH")
+                    (By.CSS_SELECTOR, "[id$='_LOOKUP_ADDRESSLOOKUPSEARCH']")
                 )
             )
             findAddress.click()
@@ -52,7 +56,7 @@ class CouncilClass(AbstractGetBinDataClass):
                 EC.element_to_be_clickable(
                     (
                         By.XPATH,
-                        "//select[@id='WASTECOLLECTIONDAYS202526_LOOKUP_ADDRESSLOOKUPADDRESS']//option[contains(., '"
+                        "//select[contains(@id, '_LOOKUP_ADDRESSLOOKUPADDRESS')]//option[contains(., '"
                         + user_paon
                         + "')]",
                     )
@@ -62,7 +66,7 @@ class CouncilClass(AbstractGetBinDataClass):
             # Wait for the submit button to appear, then click it to get the collection dates
             submit = WebDriverWait(driver, 10).until(
                 EC.presence_of_element_located(
-                    (By.ID, "WASTECOLLECTIONDAYS202526_LOOKUP_FIELD2_NEXT")
+                    (By.CSS_SELECTOR, "[id$='_LOOKUP_FIELD2_NEXT']")
                 )
             )
             submit.click()

--- a/uk_bin_collection/uk_bin_collection/councils/GatesheadCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/GatesheadCouncil.py
@@ -41,7 +41,7 @@ class CouncilClass(AbstractGetBinDataClass):
 
             # Additional wait for page to fully load after Cloudflare
             time.sleep(3)
-            
+
             # Try to accept cookies if the banner appears
             try:
                 accept_button = WebDriverWait(driver, 10).until(
@@ -84,7 +84,9 @@ class CouncilClass(AbstractGetBinDataClass):
             try:
                 # Check for Cloudflare Turnstile "Verify you are human" checkbox
                 turnstile_checkbox = WebDriverWait(driver, 10).until(
-                    EC.element_to_be_clickable((By.CSS_SELECTOR, "input[type='checkbox']"))
+                    EC.element_to_be_clickable(
+                        (By.CSS_SELECTOR, "input[type='checkbox']")
+                    )
                 )
                 turnstile_checkbox.click()
                 # Wait for verification to complete
@@ -97,11 +99,16 @@ class CouncilClass(AbstractGetBinDataClass):
 
             # Wait for page to change after address selection and handle dynamic loading
             time.sleep(5)
-            
+
             # Wait for any content that indicates results are loaded
             try:
                 WebDriverWait(driver, 15).until(
-                    EC.presence_of_element_located((By.XPATH, "//*[contains(text(), 'collection') or contains(text(), 'Collection') or contains(text(), 'bin') or contains(text(), 'Bin') or contains(text(), 'refuse') or contains(text(), 'Refuse') or contains(text(), 'recycling') or contains(text(), 'Recycling')]"))
+                    EC.presence_of_element_located(
+                        (
+                            By.XPATH,
+                            "//*[contains(text(), 'collection') or contains(text(), 'Collection') or contains(text(), 'bin') or contains(text(), 'Bin') or contains(text(), 'refuse') or contains(text(), 'Refuse') or contains(text(), 'recycling') or contains(text(), 'Recycling')]",
+                        )
+                    )
                 )
             except:
                 # If no specific text found, just wait for page to stabilize
@@ -109,20 +116,16 @@ class CouncilClass(AbstractGetBinDataClass):
 
             soup = BeautifulSoup(driver.page_source, features="html.parser")
 
-            # Save page source for debugging
-            with open("debug_page.html", "w", encoding="utf-8") as f:
-                f.write(driver.page_source)
-            
             # Find the bin collections table
             table = soup.find("table", class_="bincollections__table")
-            
+
             if not table:
-                raise ValueError("Could not find bin collections table in page source - saved debug_page.html")
-            
+                raise ValueError("Could not find bin collections table in page source")
+
             # Get current year for date parsing
             current_year = datetime.now().year
             current_month = None
-            
+
             # Parse the table rows
             rows = table.find_all("tr")
             for row in rows:
@@ -132,7 +135,7 @@ class CouncilClass(AbstractGetBinDataClass):
                     # This is a month header
                     current_month = th.get_text(strip=True)
                     continue
-                
+
                 # Parse data rows
                 cells = row.find_all("td")
                 if len(cells) >= 3:
@@ -140,7 +143,7 @@ class CouncilClass(AbstractGetBinDataClass):
                     day = cells[0].get_text(strip=True)
                     weekday = cells[1].get_text(strip=True)
                     bin_cell = cells[2]
-                    
+
                     # Extract all bin types from the cell (may contain multiple links)
                     bin_links = bin_cell.find_all("a")
                     bin_types = []
@@ -148,24 +151,24 @@ class CouncilClass(AbstractGetBinDataClass):
                         bin_type = link.get_text(strip=True)
                         if bin_type:
                             bin_types.append(bin_type)
-                    
+
                     # If no links found, try getting text directly
                     if not bin_types:
                         bin_text = bin_cell.get_text(strip=True)
                         if bin_text:
                             bin_types = [bin_text]
-                    
+
                     # Parse the date
                     if current_month and day:
                         try:
                             # Construct date string: "day month year"
                             date_str = f"{day} {current_month} {current_year}"
                             parsed_date = datetime.strptime(date_str, "%d %B %Y")
-                            
+
                             # If the parsed date is more than 6 months in the past, it's probably next year
                             if (datetime.now() - parsed_date).days > 180:
                                 parsed_date = parsed_date.replace(year=current_year + 1)
-                            
+
                             # Add each bin type as a separate entry
                             for bin_type in bin_types:
                                 dict_data = {

--- a/uk_bin_collection/uk_bin_collection/councils/MidAndEastAntrimBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/MidAndEastAntrimBoroughCouncil.py
@@ -1,14 +1,21 @@
-import time
+from urllib.parse import parse_qs, urlparse
 
 from bs4 import BeautifulSoup
-from dateutil.relativedelta import relativedelta
-from selenium.common.exceptions import NoSuchElementException
-from selenium.webdriver.common.by import By
-from selenium.webdriver.common.keys import Keys
-from selenium.webdriver.support.ui import Select
 
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
+
+# The council's own site embedded a "Bin collection calendar" iframe that
+# has since been replaced with a link out to a WhiteSpace Work and Resource
+# Planning portal (the same platform several other councils in this repo
+# already use, e.g. WaverleyBoroughCouncil) - no Selenium needed.
+BASE_URL = "https://nimea-wrp.whitespacews.com/"
+
+_HEADERS = {
+    "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36",
+    "Origin": "https://nimea-wrp.whitespacews.com",
+}
 
 
 class CouncilClass(AbstractGetBinDataClass):
@@ -19,112 +26,87 @@ class CouncilClass(AbstractGetBinDataClass):
     """
 
     def parse_data(self, page: str, **kwargs) -> dict:
-        driver = None
-        try:
-            page = "https://www.midandeastantrim.gov.uk/resident/waste-recycling/collection-dates/"
+        data = {"bins": []}
+        user_paon = kwargs.get("paon")
+        user_postcode = kwargs.get("postcode")
+        check_postcode(user_postcode)
+        check_paon(user_paon)
 
-            # Assign user info
-            user_postcode = kwargs.get("postcode")
-            # not used: user_paon = kwargs.get("paon")
-            web_driver = kwargs.get("web_driver")
-            headless = kwargs.get("headless")
+        session = requests.Session()
 
-            # Create Selenium webdriver
-            options = webdriver.ChromeOptions()
-            options.add_experimental_option("excludeSwitches", ["enable-logging"])
-            user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36"
-            driver = create_webdriver(web_driver, headless, user_agent, __name__)
+        # Starting the form generates a one-time "Track" id in the URL of
+        # the "View my collections" link - every subsequent request needs it.
+        start_response = session.get(BASE_URL, timeout=30)
+        start_soup = BeautifulSoup(start_response.content, features="html.parser")
+        start_link = start_soup.find(
+            "a", string=lambda t: t and "View my collections" in t
+        )
+        if not start_link:
+            raise ValueError("Could not find the collections form start link")
+        track_id = parse_qs(urlparse(start_link["href"]).query)["Track"][0]
 
-            driver.get(page)
+        headers = {**_HEADERS, "Referer": start_link["href"]}
+        form_data = {
+            "address_name_number": user_paon,
+            "address_street": "",
+            "street_town": "",
+            "address_postcode": user_postcode,
+        }
+        search_url = f"{BASE_URL}mop.php?serviceID=A&Track={track_id}&seq=2"
+        search_response = session.post(
+            search_url, headers=headers, data=form_data, timeout=30
+        )
+        search_soup = BeautifulSoup(search_response.content, features="html.parser")
 
-            time.sleep(5)
-            number = 0
-            driver.switch_to.frame(number)
-            # Enter postcode in text box and wait
-            inputElement_pc = driver.find_element(By.ID, "txtAjaxSearch")
-            inputElement_pc.send_keys(user_postcode)
-
-            time.sleep(5)
-
-            # Submit address information and wait - selecting the top one only
-            # if it is an exact match then it will go straight to the results
-            try:
-                button = driver.find_element(By.XPATH, '//*[@id="show-button-0"]')
-                driver.execute_script("arguments[0].click();", button)
-            except NoSuchElementException:
-                pass
-
-            time.sleep(4)
-
-            # Read next collection information
-            page = driver.find_element(By.ID, "divCalendarGraphics").get_attribute(
-                "outerHTML"
+        candidates = search_soup.find_all("a", class_="app-subnav__link")
+        paon_upper = user_paon.strip().upper()
+        address_link = next(
+            (
+                a
+                for a in candidates
+                if a.get("aria-label", "").upper().startswith(paon_upper + ",")
+            ),
+            candidates[0] if len(candidates) == 1 else None,
+        )
+        if not address_link:
+            raise ValueError(
+                f"No address found for postcode {user_postcode} and house "
+                f"number/name {user_paon}"
             )
 
-            # Make a BS4 object - remove bold tags and add @ so we can split the lines later
-            soup = BeautifulSoup(
-                page.strip()
-                .replace("<b>", "")
-                .replace("</b>", "")
-                .replace("<br>", "@"),
-                features="html.parser",
+        collections_url = BASE_URL + address_link["href"]
+        collections_response = session.get(
+            collections_url, headers={**_HEADERS, "Referer": search_url}, timeout=30
+        )
+        collections_soup = BeautifulSoup(
+            collections_response.content, features="html.parser"
+        )
+
+        ul_blocks = collections_soup.find_all(
+            "ul",
+            {
+                "class": "displayinlineblock justifycontentleft alignitemscenter margin0 padding0"
+            },
+        )
+        for ul in ul_blocks:
+            li_items = ul.find_all_next(
+                "li", {"class": "displayinlineblock padding0px20px5px0px"}
             )
-            soup.prettify()
+            # Each entry is 3 <li> - blank, date, bin type.
+            for i in range(0, len(li_items) - 2, 3):
+                date_text = li_items[i + 1].text.strip()
+                bin_type = li_items[i + 2].text.strip()
+                if not date_text or not bin_type:
+                    continue
+                try:
+                    collection_date = datetime.strptime(
+                        date_text, date_format
+                    ).strftime(date_format)
+                except ValueError:
+                    continue
+                data["bins"].append(
+                    {"type": bin_type, "collectionDate": collection_date}
+                )
+            break
 
-            # Data to return
-            data = {"bins": []}
-
-            # Valid bin types
-            binTypes = ["Refuse", "Garden"]
-
-            # Value to create dict for bin values
-            keys, values = [], []
-
-            # Loop though html for text containing bins
-            # example of html (bold tags removed above)
-            # <div id="divCalendarGraphics">
-            # <br>  <b>Refuse</b>: Tue 14 Nov then every alternate  Tue<br><b>Recycling</b>: No Recycling waste collection for this address<br><b>Garden</b>: Tue 21 Nov then every alternate  Tue<br><img src="img/Gif-Spacer.gif" alt="spacer" height="1" width="30">
-            # split by br tag and take first 4 splits
-            lines = soup.text.split("@", 4)
-            for line in lines[1:4]:
-                keys.append(line.split(":")[0].strip())
-                # strip out the day and month from the text
-                values.append(line.split(":")[1].strip().split(" ")[:3])
-
-            # Create dict for bin name and string dates
-            binDict = dict(zip(keys, values))
-
-            # Process dict for valid bin types
-            for bin in list(binDict):
-                if bin in binTypes:
-                    # Convert date - no year value so take it from todays date
-                    if binDict[bin][0] == "Tomorrow":
-                        date = datetime.today() + relativedelta(days=1)
-                    elif binDict[bin][0] == "Today":
-                        date = datetime.today()
-                    else:
-                        date = datetime.strptime(
-                            " ".join(binDict[bin][1:]), "%d %b"
-                        ).replace(year=datetime.today().year)
-                        # if the date is in the past then it means the collection is next year so add a year
-                        if date < datetime.today():
-                            date = date + relativedelta(years=1)
-
-                    # Set bin data
-                    dict_data = {
-                        "type": bin,
-                        "collectionDate": date.strftime(date_format),
-                    }
-                    data["bins"].append(dict_data)
-
-        # Quit Selenium webdriver to release session
-        except Exception as e:
-            # Here you can log the exception if needed
-            print(f"An error occurred: {e}")
-            # Optionally, re-raise the exception if you want it to propagate
-            raise
-        finally:
-            # This block ensures that the driver is closed regardless of an exception
-            if driver:
-                driver.quit()
         return data

--- a/uk_bin_collection/uk_bin_collection/councils/SwaleBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/SwaleBoroughCouncil.py
@@ -53,17 +53,14 @@ class CouncilClass(AbstractGetBinDataClass):
             driver.get(council_url)
 
             # Wait for the postcode field to appear then populate it
-            try:
-                inputElement_postcode = WebDriverWait(driver, 10).until(
-                    EC.presence_of_element_located((By.ID, "q499089_q1"))
-                )
-                inputElement_postcode.send_keys(user_postcode)
-            except Exception:
-                print("Page failed to load. Probably due to Cloudflare robot check!")
+            inputElement_postcode = WebDriverWait(driver, 10).until(
+                EC.presence_of_element_located((By.ID, "q535679_q1"))
+            )
+            inputElement_postcode.send_keys(user_postcode)
 
             # Click search button
             findAddress = WebDriverWait(driver, 10).until(
-                EC.presence_of_element_located((By.ID, "form_email_499078_submit"))
+                EC.presence_of_element_located((By.ID, "form_email_535662_submit"))
             )
             driver.execute_script("arguments[0].click();", findAddress)
 
@@ -72,7 +69,7 @@ class CouncilClass(AbstractGetBinDataClass):
                 EC.element_to_be_clickable(
                     (
                         By.XPATH,
-                        "//select[@name='q499093:q1']//option[contains(., '"
+                        "//select[@name='q535685:q1']//option[contains(., '"
                         + user_paon
                         + "')]",
                     )
@@ -81,7 +78,7 @@ class CouncilClass(AbstractGetBinDataClass):
 
             # Click search button
             getBins = WebDriverWait(driver, 10).until(
-                EC.presence_of_element_located((By.ID, "form_email_499078_submit"))
+                EC.presence_of_element_located((By.ID, "form_email_535662_submit"))
             )
             driver.execute_script("arguments[0].click();", getBins)
 


### PR DESCRIPTION
## Summary

Follow-up to the full-suite triage - deep-dived into the councils flagged as "genuinely broken, needs individual investigation" plus a couple of re-checks. 6 real fixes, 2 non-fixes documented, 1 hardening-only change.

### Fixed

- **EastLindseyDistrictCouncil**: form element ids are year-versioned (`WASTECOLLECTIONDAYS202526`) and the council rolled to `202627` - matched on the stable suffix (`[id$='_LOOKUP_ADDRESSLOOKUPPOSTCODE']` etc.) instead of hardcoding a year, so this won't break again at the next rollover.
- **AngusCouncil**: the AchieveForms form was rebuilt - postcode field id `searchString`→`search`, address dropdown `customerAddress`→`select_NewAddress`, plus a new required "Show Calendar" button click. The results markup itself (`<u>`/`<b>` tags) is unchanged.
- **BarkingDagenham**: a promotional overlay (`.prefix-overlay`) sits on top of the page and intercepts all clicks/typing below it, including the cookie banner - `ElementNotInteractableException` on the postcode field. Now dismisses both overlays explicitly.
- **MidAndEastAntrimBoroughCouncil**: the embedded iframe widget is gone entirely (0 iframes on the page) - the council moved to a linked-out WhiteSpace WRP portal, the same platform 8 other councils in this repo already use. Rewrote as a pure-HTTP scraper (no Selenium needed), mirroring the established `WaverleyBoroughCouncil` pattern. **Breaking change**: now takes postcode + house number as separate parameters (matching every other council's convention) instead of the whole address crammed into the postcode field - a quirk of the old iframe's free-text search that no longer applies.
- **SwaleBoroughCouncil**: not a Cloudflare block (the old fallback message was a guess, not a diagnosis - verified the page loads completely normally). The Squiz Matrix form was just rebuilt with new field ids. Results page structure unchanged.
- **DartfordBoroughCouncil**: the site silently serves a stripped-down page with no results table for requests without a browser-like User-Agent - the scraper sent none, always got the empty variant, and (since a missing table wasn't treated as an error) silently returned zero bins. Sent the project's UA string and made a missing table a hard error instead of a silent empty result. This was never actually a dead backend, as earlier investigation (using a UA-less request) had concluded.

### Hardening only (not a fix for the live issue)

- **HorshamDistrictCouncil**: switched to `build_retry_session()` for consistency, but verified live it still fails after 5 retries - a sustained connection reset, not a transient blip retries can fix.
- **GatesheadCouncil**: removed a stray unconditional debug file write (`debug_page.html` written to cwd on every run) and a now-stale error message referencing it. Could not reproduce the actual reported symptom (#1560, stuck/repeating collection date) live - the scraper currently produces correctly advancing dates. Commented on the issue asking for more repro detail.

### Investigated, confirmed not fixable here

- **HaltonBoroughCouncil**: genuine Google reCAPTCHA v2 block - confirmed even with `undetected-chromedriver` against a real local, non-headless Chrome, the checkbox never actually checks. Same class of problem as Haringey (#2113).
- **AshfieldDistrictCouncil**: a genuine client-side JavaScript error on the council's own portal (`Cannot read properties of null (reading 'id')`) leaves their page stuck on "Loading..." for every visitor, not just automation. Not fixable on our end.
- **GedlingBoroughCouncil, FyldeCouncil**: re-checked, both unchanged from earlier triage (Gedling's API is genuinely unstable; Fylde has moved to a login-gated system with no public lookup).

### Systematic audit: the Aberdeenshire "page-ignoring" risk class (79 councils)

Following the Aberdeenshire regression (#2158, fixed in PR #2159 - a scraper that ignores the framework's fetched page but wasn't marked `skip_get_url`, so a bug-fix elsewhere turned an always-wasted request into a hard failure), did the systematic audit rather than leaving it as noted latent risk: AST-scanned every file in `councils/` for the same shape (own request made inside `parse_data()`, incoming `page` never read), cross-checked against `input.json` for entries not already marked `skip_get_url` or Selenium-based.

**79 councils confirmed** - overwhelmingly a single shared AchieveForms/apibroker template (`SESSION_URL` + `API_URL`, e.g. Bolsover, Dudley, Aberdeen City) used across dozens of these, which never needed the framework's fetch. Marked all 79 `skip_get_url: true` - this closes off the regression risk class entirely (no more unused fetches that can turn into hard failures if their target ever breaks) and skips a genuinely wasted network request on every run for all of them.

Verified live: full BDD run of all 79 (via a small Python driver script calling `pytest.main()` directly, no xdist - ran into an unrelated pytest-xdist worker-crash flake under parallel execution that reproduced regardless of my changes, sidestepped rather than chased) - **78 passed, 1 failed** (FyldeCouncil, the same pre-existing unrelated failure documented above).

## Test plan

- [x] `poetry run pytest uk_bin_collection/tests custom_components/uk_bin_collection/tests --ignore=uk_bin_collection/tests/step_defs/` - 221 passed
- [x] `black --check` clean
- [x] Full BDD run of all 10 touched councils together (`-n 8`, matched to grid capacity) - 9 passed, 1 failed (Horsham, expected/documented)
- [x] Full BDD run of all 79 `skip_get_url` audit councils - 78 passed, 1 failed (Fylde, expected/documented)
- [x] Live verification for every fix (see commit messages)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved bin collection lookups and resilience across Angus, Barking and Dagenham, East Lindsey, Gateshead, Swale, and Mid and East Antrim.
  - Updated council website interaction flows to handle refreshed forms, service-year identifiers, pop-ups, verification steps, and address dropdown behavior.
  - Added clearer errors when expected addresses or collection results can’t be found.
  - Switched Mid and East Antrim collection retrieval to a more reliable non-browser approach.
- **Tests**
  - Updated Mid and East Antrim test input and addressing instructions.
- **Documentation**
  - Refreshed July 2026 issue-resolution progress and release notes details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
