### PR TITLE
fix: correct inverted label on manual_refresh_only config option

### DIFF
--- a/custom_components/uk_bin_collection/config_flow.py
+++ b/custom_components/uk_bin_collection/config_flow.py
@@ -117,6 +117,11 @@ class UkBinCollectionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 {
                     vol.Required("name"): cv.string,
                     vol.Required("council"): vol.In(self.council_options),
+                    # NOTE: defaulting manual_refresh_only to True means new
+                    # installs get NO automatic refresh unless the user unticks
+                    # this box. Given the "entities only update on restart"
+                    # reports (e.g. #2193), this default is questionable and
+                    # should be revisited separately (kept as-is for this PR).
                     vol.Optional("manual_refresh_only", default=True): bool,
                     vol.Optional("icon_color_mapping", default=""): cv.string,
                 }

--- a/custom_components/uk_bin_collection/strings.json
+++ b/custom_components/uk_bin_collection/strings.json
@@ -7,8 +7,11 @@
                 "data": {
                     "name": "Location name",
                     "council": "Council",
-                    "manual_refresh_only":"Automatically refresh the sensor",
+                    "manual_refresh_only": "Manual refresh only (disable automatic updates — refresh via the uk_bin_collection.manual_refresh service)",
                     "icon_color_mapping": "JSON to map Bin Type for Colour and Icon (see documentation)"
+                },
+                "data_description": {
+                    "manual_refresh_only": "When ticked, the integration will NOT refresh automatically — data is only fetched at setup and when you call the uk_bin_collection.manual_refresh service. When unticked, data refreshes every 'update_interval' hours."
                 },
                 "description": "Please see the documentation if your council isn't listed"
             },
@@ -42,9 +45,12 @@
                     "web_driver": "To run on a remote Selenium Server add the Selenium Server URL",
                     "headless": "Run Selenium in headless mode (recommended)",
                     "local_browser": "Don't run on remote Selenium server, use local install of Chrome instead",
-                    "manual_refresh_only":"Automatically refresh the sensor",
+                    "manual_refresh_only": "Manual refresh only (disable automatic updates — refresh via the uk_bin_collection.manual_refresh service)",
                     "icon_color_mapping": "JSON to map Bin Type for Colour and Icon (see documentation)",
                     "submit": "Submit"
+                },
+                "data_description": {
+                    "manual_refresh_only": "When ticked, the integration will NOT refresh automatically — data is only fetched at setup and when you call the uk_bin_collection.manual_refresh service. When unticked, data refreshes every 'update_interval' hours."
                 },
                 "description": "Please refer to your council's wiki entry for details on what to enter."
             }

--- a/custom_components/uk_bin_collection/tests/test_translations.py
+++ b/custom_components/uk_bin_collection/tests/test_translations.py
@@ -40,6 +40,17 @@ def _steps_with_key(data: dict) -> dict:
     return found
 
 
+def _steps_with_description(data: dict) -> dict:
+    """Return {step_name: text} for every config.step.*.data_description[KEY]."""
+    found = {}
+    steps = data.get("config", {}).get("step", {})
+    for step_name, step in steps.items():
+        descriptions = step.get("data_description", {})
+        if KEY in descriptions:
+            found[step_name] = descriptions[KEY]
+    return found
+
+
 def test_all_json_files_are_valid():
     """Every strings/translation file must parse as JSON."""
     _load(STRINGS_JSON)
@@ -81,3 +92,22 @@ def test_strings_and_en_translation_stay_in_sync():
     )
     # Guard against the key silently disappearing from both.
     assert strings_steps, "manual_refresh_only missing from strings.json steps"
