### PR TITLE
fix: invert refresh checkbox to a positive "Enable automatic data refresh" option

### DIFF
--- a/custom_components/uk_bin_collection/__init__.py
+++ b/custom_components/uk_bin_collection/__init__.py
@@ -140,14 +140,21 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
             raise ConfigEntryNotReady("Missing 'name' in configuration.")
 
         timeout = config_entry.data.get("timeout", 60)
-        manual_refresh = config_entry.data.get("manual_refresh_only", False)
+        # Positive framing: auto_refresh_enabled True -> poll periodically.
+        # Fall back to the legacy manual_refresh_only key for entries created
+        # before the rename (auto_refresh_enabled = not manual_refresh_only).
+        auto_refresh_enabled = config_entry.data.get("auto_refresh_enabled")
+        if auto_refresh_enabled is None:
+            auto_refresh_enabled = not config_entry.data.get(
+                "manual_refresh_only", False
+            )
         icon_color_mapping = config_entry.data.get("icon_color_mapping", "{}")
         update_interval_hours = config_entry.data.get("update_interval", 12)
 
         _LOGGER.debug(
             f"{LOG_PREFIX} Retrieved configuration: "
             f"name={name}, timeout={timeout}, "
-            f"manual_refresh_only={manual_refresh}, "
+            f"auto_refresh_enabled={auto_refresh_enabled}, "
             f"update_interval={update_interval_hours} hours, "
             f"icon_color_mapping={icon_color_mapping}"
         )
@@ -166,8 +173,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
             )
             timeout = 60
 
-        # Decide update interval based on manual_refresh_only
-        if manual_refresh:
+        # Decide update interval based on auto_refresh_enabled
+        if not auto_refresh_enabled:
             update_interval = None
             _LOGGER.info(
                 "%s Manual refresh only: no automatic updates scheduled.", LOG_PREFIX

--- a/custom_components/uk_bin_collection/__init__.py
+++ b/custom_components/uk_bin_collection/__init__.py
@@ -140,9 +140,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
             raise ConfigEntryNotReady("Missing 'name' in configuration.")
 
         timeout = config_entry.data.get("timeout", 60)
-        # Positive framing: auto_refresh_enabled True -> poll periodically.
-        # Fall back to the legacy manual_refresh_only key for entries created
-        # before the rename (auto_refresh_enabled = not manual_refresh_only).
+        # Fall back to the legacy manual_refresh_only key for pre-rename entries.
         auto_refresh_enabled = config_entry.data.get("auto_refresh_enabled")
         if auto_refresh_enabled is None:
             auto_refresh_enabled = not config_entry.data.get(

--- a/custom_components/uk_bin_collection/config_flow.py
+++ b/custom_components/uk_bin_collection/config_flow.py
@@ -541,8 +541,9 @@ class UkBinCollectionOptionsFlowHandler(config_entries.OptionsFlow):
                 ):
                     errors["icon_color_mapping"] = "Invalid JSON format."
 
-            if not user_input.get("auto_refresh_enabled"):
-                user_input["update_interval"] = None
+            # Polling is disabled at runtime when auto_refresh_enabled is
+            # false; keep the numeric update_interval so it stays valid for the
+            # schema defaults and is remembered if polling is re-enabled.
 
             if not errors:
                 # Merge the user input with existing data

--- a/custom_components/uk_bin_collection/config_flow.py
+++ b/custom_components/uk_bin_collection/config_flow.py
@@ -45,23 +45,6 @@ class UkBinCollectionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self.chromium_checked: bool = False
         self.chromium_installed: bool = False
 
-    async def async_migrate_entry(
-        self, config_entry: config_entries.ConfigEntry
-    ) -> bool:
-        """Migrate old entry to the new version with manual refresh ticked."""
-        _LOGGER.info("Migrating config entry from version %s", config_entry.version)
-        data = dict(config_entry.data)
-
-        if config_entry.version < 3:
-            # If the manual_refresh_only key is not present, add it and set to True.
-            if "manual_refresh_only" not in data:
-                _LOGGER.info("Setting 'manual_refresh_only' to True in the migration")
-                data["manual_refresh_only"] = True
-
-            self.hass.config_entries.async_update_entry(config_entry, data=data)
-            _LOGGER.info("Migration to version %s successful", self.VERSION)
-        return True
-
     async def async_step_user(self, user_input: Optional[Dict[str, Any]] = None):
         """Handle the initial step."""
         errors = {}

--- a/custom_components/uk_bin_collection/config_flow.py
+++ b/custom_components/uk_bin_collection/config_flow.py
@@ -117,9 +117,6 @@ class UkBinCollectionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 {
                     vol.Required("name"): cv.string,
                     vol.Required("council"): vol.In(self.council_options),
-                    # Ticked (default) enables periodic polling; unticking it
-                    # falls back to manual refresh via the
-                    # uk_bin_collection.manual_refresh service.
                     vol.Optional("auto_refresh_enabled", default=True): bool,
                     vol.Optional("icon_color_mapping", default=""): cv.string,
                 }

--- a/custom_components/uk_bin_collection/config_flow.py
+++ b/custom_components/uk_bin_collection/config_flow.py
@@ -117,7 +117,10 @@ class UkBinCollectionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 {
                     vol.Required("name"): cv.string,
                     vol.Required("council"): vol.In(self.council_options),
-                    vol.Optional("manual_refresh_only", default=True): bool,
+                    # Ticked (default) enables periodic polling; unticking it
+                    # falls back to manual refresh via the
+                    # uk_bin_collection.manual_refresh service.
+                    vol.Optional("auto_refresh_enabled", default=True): bool,
                     vol.Optional("icon_color_mapping", default=""): cv.string,
                 }
             ),
