### PR TITLE
fix: handle undated Lichfield collection cards

### DIFF
--- a/uk_bin_collection/tests/test_lichfield_district_council.py
+++ b/uk_bin_collection/tests/test_lichfield_district_council.py
@@ -1,0 +1,94 @@
+"""Unit tests for the Lichfield District Council collection-card parser."""
+
+from datetime import datetime as real_datetime
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from uk_bin_collection.uk_bin_collection.councils.LichfieldDistrictCouncil import (
+    CouncilClass,
+)
+
+MODULE_PATH = "uk_bin_collection.uk_bin_collection.councils.LichfieldDistrictCouncil"
+
+RESULTS_HTML = """
+<html>
+  <body>
+    <ul class="list bin-collection-tasks">
+      <li class="list__item">
+        <h3 class="bin-collection-tasks__heading">
+          <span class="visually-hidden">Your next </span>Food Waste Caddy
+          <span class="visually-hidden"> collection</span>
+        </h3>
+        <p class="bin-collection-tasks__frequency">
+          Collected every <strong>Thursday</strong>
+        </p>
+      </li>
+      <li class="list__item">
+        <h3 class="bin-collection-tasks__heading">
+          <span class="visually-hidden">Your next </span>Brown Bin
+          <span class="visually-hidden"> collection</span>
+        </h3>
+        <p class="bin-collection-tasks__date">23rd July</p>
+      </li>
+      <li class="list__item">
+        <h3 class="bin-collection-tasks__heading">
+          <span class="visually-hidden">Your next </span>Blue Bin
+          <span class="visually-hidden"> collection</span>
+        </h3>
+        <p class="bin-collection-tasks__date">23rd July</p>
+      </li>
+      <li class="list__item">
+        <h3 class="bin-collection-tasks__heading">
+          <span class="visually-hidden">Your next </span>Black Bin
+          <span class="visually-hidden"> collection</span>
+        </h3>
+        <p class="bin-collection-tasks__date">30th July</p>
+      </li>
+      <li class="list__item">
+        <h3 class="bin-collection-tasks__heading">
+          <span class="visually-hidden">Your next </span>Purple Bin
+          <span class="visually-hidden"> collection</span>
+        </h3>
+        <p class="bin-collection-tasks__date">6th August</p>
+      </li>
+      <li class="list__item">
+        <h3 class="bin-collection-tasks__heading">
+          Download <span class="visually-hidden">your bin </span>collection calendar
+        </h3>
+      </li>
+    </ul>
+  </body>
+</html>
+"""
+
+
+def parse_fixture(html: str, now: real_datetime):
+    response = SimpleNamespace(text=html)
+    with patch(f"{MODULE_PATH}.requests.get", return_value=response), patch(
+        f"{MODULE_PATH}.datetime"
+    ) as mock_datetime:
+        mock_datetime.now.return_value = now
+        mock_datetime.strptime.side_effect = real_datetime.strptime
+        return CouncilClass().parse_data("", uprn="100031694085")
+
+
+def test_parse_data_keeps_collection_dates_with_their_own_cards():
+    result = parse_fixture(RESULTS_HTML, real_datetime(2026, 7, 19, 10, 0))
+
+    assert result == {
+        "bins": [
+            {"type": "Food Waste", "collectionDate": "23/07/2026"},
+            {"type": "Brown Bin", "collectionDate": "23/07/2026"},
+            {"type": "Blue Bin", "collectionDate": "23/07/2026"},
+            {"type": "Black Bin", "collectionDate": "30/07/2026"},
+            {"type": "Purple Bin", "collectionDate": "06/08/2026"},
+        ]
+    }
+
+
+def test_parse_data_rolls_explicit_dates_into_the_next_year():
+    html = RESULTS_HTML.replace("23rd July", "5th March")
+    result = parse_fixture(html, real_datetime(2026, 12, 20, 10, 0))
+
+    assert result["bins"][1]["collectionDate"] == "05/03/2027"
+    assert result["bins"][2]["collectionDate"] == "05/03/2027"