+
+
+def test_manual_refresh_has_description_in_every_locale():
+    """Every locale must carry data_description for KEY in each step that
+    labels it, so no locale falls back to English helper text."""
+    files = [STRINGS_JSON, *_all_translation_files()]
+    for path in files:
+        data = _load(path)
+        label_steps = set(_steps_with_key(data))
+        description_steps = set(_steps_with_description(data))
+        assert label_steps, f"{path.name}: expected at least one '{KEY}' label"
+        missing = label_steps - description_steps
+        assert not missing, (
+            f"{path.name}: missing data_description.{KEY} in step(s) "
+            f"{sorted(missing)}"
+        )
+        for step_name, text in _steps_with_description(data).items():
+            where = f"{path.name} :: config.step.{step_name}.data_description.{KEY}"
+            assert text.strip(), f"{where}: description must not be empty"

--- a/custom_components/uk_bin_collection/tests/test_translations.py
+++ b/custom_components/uk_bin_collection/tests/test_translations.py
@@ -1,0 +1,83 @@
+"""Regression tests for the config-flow translation strings.
+
+These guard against the `manual_refresh_only` label inversion (issue #2193):
+the field stores "manual refresh only" semantics, but the UI used to label it
+"Automatically refresh the sensor" — the exact inverse — so ticking the box
+silently disabled automatic refresh.
+
+Dependency-free on purpose: json + pathlib only.
+"""
+
+import json
+from pathlib import Path
+
+# custom_components/uk_bin_collection/
+INTEGRATION_DIR = Path(__file__).resolve().parent.parent
+STRINGS_JSON = INTEGRATION_DIR / "strings.json"
+TRANSLATIONS_DIR = INTEGRATION_DIR / "translations"
+
+KEY = "manual_refresh_only"
+OLD_INVERTED_LABEL = "Automatically refresh the sensor"
+
+
+def _load(path: Path) -> dict:
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _all_translation_files() -> list[Path]:
+    return sorted(TRANSLATIONS_DIR.glob("*.json"))
+
+
+def _steps_with_key(data: dict) -> dict:
+    """Return {step_name: label} for every config.step.*.data carrying KEY."""
+    found = {}
+    steps = data.get("config", {}).get("step", {})
+    for step_name, step in steps.items():
+        step_data = step.get("data", {})
+        if KEY in step_data:
+            found[step_name] = step_data[KEY]
+    return found
+
+
+def test_all_json_files_are_valid():
+    """Every strings/translation file must parse as JSON."""
+    _load(STRINGS_JSON)
+    for path in _all_translation_files():
+        _load(path)
+
+
+def test_manual_refresh_label_not_inverted():
+    """No label may claim the field enables automatic refresh."""
+    files = [STRINGS_JSON, *_all_translation_files()]
+    for path in files:
+        labels = _steps_with_key(_load(path))
+        assert labels, f"{path.name}: expected at least one '{KEY}' label"
+        for step_name, label in labels.items():
+            where = f"{path.name} :: config.step.{step_name}.data.{KEY}"
+
+            # The exact old inverted English string must be gone everywhere.
+            assert label != OLD_INVERTED_LABEL, (
+                f"{where}: still uses the inverted label {OLD_INVERTED_LABEL!r}"
+            )
+
+            # If the label mentions "automatic(ally)", it must be a negation
+            # (e.g. "disable automatic updates"), never a promise to refresh.
+            lowered = label.lower()
+            if "automatic" in lowered:
+                assert "manual" in lowered or "disable" in lowered, (
+                    f"{where}: label {label!r} mentions 'automatic' without a "
+                    "negating 'manual'/'disable' — likely still inverted"
+                )
+
+
+def test_strings_and_en_translation_stay_in_sync():
+    """strings.json and en.json must carry KEY in the same steps."""
+    strings_steps = set(_steps_with_key(_load(STRINGS_JSON)))
+    en_steps = set(_steps_with_key(_load(TRANSLATIONS_DIR / "en.json")))
+    assert strings_steps == en_steps, (
+        f"strings.json steps {sorted(strings_steps)} != "
+        f"en.json steps {sorted(en_steps)}"
+    )
+    # Guard against the key silently disappearing from both.
+    assert strings_steps, "manual_refresh_only missing from strings.json steps"

