### PR TITLE
fix: #2153 Lincoln stale anchor date + Flintshire schedule-note cleanup

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/FlintshireCountyCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/FlintshireCountyCouncil.py
@@ -47,6 +47,10 @@ class CouncilClass(AbstractGetBinDataClass):
 
             # Loop through the dates for each collection type
             for bin_type in bin_types:
+                # Rows like "*New Round* - Tuesday AHP" are schedule notices,
+                # not an actual bin type - skip them.
+                if bin_type.startswith("*"):
+                    continue
 
                 dict_data = {
                     "type": bin_type,

--- a/uk_bin_collection/uk_bin_collection/councils/LincolnCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/LincolnCouncil.py
@@ -81,6 +81,8 @@ class CouncilClass(AbstractGetBinDataClass):
             ("recyclenextdate", "Brown Bin", "recycle_freq"),
             ("gardennextdate", "Green Bin", "garden_freq"),
         ]
+        FREQ_DAYS = {"weekly": 7, "fortnightly": 14}
+        today = datetime.now().date()
 
         for uprn, data in rows_data.items():
             if uprn != target_uprn:
@@ -88,12 +90,21 @@ class CouncilClass(AbstractGetBinDataClass):
             for key, bin_type, freq in BIN_TYPES:
                 if not data[key]:
                     continue
-                offsets = [0]
-                if data[freq] == "fortnightly":
-                    offsets.extend(list(range(14, 30, 14)))
-                elif data[freq] == "weekly":
-                    offsets.extend(list(range(7, 30, 7)))
                 date = datetime.strptime(data[key], "%Y-%m-%d").date()
+                step = FREQ_DAYS.get(data[freq])
+                if step:
+                    # The council's "next date" field can lag behind reality
+                    # by weeks - roll it forward by the collection frequency
+                    # until it's genuinely upcoming, rather than trusting it
+                    # as always being the next one.
+                    while date < today:
+                        date += timedelta(days=step)
+                    occurrences = 3 if step == 14 else 5
+                    offsets = [step * n for n in range(occurrences)]
+                else:
+                    if date < today:
+                        continue
+                    offsets = [0]
                 for offset in offsets:
                     dict_data = {
                         "type": bin_type,
@@ -113,7 +124,11 @@ class CouncilClass(AbstractGetBinDataClass):
         for uprn, data in rows_data.items():
             display = str(data.get("display", "")).upper()
             first_line = display.split("\n")[0].strip()
-            if first_line.startswith(paon_norm + " ") or first_line.startswith(paon_norm + ",") or first_line == paon_norm:
+            if (
+                first_line.startswith(paon_norm + " ")
+                or first_line.startswith(paon_norm + ",")
+                or first_line == paon_norm
+            ):
                 return uprn
 
         for uprn, data in rows_data.items():
@@ -121,4 +136,6 @@ class CouncilClass(AbstractGetBinDataClass):
             if paon_norm in display:
                 return uprn
 
-        raise ValueError(f"Could not match house number/name '{paon}' in address results")
+        raise ValueError(
+            f"Could not match house number/name '{paon}' in address results"
+        )


### PR DESCRIPTION
## Summary

Root cause of #2153 ("Lincoln city no longer works", all sensors unavailable, log shows "No bin data found... No previous data to fall back to").

The council's API returns a "next date" per bin type that can lag behind reality by weeks. Verified live right now: `refusenextdate` is `2026-06-03` - over 6 weeks in the past - and identical across every single address in the test postcode, confirming this is a staleness issue on the council's own backend, not anything address-specific (rules out a bad UPRN/postcode on the reporter's end).

The scraper only ever projected a small fixed window of occurrences forward from that anchor (`[0, 7, 14, 21, 28]` days for weekly, `[0, 14, 28]` for fortnightly). Once the anchor is stale by more than that window, every generated date - including the last one - is still in the past. HA's coordinator filters out all past dates, leaving nothing, which is exactly the reported "No bin data found, no previous data to fall back to" symptom.

Fix: roll the anchor date forward by the bin type's own frequency (weekly/fortnightly) until it's genuinely upcoming, *then* generate the occurrence window from there. A stale anchor no longer produces an entirely-past result.

### Also folds in #2167 (FlintshireCountyCouncil)

Found while re-investigating #2118 (Brown Bin / Garden Waste). The Brown Bin extraction itself was already working correctly (unrelated to this fix), but along the way found a genuine, separate bug: some collection weeks include a schedule-notice row (`*New Round* - Tuesday AHP`) in the same table column as the actual bin type, which was getting appended to the bins list as if it were a real collection. These notice rows are consistently prefixed with `*`, so skip them.

## Test plan

- [x] Verified live: previously all-past Lincoln dates (03/06–01/07) now correctly resolve to 15/07 onward
- [x] Verified live: Flintshire junk `*New Round*` entries gone, `Brown Bin` and everything else still correctly present
- [x] `poetry run pytest uk_bin_collection/tests/step_defs/ -k "LincolnCouncil or FlintshireCountyCouncil"` - both passed
- [x] `poetry run pytest uk_bin_collection/tests custom_components/uk_bin_collection/tests --ignore=uk_bin_collection/tests/step_defs/` - 221 passed
- [x] `black --check` clean

Fixes #2153

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Lincoln bin collection date calculations to ensure the next genuinely upcoming collection is shown for weekly and fortnightly schedules.
  * Updated future schedule generation for weekly and fortnightly services.
  * Adjusted Lincoln/Flintshire parsing so only valid bin types contribute to upcoming collection results, while preserving existing address matching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
