### PR TITLE
fix: #2204 recompute bin countdown at local midnight

### DIFF
--- a/custom_components/uk_bin_collection/sensor.py
+++ b/custom_components/uk_bin_collection/sensor.py
@@ -19,6 +19,7 @@ from homeassistant.helpers.update_coordinator import (
 )
 from homeassistant.util import dt as dt_util
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.event import async_track_time_change
 import homeassistant.helpers.config_validation as cv
 
 from .const import (
@@ -132,6 +133,30 @@ class UKBinCollectionDataSensor(CoordinatorEntity, SensorEntity):
         self._next_collection = None
         self._days = None
         self.update_state()
+
+    async def async_added_to_hass(self) -> None:
+        """Register callbacks once the entity is added to hass."""
+        await super().async_added_to_hass()
+        # The state ("In N days" / "Tomorrow" / "Today") and the days attribute
+        # are relative to the current date, but the coordinator may only refresh
+        # every few hours (or not at all in manual-refresh mode). Recompute at
+        # local midnight so the countdown stays correct between data fetches
+        # instead of being frozen at the value from the last coordinator update.
+        self.async_on_remove(
+            async_track_time_change(
+                self.hass,
+                self._async_midnight_update,
+                hour=0,
+                minute=0,
+                second=0,
+            )
+        )
+
+    @callback
+    def _async_midnight_update(self, now: datetime) -> None:
+        """Recompute the date-relative state at local midnight."""
+        self.update_state()
+        self.async_write_ha_state()
 
     @property
     def device_info(self) -> dict:

--- a/custom_components/uk_bin_collection/tests/test_sensor.py
+++ b/custom_components/uk_bin_collection/tests/test_sensor.py
@@ -1497,6 +1497,60 @@ async def test_bin_sensor_in_x_days(hass, freezer, mock_config_entry):
     assert sensor.state == "In 5 days"
 
 
+@pytest.mark.asyncio
+async def test_bin_sensor_midnight_recompute_advances_countdown(
+    hass, freezer, mock_config_entry
+):
+    """The 'In N days' countdown must decrement at midnight even if the
+    coordinator data has not been refreshed (regression for #2204)."""
+    freezer.move_to("2023-10-14")
+    collection_date = dt_util.now().date() + timedelta(days=5)
+
+    coordinator = MagicMock()
+    coordinator.data = {"General Waste": collection_date}
+    coordinator.name = "Test Coordinator"
+
+    sensor = UKBinCollectionDataSensor(
+        coordinator, "General Waste", "test_gw_midnight", {}
+    )
+    assert sensor.state == "In 5 days"
+
+    # A day passes with no new coordinator data.
+    freezer.move_to("2023-10-15")
+    # Stale cached value until the midnight recompute runs.
+    assert sensor.state == "In 5 days"
+
+    with patch.object(sensor, "async_write_ha_state") as mock_write:
+        sensor._async_midnight_update(dt_util.now())
+
+    assert sensor.state == "In 4 days"
+    assert sensor.extra_state_attributes["days"] == 4
+    mock_write.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_bin_sensor_registers_midnight_tracker(hass, mock_config_entry):
+    """async_added_to_hass schedules a daily midnight recompute."""
+    coordinator = MagicMock()
+    coordinator.data = {"General Waste": datetime(2025, 1, 1).date()}
+    coordinator.name = "Test Coordinator"
+
+    sensor = UKBinCollectionDataSensor(
+        coordinator, "General Waste", "test_gw_tracker", {}
+    )
+    sensor.hass = hass
+    sensor.async_on_remove = MagicMock()
+
+    with patch(
+        "custom_components.uk_bin_collection.sensor.async_track_time_change"
+    ) as mock_track:
+        await sensor.async_added_to_hass()
+
+    mock_track.assert_called_once()
+    # Fires at local midnight (00:00:00).
+    assert mock_track.call_args.kwargs == {"hour": 0, "minute": 0, "second": 0}
+
+
 def test_data_sensor_default_icon_unknown_type():
     coordinator = MagicMock()
     coordinator.data = {"Some Custom Bin": datetime(2025, 1, 1).date()}


### PR DESCRIPTION
## Summary

The main bin sensor's state (`"In N days"` / `"Tomorrow"` / `"Today"`) and its `days` attribute are **cached** and only recomputed inside `update_state()`, which runs at init and on `_handle_coordinator_update()`. The entity doesn't poll and had no time-based recompute, so **the countdown is frozen between coordinator refreshes** — it only advances when new data is fetched.

This surfaced in #2204: the "Next Collection Date" attribute (read live from the stored date) looked correct while the main sensor's "in two days" text was wrong. That's the exact fingerprint of a frozen relative countdown — the absolute date is still a valid future date, but the days-until value is stale.

It's most visible alongside #2193 (where automatic polling was disabled entirely by the `manual_refresh_only` flip), but it's a real gap on its own: even with a healthy 12-hour refresh, the countdown would only update on coordinator ticks rather than at the day boundary, so it could read a day off.

## Change

Register an `async_track_time_change` callback at local midnight (`00:00:00`) in `async_added_to_hass`. It recomputes the date-relative state and writes it, keeping the countdown correct independent of data fetches. Registered through `async_on_remove` so it's torn down with the entity.

Only the date-relative fields are recomputed from already-fetched coordinator data — this does **not** trigger any council scraping at midnight.

## Tests

- `test_bin_sensor_midnight_recompute_advances_countdown` — "In 5 days" → after a day passes with no new data, the midnight recompute yields "In 4 days" (and `days == 4`).
- `test_bin_sensor_registers_midnight_tracker` — `async_added_to_hass` schedules the tracker at `hour=0, minute=0, second=0`.

```bash
poetry run pytest custom_components/uk_bin_collection/tests/test_sensor.py
```

All 69 sensor tests pass locally; black clean.

## Related

- #2204 (closed as duplicate of #2193) — this addresses the "date correct but countdown wrong" half.
- #2203 — restores automatic refresh; complementary. This PR is independent and touches only `sensor.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Bin collection sensors now automatically refresh their date-based countdowns at local midnight.
  * Sensor states remain accurate even when no coordinator update occurs.

* **Tests**
  * Added coverage for midnight countdown updates and daily refresh scheduling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->