--- a/custom_components/uk_bin_collection/translations/cy.json
+++ b/custom_components/uk_bin_collection/translations/cy.json
@@ -7,7 +7,7 @@
                 "data": {
                     "name": "Enw'r lleoliad",
                     "council": "Cyngor",
-                    "manual_refresh_only": "Adnewyddu'r synhwyrydd yn awtomatig",
+                    "manual_refresh_only": "Adnewyddu â llaw yn unig (analluogi diweddariadau awtomatig — adnewyddwch drwy'r gwasanaeth uk_bin_collection.manual_refresh)",
                     "icon_color_mapping": "JSON i fapio Math y Bin ar gyfer Lliw ac Eicon gweler: https://github.com/robbrad/UKBinCollectionData"
                 },
                 "description": "Gweler [yma](https://github.com/robbrad/UKBinCollectionData#requesting-your-council) os nad yw eich cyngor wedi'i restru"
@@ -41,7 +41,7 @@
                     "usrn": "USRN (Rhif Cyfeirnod Stryd Unigryw)",
                     "web_driver": "I redeg ar weinydd Selenium o bell, ychwanegwch URL y Weinydd Selenium",
                     "headless": "Rhedeg Selenium yn y modd heb ben (argymhellir)",
-                    "manual_refresh_only": "Adnewyddu'r synhwyrydd yn awtomatig",
+                    "manual_refresh_only": "Adnewyddu â llaw yn unig (analluogi diweddariadau awtomatig — adnewyddwch drwy'r gwasanaeth uk_bin_collection.manual_refresh)",
                     "local_browser": "Peidiwch â rhedeg ar weinydd Selenium o bell, defnyddiwch osodiad lleol o Chrome yn lle",
                     "icon_color_mapping": "JSON i fapio Math y Bin ar gyfer Lliw ac Eicon gweler: https://github.com/robbrad/UKBinCollectionData",
                     "submit": "Cyflwyno"

--- a/custom_components/uk_bin_collection/translations/cy.json
+++ b/custom_components/uk_bin_collection/translations/cy.json
@@ -10,6 +10,9 @@
                     "manual_refresh_only": "Adnewyddu â llaw yn unig (analluogi diweddariadau awtomatig — adnewyddwch drwy'r gwasanaeth uk_bin_collection.manual_refresh)",
                     "icon_color_mapping": "JSON i fapio Math y Bin ar gyfer Lliw ac Eicon gweler: https://github.com/robbrad/UKBinCollectionData"
                 },
+                "data_description": {
+                    "manual_refresh_only": "Pan fydd wedi'i dicio, NI fydd yr integreiddiad yn adnewyddu'n awtomatig — dim ond wrth osod a phan fyddwch yn galw'r gwasanaeth uk_bin_collection.manual_refresh y caiff data ei nôl. Pan na fydd wedi'i dicio, caiff data ei adnewyddu bob 'update_interval' awr."
+                },
                 "description": "Gweler [yma](https://github.com/robbrad/UKBinCollectionData#requesting-your-council) os nad yw eich cyngor wedi'i restru"
             },
             "council": {
@@ -45,6 +48,9 @@
                     "local_browser": "Peidiwch â rhedeg ar weinydd Selenium o bell, defnyddiwch osodiad lleol o Chrome yn lle",
                     "icon_color_mapping": "JSON i fapio Math y Bin ar gyfer Lliw ac Eicon gweler: https://github.com/robbrad/UKBinCollectionData",
                     "submit": "Cyflwyno"
+                },
+                "data_description": {
+                    "manual_refresh_only": "Pan fydd wedi'i dicio, NI fydd yr integreiddiad yn adnewyddu'n awtomatig — dim ond wrth osod a phan fyddwch yn galw'r gwasanaeth uk_bin_collection.manual_refresh y caiff data ei nôl. Pan na fydd wedi'i dicio, caiff data ei adnewyddu bob 'update_interval' awr."
                 },
                 "description": "Cyfeiriwch at gofnod [wiki](https://github.com/robbrad/UKBinCollectionData/wiki/Councils) eich cyngor am fanylion ar beth i'w nodi."
             }

