### PR TITLE
fix: pair Lichfield bin headings with dates within their own card

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/LichfieldDistrictCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/LichfieldDistrictCouncil.py
@@ -37,15 +37,38 @@ class CouncilClass(AbstractGetBinDataClass):
 
         soup = BeautifulSoup(response.text, "html.parser")
 
-        bins = soup.find_all("h3", class_="bin-collection-tasks__heading")
-        dates = soup.find_all("p", class_="bin-collection-tasks__date")
+        def bin_name(heading):
+            # The heading reads "Your next Blue Bin collection", where the
+            # "Your next" and "collection" wrappers are visually-hidden spans.
+            # Dropping those leaves just the bin name, which keeps multi-word
+            # names such as "Food Waste Caddy" intact.
+            parts = [
+                text
+                for text in heading.find_all(string=True)
+                if "visually-hidden" not in (text.parent.get("class") or [])
+            ]
+            name = " ".join(" ".join(parts).split())
+            name = re.sub(r"^Your next\s+", "", name)
+            return re.sub(r"\s+collection$", "", name)
 
         current_year = datetime.now().year
         current_month = datetime.now().month
 
-        for i in range(len(dates)):
-            bint = " ".join(bins[i].text.split()[2:4])
-            date = dates[i].text
+        # Each bin is rendered in its own card. Pair the heading with the date
+        # inside that same card rather than zipping two page-wide lists
+        # together by index - not every card carries a date (a bin with no
+        # scheduled collection shows a "collected every <day>" frequency
+        # instead, and the calendar download link reuses the heading class),
+        # so positional pairing silently shifts every bin onto the wrong date
+        # and drops the last one entirely.
+        for heading in soup.find_all("h3", class_="bin-collection-tasks__heading"):
+            card = heading.parent
+            date_element = card.find("p", class_="bin-collection-tasks__date")
+            if date_element is None:
+                continue
+
+            bint = bin_name(heading)
+            date = date_element.text.strip()
 
             date = datetime.strptime(
                 solve(date),


### PR DESCRIPTION
### What

`LichfieldDistrictCouncil` collects two page-wide lists and zips them together by index:

```python
bins  = soup.find_all("h3", class_="bin-collection-tasks__heading")
dates = soup.find_all("p",  class_="bin-collection-tasks__date")
for i in range(len(dates)):
    bint = " ".join(bins[i].text.split()[2:4])
    date = dates[i].text
```

That holds only while every heading has a corresponding date element. Two things on the current page break the assumption:

1. The calendar download link (`Download your bin collection calendar`) reuses the `bin-collection-tasks__heading` class but is not a bin, so it pads `bins`.
2. A bin with no scheduled collection renders a `bin-collection-tasks__frequency` (`Collected every Monday`) **instead of** a `bin-collection-tasks__date`. Food Waste Caddy is in this state on at least some addresses.

When a dateless card sits *before* the others, every bin is shifted onto the following bin's date and the final bin drops off the end of the loop. The failure is silent — output stays schema-valid, it's just wrong.

### Reproduction

This affects the repo's own test UPRN for Lichfield, `100031694085`. Ground truth from the page:

| Card | Date shown |
|---|---|
| Black Bin | 30th July |
| Food Waste Caddy | *(none — "Collected every Thursday")* |
| Blue Bin | 6th August |
| Brown Bin | 6th August |
| Blue Bag | 6th August |

**Before this PR:**

```json
{"bins": [
  {"type": "Black Bin",  "collectionDate": "30/07/2026"},
  {"type": "Food Waste", "collectionDate": "06/08/2026"},
  {"type": "Blue Bin",   "collectionDate": "06/08/2026"},
  {"type": "Brown Bin",  "collectionDate": "06/08/2026"}
]}
```

`Food Waste` is given a date the page never showed, and `Blue Bag` is missing entirely.

**After this PR:**

```json
{"bins": [
  {"type": "Black Bin", "collectionDate": "30/07/2026"},
  {"type": "Blue Bin",  "collectionDate": "06/08/2026"},
  {"type": "Brown Bin", "collectionDate": "06/08/2026"},
  {"type": "Blue Bag",  "collectionDate": "06/08/2026"}
]}
```

On a second address (`394018646`) the misalignment was more visible, because the dateless Food Waste Caddy card is first:

| | Before | After | Page |
|---|---|---|---|
| Food Waste | 27/07 | *(omitted)* | no date |
| Blue Bin | 27/07 | 27/07 | 27th July |
| Blue Bag | 03/08 | 27/07 | 27th July |
| Black Bin | **missing** | 03/08 | 3rd August |

### How

- Iterate the headings and read the date from **within the same card**, skipping cards that have no date. Removes the positional coupling between the two lists.
- Derive the bin name from the heading with its `visually-hidden` `Your next` / `collection` spans removed, rather than slicing words `[2:4]`. The slice truncated three-word names (`Food Waste Caddy` → `Food Waste`). Prefix/suffix stripping is kept as a fallback should those spans ever go away.

No change to the date parsing or year-rollover logic.

### Notes

Reported downstream as bins going `unavailable` in Home Assistant — once a bin stops appearing in the output the coordinator stops creating its entities. Likely related to #1905, which presented the same way and was closed as council-side; this looks like the underlying parser fragility that made the page change bite.

Verified against the live site for both UPRNs above. `black --check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bin collection information parsing for Lichfield District Council.
  * Preserved multi-word bin names while removing hidden display text.
  * Improved matching between each bin type and its scheduled collection date.
  * Excluded bins without a scheduled collection date to prevent incomplete results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->