--- a/uk_bin_collection/uk_bin_collection/councils/LichfieldDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/LichfieldDistrictCouncil.py
@@ -37,25 +37,49 @@ class CouncilClass(AbstractGetBinDataClass):
 
         soup = BeautifulSoup(response.text, "html.parser")
 
-        bins = soup.find_all("h3", class_="bin-collection-tasks__heading")
-        dates = soup.find_all("p", class_="bin-collection-tasks__date")
+        now = datetime.now()
 
-        current_year = datetime.now().year
-        current_month = datetime.now().month
+        # Parse each collection card as a unit. Some cards, such as the weekly
+        # food-waste service and the calendar download, do not contain an
+        # explicit date. Pairing independent heading and date lists shifts all
+        # subsequent dates onto the wrong bin when one of those cards appears.
+        for task in soup.select("li.list__item"):
+            heading = task.select_one("h3.bin-collection-tasks__heading")
+            if heading is None:
+                continue
 
-        for i in range(len(dates)):
-            bint = " ".join(bins[i].text.split()[2:4])
-            date = dates[i].text
+            date_element = task.select_one("p.bin-collection-tasks__date")
+            if date_element is not None:
+                date = datetime.strptime(
+                    solve(date_element.get_text(strip=True)), "%d %B"
+                )
+                date = date.replace(year=now.year)
+                if date.date() < now.date():
+                    date = date.replace(year=now.year + 1)
+            else:
+                frequency_day = task.select_one(
+                    "p.bin-collection-tasks__frequency strong"
+                )
+                if frequency_day is None:
+                    continue
 
-            date = datetime.strptime(
-                solve(date),
-                "%d %B",
+                weekday = frequency_day.get_text(strip=True).title()
+                if weekday not in days_of_week:
+                    continue
+
+                days_until_collection = (days_of_week[weekday] - now.weekday()) % 7
+                date = now + timedelta(days=days_until_collection)
+
+            heading_text = heading.get_text(" ", strip=True)
+            bint = re.sub(
+                r"^Your next\s+|\s+collection$", "", heading_text, flags=re.IGNORECASE
             )
 
-            if (current_month > 10) and (date.month < 3):
-                date = date.replace(year=(current_year + 1))
-            else:
-                date = date.replace(year=current_year)
+            # Preserve the existing Home Assistant entity identity. The old
+            # parser exposed this card as "Food Waste" by taking two words from
+            # the heading, so changing it would create a second sensor.
+            if bint == "Food Waste Caddy":
+                bint = "Food Waste"
 
             dict_data = {
                 "type": bint,


### PR DESCRIPTION
## Summary

- parse each Lichfield collection card as a self-contained unit instead of pairing global heading and date lists by index
- derive the next food-waste collection from the weekly weekday shown by the council when no explicit date is present
- preserve the existing `Food Waste` bin type used by Home Assistant entities
- roll explicit collection dates into the next year when their month and day have already passed
- add regression coverage for the undated food-waste card, the Purple Bin date, the calendar download card, and year rollover

## Root cause

Lichfield added a Food Waste Caddy card that contains a weekly collection weekday but no `bin-collection-tasks__date` element. The scraper collected all headings and all dates into separate lists and paired them by position. The undated card shifted every subsequent date onto the wrong bin and omitted the final dated bin.

## Impact

Collection dates remain attached to their own cards, so Brown, Blue, Black, and Purple Bin data is returned correctly. The weekly Food Waste collection is also exposed without changing its existing entity identity.

## Validation

- Python 3.12 targeted regression tests: 2 passed
- Black formatting check passed
- live Lichfield scraper invocation using the repository's existing test UPRN returned correctly paired collection data


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Lichfield bin collection dates so each collection is paired with its corresponding date.
  * Improved handling of collection dates that fall in the following calendar year.
  * Preserved the expected “Food Waste” bin label for consistent integrations.

* **Tests**
  * Added coverage for date pairing, explicit collection dates, and year transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->