--- a/custom_components/uk_bin_collection/translations/en.json
+++ b/custom_components/uk_bin_collection/translations/en.json
@@ -7,8 +7,11 @@
                 "data": {
                     "name": "Location name",
                     "council": "Council",
-                    "manual_refresh_only":"Automatically refresh the sensor",
+                    "manual_refresh_only": "Manual refresh only (disable automatic updates — refresh via the uk_bin_collection.manual_refresh service)",
                     "icon_color_mapping": "JSON to map Bin Type for Colour and Icon (see documentation)"
+                },
+                "data_description": {
+                    "manual_refresh_only": "When ticked, the integration will NOT refresh automatically — data is only fetched at setup and when you call the uk_bin_collection.manual_refresh service. When unticked, data refreshes every 'update_interval' hours."
                 },
                 "description": "Please see the documentation if your council isn't listed"
             },
@@ -42,9 +45,12 @@
                     "web_driver": "To run on a remote Selenium Server add the Selenium Server URL",
                     "headless": "Run Selenium in headless mode (recommended)",
                     "local_browser": "Don't run on remote Selenium server, use local install of Chrome instead",
-                    "manual_refresh_only":"Automatically refresh the sensor",
+                    "manual_refresh_only": "Manual refresh only (disable automatic updates — refresh via the uk_bin_collection.manual_refresh service)",
                     "icon_color_mapping": "JSON to map Bin Type for Colour and Icon (see documentation)",
                     "submit": "Submit"
+                },
+                "data_description": {
+                    "manual_refresh_only": "When ticked, the integration will NOT refresh automatically — data is only fetched at setup and when you call the uk_bin_collection.manual_refresh service. When unticked, data refreshes every 'update_interval' hours."
                 },
                 "description": "Please refer to your council's wiki entry for details on what to enter."
             }

--- a/custom_components/uk_bin_collection/translations/ga.json
+++ b/custom_components/uk_bin_collection/translations/ga.json
@@ -10,6 +10,9 @@
                     "manual_refresh_only": "Athnuachan de láimh amháin (díchumasaigh nuashonruithe uathoibríocha — athnuaigh tríd an tseirbhís uk_bin_collection.manual_refresh)",
                     "icon_color_mapping": "JSON chun Cineál Bin a mhapáil do Dath agus Deilbhín féach: https://github.com/robbrad/UKBinCollectionData"
                 },
+                "data_description": {
+                    "manual_refresh_only": "Nuair a bhíonn sé ticeáilte, NÍ dhéanfaidh an chomhtháthú athnuachan go huathoibríoch — ní fhaightear sonraí ach ag am socraithe agus nuair a ghlaonn tú ar an tseirbhís uk_bin_collection.manual_refresh. Nuair nach mbíonn sé ticeáilte, déantar sonraí a athnuachan gach 'update_interval' uair."
+                },
                 "description": "Féach [anseo](https://github.com/robbrad/UKBinCollectionData#requesting-your-council) mura bhfuil do chomhairle liostaithe"
             },
             "council": {
@@ -45,6 +48,9 @@
                     "manual_refresh_only": "Athnuachan de láimh amháin (díchumasaigh nuashonruithe uathoibríocha — athnuaigh tríd an tseirbhís uk_bin_collection.manual_refresh)",
                     "icon_color_mapping": "JSON chun Cineál Bin a mhapáil do Dath agus Deilbhín féach: https://github.com/robbrad/UKBinCollectionData",
                     "submit": "Cuir isteach"
+                },
+                "data_description": {
+                    "manual_refresh_only": "Nuair a bhíonn sé ticeáilte, NÍ dhéanfaidh an chomhtháthú athnuachan go huathoibríoch — ní fhaightear sonraí ach ag am socraithe agus nuair a ghlaonn tú ar an tseirbhís uk_bin_collection.manual_refresh. Nuair nach mbíonn sé ticeáilte, déantar sonraí a athnuachan gach 'update_interval' uair."
                 },
                 "description": "Féach ar iontráil [wiki](https://github.com/robbrad/UKBinCollectionData/wiki/Councils) do chomhairle le haghaidh sonraí ar cad atá le cur isteach."
             }

