### PR TITLE
fix: #2168 NorthWestLeicestershire - sync HA config metadata with scraper

### DIFF
--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -1969,13 +1969,12 @@
     },
     "NorthWestLeicestershire": {
         "LAD24CD": "E07000134",
+        "house_number": "9",
         "postcode": "DE74 2FZ",
         "skip_get_url": true,
-        "uprn": "100030572613",
         "url": "https://www.nwleics.gov.uk/pages/collection_information",
-        "web_driver": "http://selenium:4444",
         "wiki_name": "North West Leicestershire",
-        "wiki_note": "Pass the postcode and UPRN. This parser requires a Selenium webdriver."
+        "wiki_note": "Pass the postcode and house number. No UPRN or Selenium webdriver needed."
     },
     "NorthYorkshire": {
         "LAD24CD": "E06000065",


### PR DESCRIPTION
## Summary

The scraper code was already rewritten as a pure-HTTP, postcode + house_number lookup a while back (\`ab0cd602 feat: rewrite north west leicestershire as pure http scraper\`) - no UPRN, no Selenium needed. But \`input.json\` was never updated to match, and that file is what \`custom_components/uk_bin_collection/config_flow.py\` reads directly to decide which fields to present to a user during setup: the presence of the \`uprn\`/\`web_driver\` keys is what gates showing those fields (\`config_flow.py\` lines ~294-305). So anyone setting this council up through the HA UI was still being asked for a UPRN and a Selenium webdriver address the code doesn't use, and never asked for the \`house_number\` it actually needs for disambiguation - exactly what the reporter described ("the script works, but the Home Assistant council template needs updating").

Removed \`uprn\`/\`web_driver\`, added \`house_number\`, updated \`wiki_note\`. This also happens to resolve a stale-fixture note from an earlier nightly-suite triage pass (postcode was ambiguous without a house number to disambiguate).

## Test plan

- [x] Verified live end-to-end with a real address for the test postcode (\`DE74 2FZ\`, house number \`9\`)
- [x] \`poetry run pytest uk_bin_collection/tests/step_defs/ -k NorthWestLeicestershire\` - passed
- [x] \`poetry run pytest uk_bin_collection/tests custom_components/uk_bin_collection/tests --ignore=uk_bin_collection/tests/step_defs/\` - 221 passed
- [x] \`black --check\` clean

Fixes #2168

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated North West Leicestershire address collection to work with a postcode and house number.
  * Removed the need for an additional property reference and browser-based lookup for this area.
  * Clarified the required address information for more reliable collection requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->