@@ -225,6 +228,8 @@ class UkBinCollectionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 # Merge the user input with existing data
                 data = {**existing_entry.data, **user_input}
                 data["icon_color_mapping"] = user_input.get("icon_color_mapping", "")
+                # Drop the legacy key so entries don't carry both flags.
+                data.pop("manual_refresh_only", None)
 
                 self.hass.config_entries.async_update_entry(
                     existing_entry,
@@ -324,8 +329,11 @@ class UkBinCollectionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self.council_options
             ),
             vol.Optional(
-                "manual_refresh_only",
-                default=existing_data.get("manual_refresh_only", False),
+                "auto_refresh_enabled",
+                default=existing_data.get(
+                    "auto_refresh_enabled",
+                    not existing_data.get("manual_refresh_only", False),
+                ),
             ): bool,
             vol.Required(
                 "update_interval", default=existing_data.get("update_interval", 12)
@@ -536,13 +544,15 @@ class UkBinCollectionOptionsFlowHandler(config_entries.OptionsFlow):
                 ):
                     errors["icon_color_mapping"] = "Invalid JSON format."
 
-            if user_input.get("manual_refresh_only"):
+            if not user_input.get("auto_refresh_enabled"):
                 user_input["update_interval"] = None
 
             if not errors:
                 # Merge the user input with existing data
                 data = {**existing_data, **user_input}
                 data["icon_color_mapping"] = user_input.get("icon_color_mapping", "")