--- a/custom_components/uk_bin_collection/translations/ga.json
+++ b/custom_components/uk_bin_collection/translations/ga.json
@@ -7,7 +7,7 @@
                 "data": {
                     "name": "Ainm Suíomh",
                     "council": "Comhairle",
-                    "manual_refresh_only": "Athnuaigh an braiteoir go huathoibríoch",
+                    "manual_refresh_only": "Athnuachan de láimh amháin (díchumasaigh nuashonruithe uathoibríocha — athnuaigh tríd an tseirbhís uk_bin_collection.manual_refresh)",
                     "icon_color_mapping": "JSON chun Cineál Bin a mhapáil do Dath agus Deilbhín féach: https://github.com/robbrad/UKBinCollectionData"
                 },
                 "description": "Féach [anseo](https://github.com/robbrad/UKBinCollectionData#requesting-your-council) mura bhfuil do chomhairle liostaithe"
@@ -42,7 +42,7 @@
                     "web_driver": "Chun rith ar Fhreastalaí Iargúlta Selenium cuir isteach URL an Fhreastalaí Selenium",
                     "headless": "Rith Selenium i mód gan cheann (molta)",
                     "local_browser": "Ná rith ar fhreastalaí iargúlta Selenium, úsáid suiteáil áitiúil de Chrome ina ionad",
-                    "manual_refresh_only": "Athnuaigh an braiteoir go huathoibríoch",
+                    "manual_refresh_only": "Athnuachan de láimh amháin (díchumasaigh nuashonruithe uathoibríocha — athnuaigh tríd an tseirbhís uk_bin_collection.manual_refresh)",
                     "icon_color_mapping": "JSON chun Cineál Bin a mhapáil do Dath agus Deilbhín féach: https://github.com/robbrad/UKBinCollectionData",
                     "submit": "Cuir isteach"
                 },

--- a/custom_components/uk_bin_collection/translations/gd.json
+++ b/custom_components/uk_bin_collection/translations/gd.json
@@ -11,6 +11,9 @@
                     "local_browser": "Na ruith air frithealaiche Selenium iomallach, cleachd stàladh ionadail de Chrome an àite",
                     "icon_color_mapping": "JSON gus Seòrsa Biona a mhapadh airson Dath agus Ìomhaigh faic: https://github.com/robbrad/UKBinCollectionData"
                 },
+                "data_description": {
+                    "manual_refresh_only": "Nuair a tha e air a chomharrachadh, CHA dèan an t-amalachadh ùrachadh gu fèin-obrachail — cha tèid dàta fhaighinn ach aig àm suidheachaidh agus nuair a ghairmeas tu an t-seirbheis uk_bin_collection.manual_refresh. Nuair nach eil e air a chomharrachadh, thèid dàta ùrachadh gach 'update_interval' uair."
+                },
                 "description": "Feuch an toir thu sùil [an seo](https://github.com/robbrad/UKBinCollectionData#requesting-your-council) mura h-eil do chomhairle air a liostadh"
             },
             "council": {
@@ -46,6 +49,9 @@
                     "local_browser": "Na ruith air frithealaiche Selenium iomallach, cleachd stàladh ionadail de Chrome an àite",
                     "icon_color_mapping": "JSON gus Seòrsa Biona a mhapadh airson Dath agus Ìomhaigh faic: https://github.com/robbrad/UKBinCollectionData",
                     "submit": "Cuir a-steach"
+                },
+                "data_description": {
+                    "manual_refresh_only": "Nuair a tha e air a chomharrachadh, CHA dèan an t-amalachadh ùrachadh gu fèin-obrachail — cha tèid dàta fhaighinn ach aig àm suidheachaidh agus nuair a ghairmeas tu an t-seirbheis uk_bin_collection.manual_refresh. Nuair nach eil e air a chomharrachadh, thèid dàta ùrachadh gach 'update_interval' uair."
                 },
                 "description": "Feuch an toir thu sùil air inntrigeadh [wiki](https://github.com/robbrad/UKBinCollectionData/wiki/Councils) na comhairle agad airson mion-fhiosrachadh air dè a chur a-steach."
             }

