### PR TITLE
fix(councils): dedupe EalingCouncil into LondonBoroughEaling (#1884)

### DIFF
--- a/ISSUE_RESOLUTION_PROGRESS.md
+++ b/ISSUE_RESOLUTION_PROGRESS.md
@@ -287,7 +287,7 @@ this is a maintainer decision, not made in this session.
 | 29a242d0 | EastDevonDC | Send scraper User-Agent header to get past a 403 block |
 | 7a5a585e | HorshamDistrictCouncil | Use build_retry_session() for resilience (hardening, not a fix) |
 | 65261e47 | LincolnCouncil | Fix NoneType error when UPRN not provided (zfill on None) [prior session] |
-| (pending) | EalingCouncil / LondonBoroughEaling | Dedupe #1884 - see note below |
+| 82886007 | EalingCouncil / LondonBoroughEaling | Dedupe #1884 - see note below |
 
 **Dedupe (Ealing, #1884):** both modules hit the same
 `WasteCollectionWS/home/FindCollection` API and, per the maintainer's own earlier

--- a/ISSUE_RESOLUTION_PROGRESS.md
+++ b/ISSUE_RESOLUTION_PROGRESS.md
@@ -256,7 +256,6 @@ this is a maintainer decision, not made in this session.
 | Issue | Council | Notes |
 |-------|---------|-------|
 | #2113 | Haringey | New site is behind AWS WAF Bot Control (CloudFront), not Cloudflare. Plain Selenium blocked; undetected-chromedriver also blocked (5/5 attempts). A pure-HTTP rewrite isn't feasible either - the site is a Next.js app using server actions, not a discoverable REST API. Needs a more specialized bypass (e.g. residential-IP browser farm) or a different data source. Findings posted on the issue. |
-| #1884 | Ealing | Re-verified live: the previously-reported bug (`collectionDateString` vs `collectionDate`) is already fixed in both `EalingCouncil.py` and `LondonBoroughEaling.py` (commit 57c8b1a9); both return correct data today. Only the module-duplication cleanup remains, deliberately deferred (deleting/merging either would break existing users' saved config). |
 | #1881 | NE Derbyshire | Re-checked live: self-service form still redirects to the homepage, only PDF calendars available, no postcode/address lookup exists. No change since the last update on the issue. Holding off on a PDF+area-list rewrite per earlier guidance - large, fragile, and possibly throwaway if the council republishes the form. |
 
 ## Code Fixes Made
@@ -288,6 +287,31 @@ this is a maintainer decision, not made in this session.
 | 29a242d0 | EastDevonDC | Send scraper User-Agent header to get past a 403 block |
 | 7a5a585e | HorshamDistrictCouncil | Use build_retry_session() for resilience (hardening, not a fix) |
 | 65261e47 | LincolnCouncil | Fix NoneType error when UPRN not provided (zfill on None) [prior session] |
+| (pending) | EalingCouncil / LondonBoroughEaling | Dedupe #1884 - see note below |
+
+**Dedupe (Ealing, #1884):** both modules hit the same
+`WasteCollectionWS/home/FindCollection` API and, per the maintainer's own earlier
+comment on the issue, deleting either would break existing users' saved config (the
+council module name is stored verbatim and dynamically imported - see
+`collect_data.py`'s `import_council_module`). Picked `LondonBoroughEaling` as
+canonical on the merits rather than by fiat: it matches this repo's own established
+naming convention for London boroughs (10 other councils use the
+`LondonBorough<Name>` pattern; `EalingCouncil` is the outlier), and its
+implementation was slightly more complete (explicit JSON `Content-Type` + a real
+`status_code` check, vs. `EalingCouncil.py`'s vestigial
+`requests.packages.urllib3.disable_warnings()` call that had no effect since nothing
+in that file ever passed `verify=False`). `EalingCouncil.py` is now a two-line shim
+that delegates to `LondonBoroughEaling.CouncilClass` - same behaviour, zero
+duplicated logic, still importable under its old name.
+
+Also found and fixed a latent bug this surfaced: both `input.json` entries shared the
+identical `wiki_name` ("Ealing"), and the Home Assistant config flow builds its
+council dropdown from `wiki_name` then maps a selection back to a council key via
+`list.index()` (`config_flow.py`'s `map_wiki_name_to_council_key`) - a linear search
+that always resolves to whichever entry happens to come first, so new users picking
+"Ealing" from the dropdown had no reliable way to choose between the two. Renamed
+`EalingCouncil`'s `wiki_name` to `"Ealing (deprecated, use LondonBoroughEaling)"` so
+it's distinguishable and existing users' saved selections are unaffected.
 
 ## Nightly integration suite triage
 

--- a/uk_bin_collection/tests/input.json
+++ b/uk_bin_collection/tests/input.json
@@ -787,8 +787,8 @@
         "skip_get_url": true,
         "uprn": "12073883",
         "url": "https://www.ealing.gov.uk/site/custom_scripts/WasteCollectionWS/home/FindCollection",
-        "wiki_name": "Ealing",
-        "wiki_note": "Pass the UPRN. You can find it using [FindMyAddress](https://www.findmyaddress.co.uk/search)."
+        "wiki_name": "Ealing (deprecated, use LondonBoroughEaling)",
+        "wiki_note": "Deprecated duplicate of LondonBoroughEaling (#1884) - kept only for existing users' saved config. New setups should pick \"Ealing\" (LondonBoroughEaling) instead."
     },
     "EastAyrshireCouncil": {
         "house_number": "57 Whatriggs Road",

--- a/uk_bin_collection/uk_bin_collection/councils/EalingCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/EalingCouncil.py
@@ -1,43 +1,16 @@
-import json
-from uk_bin_collection.uk_bin_collection.common import *
+from uk_bin_collection.uk_bin_collection.councils.LondonBoroughEaling import (
+    CouncilClass as LondonBoroughEalingCouncilClass,
+)
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
 
 
 class CouncilClass(AbstractGetBinDataClass):
     """
-    Concrete classes have to implement all abstract operations of the
-    base class. They can also override some operations with a default
-    implementation.
+    Deprecated duplicate of LondonBoroughEaling - both targeted the same
+    Ealing Council API (#1884). Kept as a thin alias so existing users'
+    saved config entries referencing "EalingCouncil" keep working; new
+    setups should use LondonBoroughEaling.
     """
 
     def parse_data(self, page: str, **kwargs) -> dict:
-        api_url = "https://www.ealing.gov.uk/site/custom_scripts/WasteCollectionWS/home/FindCollection"
-        user_uprn = kwargs.get("uprn")
-
-        # Check the UPRN is valid
-        check_uprn(user_uprn)
-
-        # Create the form data
-        form_data = {
-            "UPRN": user_uprn,
-        }
-
-        # Make a request to the API
-        requests.packages.urllib3.disable_warnings()
-        response = requests.post(api_url, data=form_data)
-
-        json_data = json.loads(response.text)
-
-        data = {"bins": []}
-
-        for param in json_data["param2"]:
-            data["bins"].append(
-                {
-                    "type": param["Service"],
-                    "collectionDate": datetime.strptime(
-                        param["collectionDate"][0], "%d/%m/%Y"
-                    ).strftime(date_format),
-                }
-            )
-
-        return data
+        return LondonBoroughEalingCouncilClass().parse_data(page, **kwargs)


### PR DESCRIPTION
## Summary

Closes #1884. Both `EalingCouncil.py` and `LondonBoroughEaling.py` hit the same `WasteCollectionWS/home/FindCollection` API with near-identical logic - decided which to keep on the merits rather than by fiat, since deleting either would break existing users' saved config (the council module name is stored verbatim in Home Assistant config entries and dynamically imported by name).

**Why `LondonBoroughEaling` is canonical:**
- **Naming**: matches this repo's own established convention for London boroughs - 10 other councils already use the `LondonBorough<Name>` pattern (Camden, Hammersmith and Fulham, Harrow, Havering, Hounslow, Lambeth, Lewisham, Richmond upon Thames, Redbridge, Sutton). `EalingCouncil` is the outlier.
- **Code completeness**: it has an explicit JSON `Content-Type` header and a real `status_code` check with a clear error message. `EalingCouncil.py` had a vestigial `requests.packages.urllib3.disable_warnings()` call left over from somewhere - dead code, since nothing in that file ever passes `verify=False`.

`EalingCouncil.py` is now a two-line shim delegating to `LondonBoroughEaling.CouncilClass` - identical behaviour, zero duplicated logic, and it's still importable under its old name so no existing user's config breaks.

**Bonus fix - a latent dropdown bug this surfaced:** both `input.json` entries had the exact same `wiki_name` ("Ealing"). The Home Assistant config flow builds its council-picker dropdown from `wiki_name` and maps a selection back to a council key via `list.index()` (`config_flow.py`'s `map_wiki_name_to_council_key`) - a linear search that always resolves to whichever entry happens to come first in the list. That means new users picking "Ealing" from the dropdown had no reliable way to actually choose between the two modules. Renamed `EalingCouncil`'s `wiki_name` to `"Ealing (deprecated, use LondonBoroughEaling)"` so it's distinguishable - existing users' already-saved selections are unaffected since they're keyed by module name, not `wiki_name`.

## Test plan

- [x] `pytest uk_bin_collection/tests/step_defs/ -k "EalingCouncil or LondonBoroughEaling"` - both pass, `EalingCouncil` verified to still return correct data via the shim
- [x] `pytest uk_bin_collection/tests custom_components/uk_bin_collection/tests --ignore=uk_bin_collection/tests/step_defs/` - 221 passed
- [x] `black --check` clean

Fixes #1884

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved council selection by preventing duplicate entries with the same name.
  * Preserved existing saved configurations while clarifying which Ealing option to use for new setups.
  * Marked the legacy Ealing entry as deprecated and provided guidance to select the replacement option.
* **Documentation**
  * Updated issue-resolution progress notes with the rationale for the Ealing entry consolidation and why alternative fixes weren’t feasible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->