### PR TITLE
ci: stop Docker image build racing the PyPI publish on release bumps

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -21,6 +21,17 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    # Skip the version-bump commit. `cz bump` rewrites
+    # uk_bin_collection_api_server/requirements.txt to pin the just-bumped
+    # `uk-bin-collection>=<new version>`, and pushing that commit to master
+    # triggers this workflow. Building here would `pip install` the new version
+    # before it exists on PyPI (published separately by release.yml on the tag),
+    # so it races and fails. The release.yml `docker` job (needs: release)
+    # builds and pushes the image correctly *after* the PyPI publish, so this
+    # bump-commit build is redundant as well as broken — skip it.
+    if: >-
+      github.event_name != 'push' ||
+      !startsWith(github.event.head_commit.message, 'bump:')
     steps:
     - uses: actions/checkout@v7
     - name: Publish to Registry


### PR DESCRIPTION
## Problem

The **Build - Docker Image** workflow (`docker-image.yml`) has been failing on every release with:

```
ERROR: Could not find a version that satisfies the requirement uk-bin-collection>=0.171.3
ERROR: No matching distribution found for uk-bin-collection>=0.171.3
```

(Observed on both the 0.171.2 and 0.171.3 bump commits.)

## Root cause — a release-ordering race

1. `docker-image.yml` triggers on pushes to `master` that touch `uk_bin_collection_api_server/**`.
2. `uk_bin_collection_api_server/requirements.txt` is listed in `pyproject.toml`'s `[tool.commitizen] version_files`, so `cz bump` (in `bump.yml`) rewrites it to `uk-bin-collection>=<new version>` as part of the release bump.
3. That bump commit is pushed to `master` → it changes a file under `uk_bin_collection_api_server/**` → **this workflow fires**.
4. The build runs `pip install -r requirements.txt`, which needs `uk-bin-collection>=<new version>` from **PyPI** — but that version is published separately by `release.yml` (triggered on the git *tag*), which runs concurrently. The Docker build usually loses the race and fails because the version isn't on PyPI yet.

## Why this build is redundant anyway

`release.yml` already publishes to PyPI and **then** builds and pushes the image via its `docker` job (`needs: release`) — correctly ordered, tagged `:<version>` and `:latest`. That job succeeded for 0.171.3. So the image is fine; only this extra, unordered build fails.

## Fix

Skip the build on `bump:` commits, using the same guard already present in `bump.yml`:

```yaml
if: >-
  github.event_name != 'push' ||
  !startsWith(github.event.head_commit.message, 'bump:')
```

Unaffected: PR builds (validate the image still builds), the weekly `schedule` rebuild, `workflow_dispatch`, and normal api-server merges to master (which still publish `:latest`). Release-time publishing continues to be handled — correctly ordered — by `release.yml`.

> Alternative considered: drop the `push: branches: [master]` trigger entirely and let `release.yml` own all publishing. The `bump:` guard is more surgical and keeps `:latest` updating on direct api-server merges, so I went with that. Happy to switch if you'd prefer the simpler split.

## Note

The already-failed 0.171.3 run has been re-run and now passes (0.171.3 is on PyPI), so `master` is green; this PR prevents the failure recurring on future bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image publishing to skip automated version-bump commits.
  * Existing builds and publishing continue for other eligible events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->