--- a/custom_components/uk_bin_collection/translations/gd.json
+++ b/custom_components/uk_bin_collection/translations/gd.json
@@ -7,7 +7,7 @@
                 "data": {
                     "name": "Ainm Àite",
                     "council": "Comhairle",
-                    "manual_refresh_only": "Ùraich an sensor gu fèin-obrachail",                    
+                    "manual_refresh_only": "Ùrachadh le làimh a-mhàin (cuir à comas ùrachaidhean fèin-obrachail — ùraich tron t-seirbheis uk_bin_collection.manual_refresh)",                    
                     "local_browser": "Na ruith air frithealaiche Selenium iomallach, cleachd stàladh ionadail de Chrome an àite",
                     "icon_color_mapping": "JSON gus Seòrsa Biona a mhapadh airson Dath agus Ìomhaigh faic: https://github.com/robbrad/UKBinCollectionData"
                 },
@@ -42,7 +42,7 @@
                     "usrn": "USRN (Àireamh Iomraidh Sràid Aonraic)",
                     "web_driver": "Gus ruith air Frithealaiche Selenium iomallach cuir a-steach an URL Frithealaiche Selenium",
                     "headless": "Ruith Selenium ann am modh gun cheann (air a mholadh)",
-                    "manual_refresh_only": "Ùraich an sensor gu fèin-obrachail",
+                    "manual_refresh_only": "Ùrachadh le làimh a-mhàin (cuir à comas ùrachaidhean fèin-obrachail — ùraich tron t-seirbheis uk_bin_collection.manual_refresh)",
                     "local_browser": "Na ruith air frithealaiche Selenium iomallach, cleachd stàladh ionadail de Chrome an àite",
                     "icon_color_mapping": "JSON gus Seòrsa Biona a mhapadh airson Dath agus Ìomhaigh faic: https://github.com/robbrad/UKBinCollectionData",
                     "submit": "Cuir a-steach"

--- a/custom_components/uk_bin_collection/translations/pt.json
+++ b/custom_components/uk_bin_collection/translations/pt.json
@@ -7,7 +7,7 @@
                 "data": {
                     "name": "Nome da localização",
                     "council": "Conselho",
-                    "manual_refresh_only": "Atualize o sensor automaticamente",
+                    "manual_refresh_only": "Apenas atualização manual (desativa as atualizações automáticas — atualize através do serviço uk_bin_collection.manual_refresh)",
                     "icon_color_mapping": "JSON para mapear Tipo de Lixo para Cor e Ícone veja: https://github.com/robbrad/UKBinCollectionData"
                 },
                 "description": "Por favor, veja [aqui](https://github.com/robbrad/UKBinCollectionData#requesting-your-council) se o seu conselho não estiver listado"
@@ -41,7 +41,7 @@
                     "usrn": "USRN (Número de Referência Único da Rua)",
                     "web_driver": "Para executar em um Servidor Selenium remoto, adicione o URL do Servidor Selenium",
                     "headless": "Execute o Selenium no modo sem cabeça (recomendado)",
-                    "manual_refresh_only": "Atualize o sensor automaticamente",
+                    "manual_refresh_only": "Apenas atualização manual (desativa as atualizações automáticas — atualize através do serviço uk_bin_collection.manual_refresh)",
                     "local_browser": "Não execute no servidor Selenium remoto, use a instalação local do Chrome em vez disso",
                     "icon_color_mapping": "JSON para mapear Tipo de Lixo para Cor e Ícone veja: https://github.com/robbrad/UKBinCollectionData",
                     "submit": "Enviar"

--- a/custom_components/uk_bin_collection/translations/pt.json
+++ b/custom_components/uk_bin_collection/translations/pt.json
@@ -10,6 +10,9 @@
                     "manual_refresh_only": "Apenas atualização manual (desativa as atualizações automáticas — atualize através do serviço uk_bin_collection.manual_refresh)",
                     "icon_color_mapping": "JSON para mapear Tipo de Lixo para Cor e Ícone veja: https://github.com/robbrad/UKBinCollectionData"
                 },