+                # Drop the legacy key so entries don't carry both flags.
+                data.pop("manual_refresh_only", None)
 
                 self.hass.config_entries.async_update_entry(
                     self.config_entry,
@@ -600,7 +610,13 @@ class UkBinCollectionOptionsFlowHandler(config_entries.OptionsFlow):
             vol.Required("council", default=council_current_wiki): vol.In(
                 self.council_options
             ),
-            vol.Optional("manual_refresh_only", default=False): bool,
+            vol.Optional(
+                "auto_refresh_enabled",
+                default=existing_data.get(
+                    "auto_refresh_enabled",
+                    not existing_data.get("manual_refresh_only", False),
+                ),
+            ): bool,
             vol.Required(
                 "update_interval", default=existing_data.get("update_interval", 12)
             ): vol.All(cv.positive_int, vol.Range(min=1)),

--- a/custom_components/uk_bin_collection/config_flow.py
+++ b/custom_components/uk_bin_collection/config_flow.py
@@ -16,6 +16,19 @@ from .const import DOMAIN, LOG_PREFIX, SELENIUM_SERVER_URLS, BROWSER_BINARIES, I
 
 _LOGGER = logging.getLogger(__name__)
 
+
+def resolve_auto_refresh_default(existing_data: Dict[str, Any]) -> bool:
+    """Resolve the auto_refresh_enabled checkbox default for a config entry.
+
+    Falls back to the inverse of the legacy manual_refresh_only key for entries
+    created before the rename.
+    """
+    return existing_data.get(
+        "auto_refresh_enabled",
+        not existing_data.get("manual_refresh_only", False),
+    )
+
+
 class UkBinCollectionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for UkBinCollection."""
 
@@ -327,10 +340,7 @@ class UkBinCollectionConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             ),
             vol.Optional(
                 "auto_refresh_enabled",
-                default=existing_data.get(
-                    "auto_refresh_enabled",
-                    not existing_data.get("manual_refresh_only", False),
-                ),
+                default=resolve_auto_refresh_default(existing_data),
             ): bool,
             vol.Required(
                 "update_interval", default=existing_data.get("update_interval", 12)
@@ -610,10 +620,7 @@ class UkBinCollectionOptionsFlowHandler(config_entries.OptionsFlow):
             ),
             vol.Optional(
                 "auto_refresh_enabled",
-                default=existing_data.get(
-                    "auto_refresh_enabled",
-                    not existing_data.get("manual_refresh_only", False),
-                ),
+                default=resolve_auto_refresh_default(existing_data),
             ): bool,
             vol.Required(
                 "update_interval", default=existing_data.get("update_interval", 12)

--- a/custom_components/uk_bin_collection/const.py
+++ b/custom_components/uk_bin_collection/const.py
@@ -36,5 +36,6 @@ EXCLUDED_ARG_KEYS = {
     "icon_color_mapping",
     "update_interval",
     "manual_refresh_only",
+    "auto_refresh_enabled",
     "original_parser",
 }

--- a/custom_components/uk_bin_collection/strings.json
+++ b/custom_components/uk_bin_collection/strings.json
@@ -55,5 +55,14 @@
             "selenium_unavailable": "Selenium server is not accessible. Please ensure it is running at localhost:4444 or selenium:4444",
             "chromium_not_found": "Chromium browser is not installed. Please install Chromium or Google Chrome"
         }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "auto_refresh_enabled": "Enable automatic data refresh"
+                }
+            }
+        }
     }
 }

--- a/custom_components/uk_bin_collection/strings.json
+++ b/custom_components/uk_bin_collection/strings.json
@@ -7,7 +7,7 @@
                 "data": {
                     "name": "Location name",
                     "council": "Council",
-                    "manual_refresh_only":"Automatically refresh the sensor",
+                    "auto_refresh_enabled": "Enable automatic data refresh",
                     "icon_color_mapping": "JSON to map Bin Type for Colour and Icon (see documentation)"
                 },
                 "description": "Please see the documentation if your council isn't listed"
@@ -42,7 +42,7 @@
                     "web_driver": "To run on a remote Selenium Server add the Selenium Server URL",
                     "headless": "Run Selenium in headless mode (recommended)",
                     "local_browser": "Don't run on remote Selenium server, use local install of Chrome instead",
-                    "manual_refresh_only":"Automatically refresh the sensor",
+                    "auto_refresh_enabled": "Enable automatic data refresh",
                     "icon_color_mapping": "JSON to map Bin Type for Colour and Icon (see documentation)",
                     "submit": "Submit"
                 },

--- a/custom_components/uk_bin_collection/tests/test_config_flow.py
+++ b/custom_components/uk_bin_collection/tests/test_config_flow.py
@@ -1025,8 +1025,8 @@ async def test_async_step_reconfigure_confirm_invalid_json(hass: HomeAssistant):
 
 
 @pytest.mark.asyncio
-async def test_config_flow_with_manual_refresh_only(hass: HomeAssistant):
-    """Test config flow when the user selects manual_refresh_only = True."""
+async def test_config_flow_with_auto_refresh_disabled(hass: HomeAssistant):
+    """Test config flow when the user unticks auto_refresh_enabled."""
     mock_councils = {
         "CouncilWithUPRN": {
             "wiki_name": "Council with UPRN",
@@ -1041,11 +1041,11 @@ async def test_config_flow_with_manual_refresh_only(hass: HomeAssistant):
         flow = UkBinCollectionConfigFlow()
         flow.hass = hass
 
-        # Step 1: user selects council + sets manual_refresh_only
+        # Step 1: user selects council + unticks automatic refresh
         user_input_initial = {
-            "name": "Test Manual Refresh",
+            "name": "Test Auto Refresh Off",
             "council": "Council with UPRN",
-            "manual_refresh_only": True,
+            "auto_refresh_enabled": False,
             # icon_color_mapping, etc. are optional
         }
 
@@ -1065,15 +1065,15 @@ async def test_config_flow_with_manual_refresh_only(hass: HomeAssistant):
         # Complete council step
         result = await flow.async_step_council(user_input=user_input_council)
         assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
-        assert result["title"] == "Test Manual Refresh"
+        assert result["title"] == "Test Auto Refresh Off"
 
-        # Confirm the config entry data now includes manual_refresh_only
+        # Confirm the config entry data now stores auto_refresh_enabled
         assert result["data"] == {
-            "name": "Test Manual Refresh",
+            "name": "Test Auto Refresh Off",
             "council": "CouncilWithUPRN",
             "uprn": "1234567890",
             "timeout": 45,
-            "manual_refresh_only": True,
+            "auto_refresh_enabled": False,
         }
 
 

--- a/custom_components/uk_bin_collection/tests/test_config_flow.py
+++ b/custom_components/uk_bin_collection/tests/test_config_flow.py
@@ -1077,6 +1077,93 @@ async def test_config_flow_with_auto_refresh_disabled(hass: HomeAssistant):
         }
 
 
+@pytest.mark.asyncio
+async def test_reconfigure_confirm_renames_legacy_key(hass: HomeAssistant):
+    """Reconfigure saves auto_refresh_enabled and drops legacy manual_refresh_only."""
+    with patch(
+        "custom_components.uk_bin_collection.config_flow.UkBinCollectionConfigFlow.get_councils_json",
+        return_value=MOCK_COUNCILS_DATA,
+    ):
+        flow = UkBinCollectionConfigFlow()
+        flow.hass = hass
+
+        config_entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={
+                "name": "Existing Entry",
+                "council": "CouncilWithUPRN",
+                "uprn": "1234567890",
+                "timeout": 60,
+                "update_interval": 12,
+                "manual_refresh_only": True,  # legacy key from before the rename
+            },
+        )
+        config_entry.add_to_hass(hass)
+        flow.context = {"entry_id": config_entry.entry_id}
+
+        hass.config_entries.async_get_entry = MagicMock(return_value=config_entry)
+        hass.config_entries.async_reload = AsyncMock()
+        hass.config_entries.async_update_entry = MagicMock()
+
+        user_input = {
+            "name": "Existing Entry",
+            "council": "Council with UPRN",
+            "uprn": "1234567890",
+            "timeout": 60,
+            "update_interval": 8,
+            "auto_refresh_enabled": True,
+            "icon_color_mapping": "{}",
+        }
+
+        result = await flow.async_step_reconfigure_confirm(user_input=user_input)
+
+        assert result["type"] == data_entry_flow.RESULT_TYPE_ABORT
+        assert result["reason"] == "Reconfigure Successful"
+        saved = hass.config_entries.async_update_entry.call_args.kwargs["data"]
+        assert saved["auto_refresh_enabled"] is True
+        assert "manual_refresh_only" not in saved
+        assert saved["update_interval"] == 8
+
+
+@pytest.mark.asyncio
+async def test_options_flow_disabling_auto_refresh_keeps_interval(hass: HomeAssistant):
+    """Options flow: unticking auto refresh drops the legacy key and keeps the
+    numeric update_interval (it is not overwritten with None)."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "name": "Opt Entry",
+            "council": "CouncilWithUPRN",
+            "uprn": "1234567890",
+            "timeout": 60,
+            "update_interval": 12,
+            "manual_refresh_only": False,  # legacy key from before the rename
+        },
+    )
+    config_entry.add_to_hass(hass)
+    flow = UkBinCollectionOptionsFlowHandler(config_entry)
+    flow.hass = hass
+    flow.get_councils_json = AsyncMock(return_value=MOCK_COUNCILS_DATA)
+    hass.config_entries.async_reload = AsyncMock()
+    hass.config_entries.async_update_entry = MagicMock()
+
+    user_input = {
+        "name": "Opt Entry",
+        "council": "Council with UPRN",
+        "update_interval": 6,
+        "auto_refresh_enabled": False,
+        "icon_color_mapping": "{}",
+    }
+
+    result = await flow.async_step_init(user_input=user_input)
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_CREATE_ENTRY
+    saved = hass.config_entries.async_update_entry.call_args.kwargs["data"]
+    assert saved["auto_refresh_enabled"] is False
+    assert "manual_refresh_only" not in saved
+    assert saved["update_interval"] == 6
+
+
 # ---------------------------
 # Tests for helper functions
 # ---------------------------

