### PR TITLE
fix: FlintshireCountyCouncil - skip schedule-note rows

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/FlintshireCountyCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/FlintshireCountyCouncil.py
@@ -47,6 +47,10 @@ class CouncilClass(AbstractGetBinDataClass):
 
             # Loop through the dates for each collection type
             for bin_type in bin_types:
+                # Rows like "*New Round* - Tuesday AHP" are schedule notices,
+                # not an actual bin type - skip them.
+                if bin_type.startswith("*"):
+                    continue
 
                 dict_data = {
                     "type": bin_type,


### PR DESCRIPTION
## Summary

Found while re-investigating #2118 (Brown Bin / Garden Waste not showing). The Brown Bin extraction itself was already working correctly (confirmed live again just now, unrelated to this fix - see comment on the issue), but along the way I noticed a real, separate bug: some collection weeks include a row like \`*New Round* - Tuesday AHP\` in the same table column as the actual bin type, and the scraper was appending it to the bins list as if it were a real collection type.

These schedule-notice rows are consistently prefixed with \`*\`, so skip them rather than treating them as a bin type.

## Test plan

- [x] Verified live: junk \`*New Round*\` entries gone, \`Brown Bin\` entries (and everything else) still correctly present
- [x] \`poetry run pytest uk_bin_collection/tests/step_defs/ -k FlintshireCountyCouncil\` - passed
- [x] \`poetry run pytest uk_bin_collection/tests custom_components/uk_bin_collection/tests --ignore=uk_bin_collection/tests/step_defs/\` - 221 passed
- [x] \`black --check\` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Excluded non-bin schedule notices from collection results, preventing them from appearing as bin types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->