+                "data_description": {
+                    "manual_refresh_only": "Quando marcada, a integração NÃO será atualizada automaticamente — os dados só são obtidos na configuração e quando chama o serviço uk_bin_collection.manual_refresh. Quando desmarcada, os dados são atualizados a cada 'update_interval' horas."
+                },
                 "description": "Por favor, veja [aqui](https://github.com/robbrad/UKBinCollectionData#requesting-your-council) se o seu conselho não estiver listado"
             },
             "council": {
@@ -45,6 +48,9 @@
                     "local_browser": "Não execute no servidor Selenium remoto, use a instalação local do Chrome em vez disso",
                     "icon_color_mapping": "JSON para mapear Tipo de Lixo para Cor e Ícone veja: https://github.com/robbrad/UKBinCollectionData",
                     "submit": "Enviar"
+                },
+                "data_description": {
+                    "manual_refresh_only": "Quando marcada, a integração NÃO será atualizada automaticamente — os dados só são obtidos na configuração e quando chama o serviço uk_bin_collection.manual_refresh. Quando desmarcada, os dados são atualizados a cada 'update_interval' horas."
                 },
                 "description": "Por favor, consulte a entrada [wiki](https://github.com/robbrad/UKBinCollectionData/wiki/Councils) do seu conselho para detalhes sobre o que inserir."
             }


### PR DESCRIPTION
## Summary

The `manual_refresh_only` config field was labelled **"Automatically refresh the sensor"** — the exact inverse of what it does. Ticking the box actually *disables* automatic refresh, and `async_step_user` defaults the field to `True`, so new installs silently got no periodic updates while showing a ticked "Automatically refresh" checkbox. This is the likely root cause of the recurring "entities only update on restart" reports.

Fixes #2193

## What this does

The field's name, stored value, and semantics are **unchanged** — no config migration, no inversion in code. This PR only fixes the misleading UI text:

- **Relabelled** the checkbox to match its real meaning: *"Manual refresh only (disable automatic updates — refresh via the `uk_bin_collection.manual_refresh` service)"* in both the `user` and `reconfigure_confirm` steps.
- Updated `strings.json` and **all** translation files. `en.json` uses the new English label; `cy`, `ga`, `gd`, and `pt` get proper native translations (the literal service name is preserved).
- Added a `data_description` helper explaining: ticked = no automatic refresh; unticked = refresh every `update_interval` hours.
- Added a code comment flagging that `default=True` in `async_step_user` is questionable given the symptom reports — **left unchanged** here so it can be decided separately.

## What this deliberately does NOT change

- No changes to `__init__.py` refresh logic.
- No changes to stored config entry data / no migration.
- No change to the `default=True` value.

## Tests

- New dependency-free (`json` + `pathlib` only) regression test `tests/test_translations.py` that loads `strings.json` and every `translations/*.json`, asserts no label is the old inverted string (or an un-negated "automatic" claim), and checks `strings.json`/`en.json` stay in sync.
- Existing `test_async_setup_entry_manual_refresh_only_disables_polling` (True → `update_interval is None`, False → `timedelta(hours=12)`) left in place and still passing.

```bash
poetry run pytest custom_components/uk_bin_collection/tests/
```

## Note for reviewers

I'm confident in the Portuguese translation and reasonably confident in the Welsh/Irish/Scottish Gaelic ones, but a native-speaker review on those three would be welcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refined the “Manual refresh only” setting wording in setup and reconfiguration screens.
  * Added clearer help text explaining when data updates occur and that updates can be triggered via the `uk_bin_collection.manual_refresh` service.
  * Updated the wording consistently across all supported translations.
* **Bug Fixes**
  * Replaced confusing “auto refresh” wording with manual-refresh-only behavior descriptions.
* **Tests**
  * Added a regression check to ensure every locale’s “manual_refresh_only” label also includes non-empty matching descriptive help text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->