--- a/custom_components/uk_bin_collection/tests/test_init.py
+++ b/custom_components/uk_bin_collection/tests/test_init.py
@@ -233,7 +233,8 @@ async def test_async_setup_entry_missing_name(hass, dummy_config_entry):
 async def test_async_setup_entry_manual_refresh_only_disables_polling(
     hass, dummy_config_entry
 ):
-    # dummy_config_entry has manual_refresh_only=True: no automatic polling.
+    # Legacy fallback: entry only has manual_refresh_only=True (no
+    # auto_refresh_enabled), which must be read as auto refresh disabled.
     hass.data.setdefault(DOMAIN, {})
 
     with patch(
@@ -250,7 +251,8 @@ async def test_async_setup_entry_manual_refresh_only_disables_polling(
 async def test_async_setup_entry_automatic_refresh_when_not_manual(
     hass, dummy_config_entry
 ):
-    # manual_refresh_only=False: coordinator should poll on update_interval.
+    # Legacy fallback: manual_refresh_only=False -> auto refresh enabled,
+    # coordinator should poll on update_interval.
     dummy_config_entry.data["manual_refresh_only"] = False
     hass.data.setdefault(DOMAIN, {})
 
@@ -262,6 +264,45 @@ async def test_async_setup_entry_automatic_refresh_when_not_manual(
 
     coordinator = hass.data[DOMAIN][dummy_config_entry.entry_id]["coordinator"]
     assert coordinator.update_interval == timedelta(hours=12)
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_auto_refresh_enabled_true_polls(
+    hass, dummy_config_entry
+):
+    # New key: auto_refresh_enabled=True -> coordinator polls on interval.
+    dummy_config_entry.data.pop("manual_refresh_only", None)
+    dummy_config_entry.data["auto_refresh_enabled"] = True
+    hass.data.setdefault(DOMAIN, {})
+
+    with patch(
+        "custom_components.uk_bin_collection.UKBinCollectionApp",
+        return_value=DummyUKBinCollectionApp(),
+    ):
+        await async_setup_entry(hass, dummy_config_entry)
+
+    coordinator = hass.data[DOMAIN][dummy_config_entry.entry_id]["coordinator"]
+    assert coordinator.update_interval == timedelta(hours=12)
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_auto_refresh_enabled_false_disables_polling(
+    hass, dummy_config_entry
+):
+    # New key: auto_refresh_enabled=False -> no automatic polling. Takes
+    # precedence over any stale legacy key.
+    dummy_config_entry.data["auto_refresh_enabled"] = False
+    dummy_config_entry.data["manual_refresh_only"] = False
+    hass.data.setdefault(DOMAIN, {})
+
+    with patch(
+        "custom_components.uk_bin_collection.UKBinCollectionApp",
+        return_value=DummyUKBinCollectionApp(),
+    ):
+        await async_setup_entry(hass, dummy_config_entry)
+
+    coordinator = hass.data[DOMAIN][dummy_config_entry.entry_id]["coordinator"]
+    assert coordinator.update_interval is None
 
 
 # --- Test async_unload_entry ---

--- a/custom_components/uk_bin_collection/translations/cy.json
+++ b/custom_components/uk_bin_collection/translations/cy.json
@@ -55,5 +55,14 @@
             "selenium_unavailable": "❌ Nid yw gweinydd Selenium ar gael. Sicrhewch ei fod yn rhedeg yn http://localhost:4444 neu http://selenium:4444. [Canllaw Gosod](https://example.com/selenium-setup)",
             "chromium_not_found": "❌ Nid yw porwr Chromium wedi'i osod. Gosodwch Chromium neu Google Chrome os gwelwch yn dda. [Canllaw Gosod](https://example.com/chromium-install)"
         }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "auto_refresh_enabled": "Adnewyddu'r synhwyrydd yn awtomatig"
+                }
+            }
+        }
     }
 }

