### PR TITLE
fix(councils): anchor Babergh address regex; clear error on backend fault

### DIFF
--- a/ISSUE_RESOLUTION_PROGRESS.md
+++ b/ISSUE_RESOLUTION_PROGRESS.md
@@ -285,7 +285,7 @@ this is a maintainer decision, not made in this session.
 | 7a5a585e | HorshamDistrictCouncil | Use build_retry_session() for resilience (hardening, not a fix) |
 | 65261e47 | LincolnCouncil | Fix NoneType error when UPRN not provided (zfill on None) [prior session] |
 | 82886007 | EalingCouncil / LondonBoroughEaling | Dedupe #1884 - see note below |
-| (pending) | BaberghDistrictCouncil | Anchor paon regex to string start; clear error on backend "temporarily unavailable" (#2173) |
+| f86f8c87 | BaberghDistrictCouncil | Anchor paon regex to string start; clear error on backend "temporarily unavailable" (#2173) |
 
 **Dedupe (Ealing, #1884):** both modules hit the same
 `WasteCollectionWS/home/FindCollection` API and, per the maintainer's own earlier

--- a/ISSUE_RESOLUTION_PROGRESS.md
+++ b/ISSUE_RESOLUTION_PROGRESS.md
@@ -285,6 +285,7 @@ this is a maintainer decision, not made in this session.
 | 7a5a585e | HorshamDistrictCouncil | Use build_retry_session() for resilience (hardening, not a fix) |
 | 65261e47 | LincolnCouncil | Fix NoneType error when UPRN not provided (zfill on None) [prior session] |
 | 82886007 | EalingCouncil / LondonBoroughEaling | Dedupe #1884 - see note below |
+| (pending) | BaberghDistrictCouncil | Anchor paon regex to string start; clear error on backend "temporarily unavailable" (#2173) |
 
 **Dedupe (Ealing, #1884):** both modules hit the same
 `WasteCollectionWS/home/FindCollection` API and, per the maintainer's own earlier
@@ -309,6 +310,58 @@ that always resolves to whichever entry happens to come first, so new users pick
 "Ealing" from the dropdown had no reliable way to choose between the two. Renamed
 `EalingCouncil`'s `wiki_name` to `"Ealing (deprecated, use LondonBoroughEaling)"` so
 it's distinguishable and existing users' saved selections are unaffected.
+
+## Post-release triage (2026-07-15, three new issues)
+
+**Fixed - BaberghDistrictCouncil (#2173):** the reporter found two real problems.
+(1) The `paon_pattern` regex used to select an address from the dropdown wasn't
+anchored to the start of the option text (`(^|[ ,])PAON[A-Z]?([ ,]|$)`), so it could
+match a house name as a substring of a *different* property's name later in the
+string (verified live: Babergh's dropdown options have no separator between fields,
+e.g. `"LITTLE CHANGES BLUNDENS CORNER STOKE BY NAYLAND COLCHESTER CO6 4RA"` - a paon
+of `"ELM COTTAGE"` would wrongly match an option for `"THE OLD ELM COTTAGE ..."`
+since the pattern allowed the match anywhere after a space). Anchored to `^` only.
+(2) The council's own backend errors for specific addresses with "Collection day
+finder is temporarily unavailable" instead of rendering results, which the scraper
+had no way to distinguish from "something changed" - it just burned the full 30s
+Selenium wait and raised an unhelpful bare timeout. Now detects that text and raises
+a clear error identifying it as an upstream fault. Couldn't run the live BDD test for
+this one (no local Selenium grid available this session) - verified the regex fix
+with standalone unit-style checks against the reporter's exact scenario, and walked
+the live site's postcode/address selectors end-to-end via browser automation to
+confirm the DOM structure the scraper depends on is unchanged.
+
+**Investigated, not a code bug - PowysCouncil (#2175):** reporter hit a generic
+`[UKBinCollection] Timeout while updating data` during first setup. Drove the exact
+same flow live (postcode → address dropdown → next → results table) end-to-end via
+browser automation using the project's own selectors - every element ID still
+resolves correctly and the full flow completes in ~3 seconds. No selector/site change
+found. Most likely cause is environment-specific (their Selenium remote webdriver
+being slow, unreachable, or under resource contention at setup time) rather than a
+scraper regression - commented on the issue asking for their `web_driver`/`timeout`
+config to narrow it down further.
+
+**Investigated, not a code bug - FenlandDistrictCouncil (#2174):** reporter saw 500
+errors from `bins.azurewebsites.net/api/getcollections`. Reproduced the exact error
+live: an empty/invalid `premisesid` param produces that same 500
+(`System.FormatException: The input string '...' was not in a correct format.`),
+while a valid PremiseID returns 200 with real data - confirming Fenland's API itself
+is healthy and this is a param-plumbing issue on the reporter's end, not a backend
+outage. Also checked their two suspected `custom_components/uk_bin_collection/
+__init__.py` bugs: `build_ukbcd_args` already forwards arbitrary `config_data` keys
+(including `postcode`/`number`) unless excluded, so no fix needed there. Their other
+claim - that `manual_refresh_only`'s branch logic is inverted - turned out to be
+**not a bug**: the config UI's own field label for that key is literally
+`"Automatically refresh the sensor"` (`strings.json`/`translations/en.json`) and
+defaults to `True` for new installs, which is exactly what the current code does
+when the flag is set. The *key name* `manual_refresh_only` is just confusingly worded
+relative to its own UI label and behaviour, but "fixing" the branch to match the key
+name would have silently disabled automatic refresh for every existing user relying
+on the current (correct, UI-matching) behaviour - did not touch it. Commented on the
+issue pointing at the existing `input.json` guidance (use the 5-digit Fenland
+PremiseID directly in the `uprn` field) as the actual fix for their symptom, and
+noted the council's own comment thread that Fenland is migrating to a new site
+(`yourbins.fenland.gov.uk`) which may supersede this entirely.
 
 ## Nightly integration suite triage
 

--- a/uk_bin_collection/uk_bin_collection/councils/BaberghDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/BaberghDistrictCouncil.py
@@ -2,6 +2,7 @@ import re
 from datetime import datetime
 
 from bs4 import BeautifulSoup
+from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import Select, WebDriverWait
@@ -94,12 +95,14 @@ class CouncilClass(AbstractGetBinDataClass):
                 postcode_upper = user_postcode.upper()
                 paon_str = str(user_paon).upper()
 
-                # Match the house name/number as a whole token, allowing an
-                # optional single-letter suffix (e.g. "1A", "1B") and either a
-                # space or comma as the surrounding separator.
-                paon_pattern = re.compile(
-                    rf"(^|[ ,]){re.escape(paon_str)}[A-Z]?([ ,]|$)"
-                )
+                # Match the house name/number at the very start of the
+                # address (options are formatted "<PAON> <STREET> <TOWN>
+                # <POSTCODE>" with no separator between fields), allowing an
+                # optional single-letter suffix (e.g. "1A", "1B"). Anchoring
+                # to the start avoids matching it as a substring elsewhere,
+                # e.g. paon "ELM COTTAGE" wrongly matching an option for
+                # "THE OLD ELM COTTAGE ...".
+                paon_pattern = re.compile(rf"^{re.escape(paon_str)}[A-Z]?([ ,]|$)")
 
                 # Check if this option contains both postcode and house name/number
                 if postcode_upper in option_text and paon_pattern.search(option_text):
@@ -120,12 +123,26 @@ class CouncilClass(AbstractGetBinDataClass):
             driver.execute_script("arguments[0].scrollIntoView();", find_days_button)
             driver.execute_script("arguments[0].click();", find_days_button)
 
-            # Wait for the results table to load
-            wait.until(
-                EC.presence_of_element_located(
-                    (By.CSS_SELECTOR, "div.collection-days-page table")
+            # Wait for the results table to load. The council's own backend
+            # sometimes errors for specific addresses (unrelated to this
+            # scraper), rendering "Collection day finder is temporarily
+            # unavailable" instead of a results table - detect that and
+            # raise a clear error rather than a bare timeout.
+            try:
+                wait.until(
+                    EC.presence_of_element_located(
+                        (By.CSS_SELECTOR, "div.collection-days-page table")
+                    )
                 )
-            )
+            except TimeoutException:
+                if "temporarily unavailable" in driver.page_source.lower():
+                    raise ValueError(
+                        "Babergh's collection day finder is reporting "
+                        "'temporarily unavailable' for this address - this "
+                        "is an error on the council's own backend, not this "
+                        "scraper. Try again later."
+                    )
+                raise
 
             # Parse the HTML content
             soup = BeautifulSoup(driver.page_source, "html.parser")


### PR DESCRIPTION
## Summary

Fixes #2173. Two real bugs the reporter found, both confirmed independently.

**1. Address-matching regex wasn't anchored to the start of the option text.** Babergh's address dropdown concatenates fields with no separator, e.g. `"LITTLE CHANGES BLUNDENS CORNER STOKE BY NAYLAND COLCHESTER CO6 4RA"` (verified live). The old pattern `(^|[ ,])PAON[A-Z]?([ ,]|$)` allowed a match anywhere after a space, not just at the start — so a paon of `"ELM COTTAGE"` could wrongly match an option for `"THE OLD ELM COTTAGE ..."` and silently select the wrong address (first match wins). Anchored to `^` only, matching the reporter's own suggested fix.

**2. Babergh's backend genuinely errors for specific addresses** with "Collection day finder is temporarily unavailable" instead of a results table. The scraper couldn't distinguish that from "the page format changed" — it just burned the full 30s Selenium wait and raised an opaque `TimeoutException`. Now detects that text and raises a clear error identifying it as an upstream fault, per the reporter's suggestion.

## Test plan

- [x] Verified the regex fix against the reporter's exact scenario ("ELM COTTAGE" vs "THE OLD ELM COTTAGE" vs a real Babergh postcode's dropdown format) with standalone checks
- [x] Walked the live site (`https://www.babergh.gov.uk/check-your-collection-day`) end-to-end via browser automation using the scraper's own element IDs — postcode entry, address lookup, dropdown population all confirmed unchanged
- [x] `black --check` clean
- [ ] Could not run the live BDD test this session — no local Selenium grid available. Would appreciate a CI run confirming the full flow.

Fixes #2173

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved address matching for Babergh District Council to prevent incorrect results from partial matches.
  * Added clearer feedback when the council’s service is temporarily unavailable instead of showing a generic timeout error.

* **Documentation**
  * Updated issue-resolution records with details of recent investigations, fixes, and service-related findings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->