### PR TITLE
fix(councils): rewrite Slough and Sunderland as pure HTTP, no browser

### DIFF
--- a/ISSUE_RESOLUTION_PROGRESS.md
+++ b/ISSUE_RESOLUTION_PROGRESS.md
@@ -51,8 +51,7 @@ on a couple of previously-confirmed-broken ones.
 
 **Confirmed not fixable here:**
 - **HaltonBoroughCouncil**: genuine Google reCAPTCHA v2 - confirmed blocked even
-  with `undetected-chromedriver` against a real local, non-headless Chrome. Same
-  class of problem as Haringey (#2113).
+  with `undetected-chromedriver` against a real local, non-headless Chrome.
 - **AshfieldDistrictCouncil**: a genuine client-side JS error on the council's own
   portal (`Cannot read properties of null (reading 'id')`) leaves the page stuck on
   "Loading..." for every visitor, not just automation.
@@ -142,17 +141,15 @@ Triage of the 26 failures:
     fix.
   - **SwaleBoroughCouncil** - confirmed Cloudflare bot-check blocking page load
     (the scraper's own diagnostic print already says so). Same class of problem as
-    Sunderland (#2140, fixed with undetected-chromedriver) / Haringey (#2113,
-    still unfixed - AWS WAF, not Cloudflare). Not attempted this pass.
+    Sunderland (#2140, fixed with undetected-chromedriver). Not attempted this pass.
   - **EastLindseyDistrictCouncil, AngusCouncil, HaltonBoroughCouncil,
     AshfieldDistrictCouncil, BarkingDagenham, MidAndEastAntrimBoroughCouncil** -
     confirmed genuinely broken on a sequential re-run (not contention), each with a
     generic Selenium `TimeoutException` (or `ElementNotInteractableException` /
     `NoSuchFrameException`) - needs individual selector/page-change investigation
     per council, not done this pass given time already spent.
-  - **HaringeyCouncil, NorthEastDerbyshireDistrictCouncil** - already deeply
-    investigated earlier this session (see "Investigated, not fixed" below);
-    unchanged.
+  - **NorthEastDerbyshireDistrictCouncil** - already deeply investigated earlier
+    this session (see "Investigated, not fixed" below); unchanged.
 
 ## July 2026 Release: [PR #2154](https://github.com/robbrad/UKBinCollectionData/pull/2154) (merged) + [PR #2155](https://github.com/robbrad/UKBinCollectionData/pull/2155) (follow-up)
 
@@ -255,7 +252,6 @@ this is a maintainer decision, not made in this session.
 
 | Issue | Council | Notes |
 |-------|---------|-------|
-| #2113 | Haringey | New site is behind AWS WAF Bot Control (CloudFront), not Cloudflare. Plain Selenium blocked; undetected-chromedriver also blocked (5/5 attempts). A pure-HTTP rewrite isn't feasible either - the site is a Next.js app using server actions, not a discoverable REST API. Needs a more specialized bypass (e.g. residential-IP browser farm) or a different data source. Findings posted on the issue. |
 | #1884 | Ealing | Re-verified live: the previously-reported bug (`collectionDateString` vs `collectionDate`) is already fixed in both `EalingCouncil.py` and `LondonBoroughEaling.py` (commit 57c8b1a9); both return correct data today. Only the module-duplication cleanup remains, deliberately deferred (deleting/merging either would break existing users' saved config). |
 | #1881 | NE Derbyshire | Re-checked live: self-service form still redirects to the homepage, only PDF calendars available, no postcode/address lookup exists. No change since the last update on the issue. Holding off on a PDF+area-list rewrite per earlier guidance - large, fragile, and possibly throwaway if the council republishes the form. |
 
@@ -288,6 +284,61 @@ this is a maintainer decision, not made in this session.
 | 29a242d0 | EastDevonDC | Send scraper User-Agent header to get past a 403 block |
 | 7a5a585e | HorshamDistrictCouncil | Use build_retry_session() for resilience (hardening, not a fix) |
 | 65261e47 | LincolnCouncil | Fix NoneType error when UPRN not provided (zfill on None) [prior session] |
+| 54c04e21 | HaringeyCouncil | Rewrite for `wastecollections.haringey.gov.uk` JSON API - corrects earlier "AWS WAF, unfixable" conclusion, see note below |
+| (pending) | SloughBoroughCouncil | Rewrite for `waste.slough.gov.uk` Public Dashboard, pure HTTP, drops Selenium entirely - see note below |
+| (pending) | SunderlandCityCouncil | Rewrite the GOSS iCM form flow as pure HTTP, drops undetected-chromedriver entirely - see note below |
+
+**Correction (Haringey, #2113):** the earlier "Investigated, not fixed" entry above
+was wrong. Re-investigated live: the *old* `/property/{uprn}` URL the scraper POSTed
+to genuinely 404s (a real Next.js `not-found` route, not a WAF block), which is what
+produced the appearance of blocking. The current site
+(`https://wastecollections.haringey.gov.uk`) is not behind Cloudflare or AWS WAF at
+all - `curl`/plain `requests` reach it with no `cf-ray`/challenge headers whatsoever.
+Its postcode-search UI calls two undocumented but fully public JSON endpoints with no
+auth, cookies, or session state required: `POST /api/getPropertySearch`
+(`{"councilId":"45","searchQuery":"<postcode>"}` → list of addresses with `id`/`uprn`)
+and `POST /api/getCollectionDays` (`{"pointId":"<id>","pointType":"PointAddress","councilId":"45"}`
+→ per-service `serviceSchedules` with real dates). Verified with a bare
+`requests.post()`, zero prior GET/cookie needed. Rewrote `HaringeyCouncil.py` to use
+this API; `input.json` now also carries `postcode` alongside the existing `uprn`.
+
+**Slough (no issue number, found while re-auditing the same "behind a WAF" class of
+problem):** the existing scraper drove the old Jadu directory search on
+`www.slough.gov.uk` via Selenium + a hardcoded Google Maps geocoding API key, and
+open bug #2079 reports it timing out waiting for the cookie-consent button. The
+council actually has a separate, modern portal at `waste.slough.gov.uk` (a Syncfusion
+"Public Dashboard", the same system already handled for HighPeakCouncil and
+StaffordshireMoorlandsDistrictCouncil) that renders both the premises list and the
+full collection schedule as plain JSON embedded in server-rendered HTML - no
+Selenium needed. It's a standard ASP.NET Razor Pages form
+(`__RequestVerificationToken` + session cookie, same pattern as
+`DerbyshireDalesDistrictCouncil.py`): `POST /PublicDashboard?handler=SearchPostcode`
+returns a premises array (`id`, `UPRN`, `Premises` address string), then
+`POST /PublicDashboard?handler=SelectPrem` (keyed by `UPRN`, not `id`) returns the
+`eventSettings.dataSource` array with real collection dates. Rewrote
+`SloughBoroughCouncil.py` to use this directly; `input.json` now carries `postcode` +
+`house_number` instead of relying on Selenium/`web_driver`.
+
+**Sunderland (#2140, re-investigated):** the original fix (commit 22390ee6) was
+correct for what was true at the time - a previous investigation (documented on the
+issue) rigorously confirmed the `/bindays` GOSS iCM flow was hard-blocked by
+Cloudflare Bot Management for every plain-Selenium configuration tried (headless,
+headed, remote grid, fully stealthed), and only `undetected-chromedriver` driving a
+real local Chrome got through. Re-tested live just now: the same flow now completes
+with **zero Cloudflare challenge**, via both a plain browser session and a bare
+`requests.Session()` with no special fingerprinting at all - either Cloudflare's bot
+management config for this site has been relaxed since, or it was keyed specifically
+off Selenium's automation fingerprint rather than the request pattern itself. The
+form is a classic GOSS iCM postback wizard: `GET` the form page for
+`BINCOLLECTIONCHECKERNEWV3_*` hidden fields, `POST` back to
+`/apiserver/formsservice/http/processsubmission?...` with the postcode to get an
+address `<select>`, then `POST` again with the selected option's value copied into
+the `UPRN`/`ADDRESSTEXT` hidden fields (mirroring what the page's own `onchange`
+handler does) to get the results page, and parse `.myaccount-block__item--bin`
+exactly as the old Selenium version did. Rewrote `SunderlandCityCouncil.py` as pure
+`requests` - drops the `undetected-chromedriver` dependency and the "needs a real
+local, non-headless Chrome, can't use the remote Selenium grid" CI limitation
+entirely. Worth re-verifying periodically in case Cloudflare's config reverts.
 
 ## Nightly integration suite triage
 

--- a/ISSUE_RESOLUTION_PROGRESS.md
+++ b/ISSUE_RESOLUTION_PROGRESS.md
@@ -285,8 +285,8 @@ this is a maintainer decision, not made in this session.
 | 7a5a585e | HorshamDistrictCouncil | Use build_retry_session() for resilience (hardening, not a fix) |
 | 65261e47 | LincolnCouncil | Fix NoneType error when UPRN not provided (zfill on None) [prior session] |
 | 54c04e21 | HaringeyCouncil | Rewrite for `wastecollections.haringey.gov.uk` JSON API - corrects earlier "AWS WAF, unfixable" conclusion, see note below |
-| (pending) | SloughBoroughCouncil | Rewrite for `waste.slough.gov.uk` Public Dashboard, pure HTTP, drops Selenium entirely - see note below |
-| (pending) | SunderlandCityCouncil | Rewrite the GOSS iCM form flow as pure HTTP, drops undetected-chromedriver entirely - see note below |
+| 2c1b9095 | SloughBoroughCouncil | Rewrite for `waste.slough.gov.uk` Public Dashboard, pure HTTP, drops Selenium entirely - see note below |
+| 2c1b9095 | SunderlandCityCouncil | Rewrite the GOSS iCM form flow as pure HTTP, drops undetected-chromedriver entirely - see note below |
 
 **Correction (Haringey, #2113):** the earlier "Investigated, not fixed" entry above
 was wrong. Re-investigated live: the *old* `/property/{uprn}` URL the scraper POSTed

--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -2309,12 +2309,12 @@
     },
     "SloughBoroughCouncil": {
         "LAD24CD": "E06000039",
+        "house_number": "149",
         "postcode": "SL2 2EW",
         "skip_get_url": true,
-        "url": "https://www.slough.gov.uk/bin-collections",
-        "web_driver": "http://selenium:4444",
+        "url": "https://waste.slough.gov.uk/PublicDashboard",
         "wiki_name": "Slough",
-        "wiki_note": "Pass the UPRN and postcode in their respective parameters. This parser requires a Selenium webdriver."
+        "wiki_note": "Pass the postcode, and either the UPRN or the house number to disambiguate."
     },
     "SolihullCouncil": {
         "LAD24CD": "E08000029",
@@ -2578,7 +2578,7 @@
         "skip_get_url": true,
         "url": "https://www.sunderland.gov.uk/article/12142/Find-your-bin-collection-day",
         "wiki_name": "Sunderland",
-        "wiki_note": "Provide your house number and postcode. The council's site is behind Cloudflare bot management, so this parser needs a real local, non-headless Chrome (via undetected-chromedriver) rather than a remote Selenium grid - it will not work with the usual web_driver/headless config."
+        "wiki_note": "Provide your house number and postcode."
     },
     "SurreyHeathBoroughCouncil": {
         "LAD24CD": "E07000214",

--- a/uk_bin_collection/uk_bin_collection/councils/SloughBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/SloughBoroughCouncil.py
@@ -1,158 +1,129 @@
-import re
-import time
-from datetime import datetime
+import json
 
 import requests
 from bs4 import BeautifulSoup
-from selenium.webdriver.common.by import By
-from selenium.webdriver.common.keys import Keys
-from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.support.ui import WebDriverWait
 
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
+BASE_URL = "https://waste.slough.gov.uk/PublicDashboard"
 
-def get_street_from_postcode(postcode: str, api_key: str) -> str:
-    url = "https://maps.googleapis.com/maps/api/geocode/json"
-    params = {"address": postcode, "key": api_key}
-    response = requests.get(url, params=params)
-    data = response.json()
 
-    if data["status"] != "OK":
-        raise ValueError(f"API error: {data['status']}")
-
-    for component in data["results"][0]["address_components"]:
-        if "route" in component["types"]:
-            return component["long_name"]
-
-    raise ValueError("No street (route) found in the response.")
+def _extract_json_array(text: str, marker: str, start_from: int = 0):
+    """Pull the JSON array passed to ejs.data.DataUtil.parse.isJson(...) after marker."""
+    idx = text.index(marker, start_from) + len(marker)
+    start = text.index("[", idx)
+    array, _ = json.JSONDecoder().raw_decode(text, start)
+    return array
 
 
 class CouncilClass(AbstractGetBinDataClass):
+    """
+    Slough Borough Council uses a Syncfusion-based "Public Dashboard"
+    (waste.slough.gov.uk) that renders premises and the collection schedule
+    as plain server-rendered JSON embedded in the page - no browser needed.
+    """
+
     def parse_data(self, page: str, **kwargs) -> dict:
-        driver = None
-        bin_data = {"bins": []}
-        try:
-            user_postcode = kwargs.get("postcode")
-            if not user_postcode:
-                raise ValueError("No postcode provided.")
-            check_postcode(user_postcode)
+        user_postcode = kwargs.get("postcode")
+        user_paon = kwargs.get("paon")
+        user_uprn = kwargs.get("uprn")
+        check_postcode(user_postcode)
+        bindata = {"bins": []}
 
-            headless = kwargs.get("headless")
-            web_driver = kwargs.get("web_driver")
-            UserAgent = "Mozilla/5.0"
-            driver = create_webdriver(web_driver, headless, UserAgent, __name__)
-            page = "https://www.slough.gov.uk/bin-collections"
-            driver.get(page)
-            # Accept cookies
-            WebDriverWait(driver, 10).until(
-                EC.element_to_be_clickable((By.ID, "ccc-recommended-settings"))
-            ).click()
+        headers = {
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+        }
 
-            # Enter the street name into the address search
-            address_input = WebDriverWait(driver, 10).until(
-                EC.presence_of_element_located((By.ID, "keyword_directory30"))
+        s = requests.Session()
+        r = s.get(BASE_URL, headers=headers, timeout=15)
+        r.raise_for_status()
+        soup = BeautifulSoup(r.text, "html.parser")
+        token = soup.find("input", {"name": "__RequestVerificationToken"})["value"]
+
+        post_headers = {
+            **headers,
+            "Referer": BASE_URL,
+            "Content-Type": "application/x-www-form-urlencoded",
+        }
+
+        r = s.post(
+            f"{BASE_URL}?handler=SearchPostcode",
+            data={
+                "SelectedPostcode": user_postcode,
+                "__RequestVerificationToken": token,
+            },
+            headers=post_headers,
+            timeout=15,
+        )
+        r.raise_for_status()
+        premises = _extract_json_array(r.text, "ejs.data.DataUtil.parse.isJson(")
+        if not premises:
+            raise ValueError("No addresses found for this postcode")
+
+        soup = BeautifulSoup(r.text, "html.parser")
+        token = soup.find("input", {"name": "__RequestVerificationToken"})["value"]
+
+        if user_uprn:
+            check_uprn(user_uprn)
+            match = next(
+                (p for p in premises if str(int(p["UPRN"])) == str(user_uprn)), None
             )
-            user_address = get_street_from_postcode(
-                user_postcode, "AIzaSyBDLULT7EIlNtHerswPtfmL15Tt3Oc0bV8"
-            )
-            address_input.send_keys(user_address + Keys.ENTER)
-
-            # Wait for address results to load
-            WebDriverWait(driver, 10).until(
-                EC.presence_of_all_elements_located(
-                    (By.CSS_SELECTOR, "span.list__link-text")
+            if not match:
+                raise ValueError(
+                    f"Could not match UPRN '{user_uprn}' in address results"
                 )
+        elif user_paon:
+            check_paon(user_paon)
+            paon_norm = str(user_paon).strip().upper()
+            match = next(
+                (
+                    p
+                    for p in premises
+                    if p["Premises"].upper().startswith(paon_norm + " ")
+                ),
+                None,
             )
-            span_elements = driver.find_elements(
-                By.CSS_SELECTOR, "span.list__link-text"
-            )
-
-            for span in span_elements:
-                if user_address.lower() in span.text.lower():
-                    span.click()
-                    break
-            else:
-                raise Exception(f"No link found containing address: {user_address}")
-
-            # Wait for address detail page
-            WebDriverWait(driver, 10).until(
-                EC.presence_of_element_located(
-                    (By.CSS_SELECTOR, "section.site-content")
+            if not match:
+                raise ValueError(
+                    f"Could not match house number '{user_paon}' in address results"
                 )
+        elif len(premises) == 1:
+            match = premises[0]
+        else:
+            raise ValueError(
+                "Multiple addresses found for this postcode; provide a UPRN or house number to disambiguate"
             )
-            soup = BeautifulSoup(driver.page_source, "html.parser")
 
-            # Extract each bin link and type
-            for heading in soup.select("dt.definition__heading"):
-                heading_text = heading.get_text(strip=True)
-                if "bin day details" in heading_text.lower():
-                    bin_type = heading_text.split()[0].capitalize() + " bin"
-                    dd = heading.find_next_sibling("dd")
-                    link = dd.find("a", href=True)
+        r = s.post(
+            f"{BASE_URL}?handler=SelectPrem",
+            data={
+                "SelectedPostcode": user_postcode,
+                "SelectedPremises": str(int(match["UPRN"])),
+                "__RequestVerificationToken": token,
+            },
+            headers=post_headers,
+            timeout=15,
+        )
+        r.raise_for_status()
+        events = _extract_json_array(
+            r.text, "ejs.data.DataUtil.parse.isJson(", r.text.index("eventSettings")
+        )
 
-                    if link:
-                        bin_url = link["href"]
-                        if not bin_url.startswith("http"):
-                            bin_url = "https://www.slough.gov.uk" + bin_url
+        today = datetime.now().date()
+        for event in events:
+            collection_date = datetime.fromisoformat(event["StartTime"]).date()
+            if collection_date < today:
+                continue
+            bindata["bins"].append(
+                {
+                    "type": event["Subject"].title(),
+                    "collectionDate": collection_date.strftime(date_format),
+                }
+            )
 
-                        # Visit the child page
-                        # print(f"Navigating to {bin_url}")
-                        driver.get(bin_url)
-                        WebDriverWait(driver, 10).until(
-                            EC.presence_of_element_located(
-                                (By.CSS_SELECTOR, "div.page-content")
-                            )
-                        )
-                        child_soup = BeautifulSoup(driver.page_source, "html.parser")
+        bindata["bins"].sort(
+            key=lambda x: datetime.strptime(x.get("collectionDate"), date_format)
+        )
 
-                        editor_div = child_soup.find("div", class_="editor")
-                        if not editor_div:
-                            # print("No editor div found on bin detail page.")
-                            continue
-
-                        ul = editor_div.find("ul")
-                        if not ul:
-                            # print("No <ul> with dates found in editor div.")
-                            continue
-
-                    for li in ul.find_all("li"):
-                        raw_text = li.get_text(strip=True).replace(".", "")
-
-                        if (
-                            "no collection" in raw_text.lower()
-                            or "no collections" in raw_text.lower()
-                        ):
-                            # print(f"Ignoring non-collection note: {raw_text}")
-                            continue
-
-                        raw_date = raw_text
-
-                        try:
-                            parsed_date = datetime.strptime(raw_date, "%d %B %Y")
-                        except ValueError:
-                            raw_date_cleaned = raw_date.split("(")[0].strip()
-                            try:
-                                parsed_date = datetime.strptime(
-                                    raw_date_cleaned, "%d %B %Y"
-                                )
-                            except Exception:
-                                print(f"Could not parse date: {raw_text}")
-                                continue
-
-                        formatted_date = parsed_date.strftime("%d/%m/%Y")
-                        contains_date(formatted_date)
-                        bin_data["bins"].append(
-                            {"type": bin_type, "collectionDate": formatted_date}
-                        )
-
-                        # print(f"Type: {bin_type}, Date: {formatted_date}")
-
-        except Exception as e:
-            print(f"An error occurred: {e}")
-            raise
-        finally:
-            if driver:
-                driver.quit()
-        return bin_data
+        return bindata

--- a/uk_bin_collection/uk_bin_collection/councils/SunderlandCityCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/SunderlandCityCouncil.py
@@ -1,178 +1,124 @@
-import platform
 import re
-import subprocess
-import time
-from datetime import datetime
 
-import undetected_chromedriver as uc
+import requests
 from bs4 import BeautifulSoup
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.support.ui import Select, WebDriverWait
 
-from uk_bin_collection.uk_bin_collection.common import (
-    check_paon,
-    check_postcode,
-    date_format,
-)
+from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
+FORM_PAGE = "https://www.sunderland.gov.uk/article/12142/Find-your-bin-collection-day"
+FORM_ID = "BINCOLLECTIONCHECKERNEWV3_FORM"
+NEXT_TRIGGER = "BINCOLLECTIONCHECKERNEWV3_ADDRESSSEARCH_POSTCODETRIGGER"
 
-def _installed_chrome_major_version() -> int | None:
-    """
-    undetected-chromedriver's own auto-detection sometimes grabs the
-    latest chromedriver release instead of one matching the locally
-    installed Chrome, causing a version-mismatch failure. Asking the
-    local Chrome binary directly is more reliable.
-    """
-    exe = uc.find_chrome_executable()
-    if not exe:
-        return None
 
-    if platform.system() == "Windows":
-        # On Windows, `chrome.exe --version` launches the browser rather
-        # than printing to stdout and returning, so read the file's
-        # version resource instead.
-        try:
-            output = subprocess.check_output(
-                [
-                    "powershell",
-                    "-NoProfile",
-                    "-Command",
-                    f"(Get-Item '{exe}').VersionInfo.FileVersion",
-                ],
-                stderr=subprocess.DEVNULL,
-                timeout=10,
-            ).decode()
-        except Exception:
-            return None
-    else:
-        try:
-            output = subprocess.check_output(
-                [exe, "--version"], stderr=subprocess.DEVNULL, timeout=10
-            ).decode()
-        except Exception:
-            return None
-
-    match = re.search(r"(\d+)\.", output)
-    return int(match.group(1)) if match else None
+def _form_fields(soup: BeautifulSoup) -> dict:
+    form = soup.find("form", id=FORM_ID)
+    return {
+        inp.get("name"): inp.get("value") or ""
+        for inp in form.find_all("input")
+        if inp.get("name")
+    }, form.get("action")
 
 
 class CouncilClass(AbstractGetBinDataClass):
     """
-    Sunderland City Council moved its bin-day checker onto a GOSS iCM form
-    behind Cloudflare bot management. Plain Selenium (headless or not,
-    local or remote grid, fully stealthed) is reliably blocked - only a
-    genuine, local, non-headless Chrome driven by undetected-chromedriver
-    clears the challenge. That means this council cannot use the shared
-    remote-grid `web_driver` pattern the other scrapers use: it always
-    launches its own local, visible Chrome (e.g. under Xvfb on Linux).
+    Sunderland City Council's bin-day checker is a GOSS iCM form. It's
+    fronted by Cloudflare, but the form itself is a plain HTML postback
+    wizard - no challenge is triggered by driving it directly with
+    requests (session cookies + the same hidden fields/referer a real
+    browser would send).
     """
 
     def parse_data(self, page: str, **kwargs) -> dict:
-        driver = None
-        try:
-            user_paon = kwargs.get("paon")
-            user_postcode = kwargs.get("postcode")
-            check_paon(user_paon)
-            check_postcode(user_postcode)
+        user_paon = kwargs.get("paon")
+        user_postcode = kwargs.get("postcode")
+        check_paon(user_paon)
+        check_postcode(user_postcode)
+        bindata = {"bins": []}
 
-            options = uc.ChromeOptions()
-            driver = uc.Chrome(
-                options=options,
-                headless=False,
-                version_main=_installed_chrome_major_version(),
+        headers = {
+            "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+        }
+
+        s = requests.Session()
+        r = s.get(FORM_PAGE, headers=headers, timeout=15)
+        r.raise_for_status()
+        soup = BeautifulSoup(r.text, "html.parser")
+
+        fields, action = _form_fields(soup)
+        fields["BINCOLLECTIONCHECKERNEWV3_ADDRESSSEARCH_SCCPOSTCODE"] = user_postcode
+        fields["BINCOLLECTIONCHECKERNEWV3_FORMACTION_NEXT"] = NEXT_TRIGGER
+
+        post_headers = {**headers, "Referer": FORM_PAGE}
+        r = s.post(action, data=fields, headers=post_headers, timeout=15)
+        r.raise_for_status()
+        soup = BeautifulSoup(r.text, "html.parser")
+
+        select = soup.find(
+            "select", id="BINCOLLECTIONCHECKERNEWV3_ADDRESSSEARCH_SCCLISTOFADDRESSES"
+        )
+        if not select:
+            raise ValueError("No addresses found for this postcode")
+
+        paon_upper = user_paon.strip().upper()
+        match = next(
+            (
+                option
+                for option in select.find_all("option")
+                if option.get("value")
+                and option.get_text(strip=True).upper().startswith(paon_upper)
+            ),
+            None,
+        )
+        if not match:
+            raise ValueError(
+                f"Could not match house number '{user_paon}' in address results"
             )
 
-            driver.get(
-                "https://www.sunderland.gov.uk/article/12142/Find-your-bin-collection-day"
+        fields, action = _form_fields(soup)
+        fields["BINCOLLECTIONCHECKERNEWV3_ADDRESSSEARCH_SCCPOSTCODE"] = user_postcode
+        fields["BINCOLLECTIONCHECKERNEWV3_ADDRESSSEARCH_SCCLISTOFADDRESSES"] = match[
+            "value"
+        ]
+        fields["BINCOLLECTIONCHECKERNEWV3_ADDRESSSEARCH_UPRN"] = match["value"]
+        fields["BINCOLLECTIONCHECKERNEWV3_ADDRESSSEARCH_POSTCODE"] = user_postcode
+        fields["BINCOLLECTIONCHECKERNEWV3_ADDRESSSEARCH_ADDRESSTEXT"] = (
+            match.get_text(strip=True)
+        )
+        fields["BINCOLLECTIONCHECKERNEWV3_FORMACTION_NEXT"] = NEXT_TRIGGER
+
+        post_headers = {**headers, "Referer": "https://www.sunderland.gov.uk/bindays"}
+        r = s.post(action, data=fields, headers=post_headers, timeout=15)
+        r.raise_for_status()
+        soup = BeautifulSoup(r.text, "html.parser")
+
+        for item in soup.select(".myaccount-block__item--bin"):
+            title_el = item.select_one(".myaccount-block__title")
+            if not title_el:
+                continue
+            bin_type = title_el.get_text(strip=True)
+
+            # The waste/recycling blocks wrap their date in a
+            # "myaccount-block__date" <p>, but the Garden Waste block
+            # just puts it in a plain <p> with no distinguishing
+            # class, so search the whole item's text instead of a
+            # specific date element.
+            date_match = re.search(
+                r"[A-Za-z]{3} [A-Za-z]{3} \d{1,2} \d{4}", item.get_text()
+            )
+            if not date_match:
+                continue
+
+            collection_date = datetime.strptime(date_match.group(), "%a %b %d %Y")
+            bindata["bins"].append(
+                {
+                    "type": bin_type,
+                    "collectionDate": collection_date.strftime(date_format),
+                }
             )
 
-            try:
-                WebDriverWait(driver, 10).until(
-                    EC.element_to_be_clickable(
-                        (By.XPATH, "//button[contains(., 'Accept all')]")
-                    )
-                ).click()
-            except Exception:
-                pass
+        bindata["bins"].sort(
+            key=lambda x: datetime.strptime(x["collectionDate"], date_format)
+        )
 
-            postcode_input = WebDriverWait(driver, 30).until(
-                EC.presence_of_element_located(
-                    (By.ID, "BINCOLLECTIONCHECKERNEWV3_ADDRESSSEARCH_SCCPOSTCODE")
-                )
-            )
-            postcode_input.send_keys(user_postcode)
-            driver.find_element(
-                By.ID, "BINCOLLECTIONCHECKERNEWV3_ADDRESSSEARCH_POSTCODETRIGGER_NEXT"
-            ).click()
-
-            address_select = Select(
-                WebDriverWait(driver, 30).until(
-                    EC.presence_of_element_located(
-                        (
-                            By.ID,
-                            "BINCOLLECTIONCHECKERNEWV3_ADDRESSSEARCH_SCCLISTOFADDRESSES",
-                        )
-                    )
-                )
-            )
-            paon_upper = user_paon.strip().upper()
-            matched_value = None
-            for option in address_select.options:
-                if option.text.strip().upper().startswith(paon_upper):
-                    matched_value = option.get_attribute("value")
-                    break
-            if not matched_value:
-                raise ValueError(f"Address not found in dropdown: {user_paon}")
-            address_select.select_by_value(matched_value)
-
-            WebDriverWait(driver, 30).until(
-                EC.presence_of_element_located(
-                    (By.CSS_SELECTOR, ".myaccount-block__item--bin")
-                )
-            )
-            # The result grid renders its bin blocks (waste, recycling,
-            # garden) in separate async steps with no reliable DOM signal
-            # for "all done" - a fixed settle delay is more reliable here
-            # than polling, since slower blocks (e.g. Garden Waste) can
-            # still be mid-render when a stable-count check would fire.
-            time.sleep(8)
-
-            soup = BeautifulSoup(driver.page_source, features="html.parser")
-            data = {"bins": []}
-            for item in soup.select(".myaccount-block__item--bin"):
-                title_el = item.select_one(".myaccount-block__title")
-                if not title_el:
-                    continue
-                bin_type = title_el.get_text(strip=True)
-
-                # The waste/recycling blocks wrap their date in a
-                # "myaccount-block__date" <p>, but the Garden Waste block
-                # just puts it in a plain <p> with no distinguishing
-                # class, so search the whole item's text instead of a
-                # specific date element.
-                date_match = re.search(
-                    r"[A-Za-z]{3} [A-Za-z]{3} \d{1,2} \d{4}", item.get_text()
-                )
-                if not date_match:
-                    continue
-
-                collection_date = datetime.strptime(date_match.group(), "%a %b %d %Y")
-                data["bins"].append(
-                    {
-                        "type": bin_type,
-                        "collectionDate": collection_date.strftime(date_format),
-                    }
-                )
-
-            data["bins"].sort(
-                key=lambda x: datetime.strptime(x["collectionDate"], date_format)
-            )
-        except Exception as e:
-            print(f"An error occurred: {e}")
-            raise
-        finally:
-            if driver:
-                driver.quit()
-        return data
+        return bindata


### PR DESCRIPTION
## Summary

Follow-up to the Haringey #2113 re-investigation (#2170) - applied the same "actually check, don't assume it's blocked" approach to Slough and Sunderland.

**SloughBoroughCouncil** (relates to open bug #2079, "ccc-recommended-settings timeout"): the existing scraper drove the old Jadu directory search on `www.slough.gov.uk` via Selenium + a hardcoded Google Maps geocoding API key. Turns out the council has a separate, modern portal at `waste.slough.gov.uk` — a Syncfusion "Public Dashboard", the same system already handled for `HighPeakCouncil`/`StaffordshireMoorlandsDistrictCouncil` — that renders both the premises list and the full collection schedule as plain JSON embedded in server-rendered HTML. It's a standard ASP.NET Razor Pages form (`__RequestVerificationToken` + session cookie, same pattern as `DerbyshireDalesDistrictCouncil.py`):
- `POST /PublicDashboard?handler=SearchPostcode` → premises array (`id`, `UPRN`, address)
- `POST /PublicDashboard?handler=SelectPrem` (keyed by `UPRN`) → `eventSettings.dataSource` with real dates

No Selenium needed at all — this also sidesteps #2079's cookie-consent timeout entirely.

**SunderlandCityCouncil** (#2140): a prior investigation (documented on the issue) rigorously confirmed the `/bindays` GOSS iCM flow was hard-blocked by Cloudflare Bot Management for every plain-Selenium config tried — only `undetected-chromedriver` driving a real local, non-headless Chrome got through, which is why this council couldn't use the shared remote-grid pattern or run in the normal CI harness. Re-tested live just now: the same flow completes with **zero Cloudflare challenge** via a bare `requests.Session()`. Either the site's bot-management config has relaxed since, or it was keyed to Selenium's automation fingerprint rather than the request pattern itself. Rewrote as a pure-HTTP GOSS iCM postback flow (GET the form for hidden fields → POST the postcode → POST the selected address's fields back, mirroring the page's own `onchange` handler), parsing the same `.myaccount-block__item--bin` markup as before.

This drops the `undetected-chromedriver` dependency and the "needs a real local, non-headless Chrome, can't use the remote Selenium grid" CI limitation for Sunderland entirely.

## Test plan

- [x] `pytest uk_bin_collection/tests/step_defs/ -k "SloughBoroughCouncil or SunderlandCityCouncil"` — both passed live
- [x] `pytest uk_bin_collection/tests custom_components/uk_bin_collection/tests --ignore=uk_bin_collection/tests/step_defs/` — 221 passed
- [x] `black --check` clean
- [x] `input.json` fixtures updated (Slough: `postcode` + `house_number`, no more `web_driver`; Sunderland unchanged fixture, just no longer needs `undetected-chromedriver`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved bin collection lookup for Slough, supporting postcode searches with UPRN or house number disambiguation.
  * Improved Sunderland bin collection lookup using house number and postcode.
  * Collection results are sorted chronologically and exclude dates that have already passed.

* **Documentation**
  * Updated council investigation notes, resolution status, and setup guidance for Slough, Sunderland, and Haringey.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->