--- a/custom_components/uk_bin_collection/translations/cy.json
+++ b/custom_components/uk_bin_collection/translations/cy.json
@@ -7,7 +7,7 @@
                 "data": {
                     "name": "Enw'r lleoliad",
                     "council": "Cyngor",
-                    "manual_refresh_only": "Adnewyddu'r synhwyrydd yn awtomatig",
+                    "auto_refresh_enabled": "Adnewyddu'r synhwyrydd yn awtomatig",
                     "icon_color_mapping": "JSON i fapio Math y Bin ar gyfer Lliw ac Eicon gweler: https://github.com/robbrad/UKBinCollectionData"
                 },
                 "description": "Gweler [yma](https://github.com/robbrad/UKBinCollectionData#requesting-your-council) os nad yw eich cyngor wedi'i restru"
@@ -41,7 +41,7 @@
                     "usrn": "USRN (Rhif Cyfeirnod Stryd Unigryw)",
                     "web_driver": "I redeg ar weinydd Selenium o bell, ychwanegwch URL y Weinydd Selenium",
                     "headless": "Rhedeg Selenium yn y modd heb ben (argymhellir)",
-                    "manual_refresh_only": "Adnewyddu'r synhwyrydd yn awtomatig",
+                    "auto_refresh_enabled": "Adnewyddu'r synhwyrydd yn awtomatig",
                     "local_browser": "Peidiwch â rhedeg ar weinydd Selenium o bell, defnyddiwch osodiad lleol o Chrome yn lle",
                     "icon_color_mapping": "JSON i fapio Math y Bin ar gyfer Lliw ac Eicon gweler: https://github.com/robbrad/UKBinCollectionData",
                     "submit": "Cyflwyno"

--- a/custom_components/uk_bin_collection/translations/en.json
+++ b/custom_components/uk_bin_collection/translations/en.json
@@ -55,5 +55,14 @@
             "selenium_unavailable": "Selenium server is not accessible. Please ensure it is running at localhost:4444 or selenium:4444",
             "chromium_not_found": "Chromium browser is not installed. Please install Chromium or Google Chrome"
         }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "auto_refresh_enabled": "Enable automatic data refresh"
+                }
+            }
+        }
     }
 }

--- a/custom_components/uk_bin_collection/translations/en.json
+++ b/custom_components/uk_bin_collection/translations/en.json
@@ -7,7 +7,7 @@
                 "data": {
                     "name": "Location name",
                     "council": "Council",
-                    "manual_refresh_only":"Automatically refresh the sensor",
+                    "auto_refresh_enabled": "Enable automatic data refresh",
                     "icon_color_mapping": "JSON to map Bin Type for Colour and Icon (see documentation)"
                 },
                 "description": "Please see the documentation if your council isn't listed"
@@ -42,7 +42,7 @@
                     "web_driver": "To run on a remote Selenium Server add the Selenium Server URL",
                     "headless": "Run Selenium in headless mode (recommended)",
                     "local_browser": "Don't run on remote Selenium server, use local install of Chrome instead",
-                    "manual_refresh_only":"Automatically refresh the sensor",
+                    "auto_refresh_enabled": "Enable automatic data refresh",
                     "icon_color_mapping": "JSON to map Bin Type for Colour and Icon (see documentation)",
                     "submit": "Submit"
                 },

--- a/custom_components/uk_bin_collection/translations/ga.json
+++ b/custom_components/uk_bin_collection/translations/ga.json
@@ -55,5 +55,14 @@
             "selenium_unavailable": "❌ Níl freastalaí Selenium inrochtana. Cinntigh go bhfuil sé ag rith ag http://localhost:4444 nó http://selenium:4444. [Treoir Socraithe](https://example.com/selenium-setup)",
             "chromium_not_found": "❌ Níl brabhsálaí Chromium suiteáilte. Suiteáil Chromium nó Google Chrome le do thoil. [Treoir Suiteála](https://example.com/chromium-install)"
         }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "auto_refresh_enabled": "Athnuaigh an braiteoir go huathoibríoch"
+                }
+            }
+        }
     }
 }

--- a/custom_components/uk_bin_collection/translations/ga.json
+++ b/custom_components/uk_bin_collection/translations/ga.json
@@ -7,7 +7,7 @@
                 "data": {
                     "name": "Ainm Suíomh",
                     "council": "Comhairle",
-                    "manual_refresh_only": "Athnuaigh an braiteoir go huathoibríoch",
+                    "auto_refresh_enabled": "Athnuaigh an braiteoir go huathoibríoch",
                     "icon_color_mapping": "JSON chun Cineál Bin a mhapáil do Dath agus Deilbhín féach: https://github.com/robbrad/UKBinCollectionData"
                 },
                 "description": "Féach [anseo](https://github.com/robbrad/UKBinCollectionData#requesting-your-council) mura bhfuil do chomhairle liostaithe"
@@ -42,7 +42,7 @@
                     "web_driver": "Chun rith ar Fhreastalaí Iargúlta Selenium cuir isteach URL an Fhreastalaí Selenium",
                     "headless": "Rith Selenium i mód gan cheann (molta)",
                     "local_browser": "Ná rith ar fhreastalaí iargúlta Selenium, úsáid suiteáil áitiúil de Chrome ina ionad",
-                    "manual_refresh_only": "Athnuaigh an braiteoir go huathoibríoch",
+                    "auto_refresh_enabled": "Athnuaigh an braiteoir go huathoibríoch",
                     "icon_color_mapping": "JSON chun Cineál Bin a mhapáil do Dath agus Deilbhín féach: https://github.com/robbrad/UKBinCollectionData",
                     "submit": "Cuir isteach"
                 },

--- a/custom_components/uk_bin_collection/translations/gd.json
+++ b/custom_components/uk_bin_collection/translations/gd.json
@@ -7,7 +7,7 @@
                 "data": {
                     "name": "Ainm Àite",
                     "council": "Comhairle",
-                    "manual_refresh_only": "Ùraich an sensor gu fèin-obrachail",                    
+                    "auto_refresh_enabled": "Ùraich an sensor gu fèin-obrachail",                    
                     "local_browser": "Na ruith air frithealaiche Selenium iomallach, cleachd stàladh ionadail de Chrome an àite",
                     "icon_color_mapping": "JSON gus Seòrsa Biona a mhapadh airson Dath agus Ìomhaigh faic: https://github.com/robbrad/UKBinCollectionData"
                 },
@@ -42,7 +42,7 @@
                     "usrn": "USRN (Àireamh Iomraidh Sràid Aonraic)",
                     "web_driver": "Gus ruith air Frithealaiche Selenium iomallach cuir a-steach an URL Frithealaiche Selenium",
                     "headless": "Ruith Selenium ann am modh gun cheann (air a mholadh)",
-                    "manual_refresh_only": "Ùraich an sensor gu fèin-obrachail",
+                    "auto_refresh_enabled": "Ùraich an sensor gu fèin-obrachail",
                     "local_browser": "Na ruith air frithealaiche Selenium iomallach, cleachd stàladh ionadail de Chrome an àite",
                     "icon_color_mapping": "JSON gus Seòrsa Biona a mhapadh airson Dath agus Ìomhaigh faic: https://github.com/robbrad/UKBinCollectionData",
                     "submit": "Cuir a-steach"

--- a/custom_components/uk_bin_collection/translations/gd.json
+++ b/custom_components/uk_bin_collection/translations/gd.json
@@ -56,5 +56,14 @@
             "selenium_unavailable": "❌ Chan eil frithealaiche Selenium ruigsinneach. Dèan cinnteach gu bheil e a’ ruith aig http://localhost:4444 no http://selenium:4444. [Stiùireadh Stèidheachaidh](https://example.com/selenium-setup)",
             "chromium_not_found": "❌ Chan eil brabhsair Chromium air a chuir a-steach. Stàlaich Chromium no Google Chrome mas e do thoil e. [Stiùireadh Stàlaidh](https://example.com/chromium-install)"
         }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "auto_refresh_enabled": "Ùraich an sensor gu fèin-obrachail"
+                }
+            }
+        }
     }
 }

--- a/custom_components/uk_bin_collection/translations/pt.json
+++ b/custom_components/uk_bin_collection/translations/pt.json
@@ -7,7 +7,7 @@
                 "data": {
                     "name": "Nome da localização",
                     "council": "Conselho",
-                    "manual_refresh_only": "Atualize o sensor automaticamente",
+                    "auto_refresh_enabled": "Atualize o sensor automaticamente",
                     "icon_color_mapping": "JSON para mapear Tipo de Lixo para Cor e Ícone veja: https://github.com/robbrad/UKBinCollectionData"
                 },
                 "description": "Por favor, veja [aqui](https://github.com/robbrad/UKBinCollectionData#requesting-your-council) se o seu conselho não estiver listado"
@@ -41,7 +41,7 @@
                     "usrn": "USRN (Número de Referência Único da Rua)",
                     "web_driver": "Para executar em um Servidor Selenium remoto, adicione o URL do Servidor Selenium",
                     "headless": "Execute o Selenium no modo sem cabeça (recomendado)",
-                    "manual_refresh_only": "Atualize o sensor automaticamente",
+                    "auto_refresh_enabled": "Atualize o sensor automaticamente",
                     "local_browser": "Não execute no servidor Selenium remoto, use a instalação local do Chrome em vez disso",
                     "icon_color_mapping": "JSON para mapear Tipo de Lixo para Cor e Ícone veja: https://github.com/robbrad/UKBinCollectionData",
                     "submit": "Enviar"

--- a/custom_components/uk_bin_collection/translations/pt.json
+++ b/custom_components/uk_bin_collection/translations/pt.json
@@ -55,5 +55,14 @@
             "selenium_unavailable": "❌ O servidor Selenium não está acessível. Por favor, certifique-se de que está em execução em http://localhost:4444 ou http://selenium:4444. [Guia de Configuração](https://example.com/selenium-setup)",
             "chromium_not_found": "❌ O navegador Chromium não está instalado. Por favor, instale o Chromium ou o Google Chrome. [Guia de Instalação](https://example.com/chromium-install)"
         }
+    },
+    "options": {
+        "step": {
+            "init": {
+                "data": {
+                    "auto_refresh_enabled": "Atualize o sensor automaticamente"
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

The `manual_refresh_only` checkbox is counter-intuitive: it is labelled **"Automatically refresh the sensor"** but ticking it actually *disables* polling, and it defaults to `True` — so new installs silently get no periodic updates while showing a ticked "automatically refresh" box. This is the likely root cause of the recurring "entities only update on restart" reports.

Fixes #2193

This PR **inverts the control** so the checkbox reads the way it behaves: ticking it enables automatic refresh.

> Note: this is an *alternative* approach to #2196, which instead relabels the existing inverted field. Pick whichever you prefer — they solve the same issue and only one should be merged.

## What changes

- New positive config field **`auto_refresh_enabled`** (default `True` = poll on `update_interval`). `async_setup_entry` decides the coordinator's update interval from it.
- Checkbox relabelled **"Enable automatic data refresh"**.
- As a side effect this also fixes the questionable default — new installs now poll by default.

## Backward compatibility

- **No config version bump / no migration required.** Existing entries are read via a lazy fallback: `auto_refresh_enabled = not manual_refresh_only`.
- The reconfigure and options flows derive the checkbox's default state from either key and drop the legacy `manual_refresh_only` key when the entry is next saved.

## Translations (minimal)

The existing translated values already said "refresh automatically" — which is now *correct* under the inverted semantics — so only the key is renamed (`manual_refresh_only` → `auto_refresh_enabled`), plus the improved English label. No value churn in cy/ga/gd/pt.

## Tests

- New tests covering `auto_refresh_enabled` in both states (polls when `True`, no polling when `False`).
- Existing tests retained as legacy-fallback coverage (entries that only carry `manual_refresh_only`).
- `test_init.py` and `test_config_flow.py` pass locally (pre-existing `event_loop`-fixture errors and the `freezegun`-dependent sensor/calendar tests are unrelated to this change).

## Note for reviewers

The non-English strings are the project's existing translations, just re-keyed — a native-speaker glance is welcome but nothing was newly translated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **“Enable automatic data refresh”** setting during setup, reconfiguration, and in the integration options.
* **Bug Fixes**
  * Existing configurations using the legacy refresh setting are automatically migrated.
  * When automatic refresh is disabled, automatic polling is stopped and the update interval is preserved for when it’s re-enabled.
  * Disabling auto refresh now takes precedence over legacy settings.
* **Documentation**
  * Updated UI text/labels and translations (English, Welsh, Irish, Scottish Gaelic, Portuguese) to use **auto refresh enabled**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->