### PR TITLE
fix(coventry-city-council): fixes scraping format after food waste caddy

### DIFF
--- a/uk_bin_collection/tests/test_coventry_city_council.py
+++ b/uk_bin_collection/tests/test_coventry_city_council.py
@@ -1,0 +1,79 @@
+"""Unit tests for the Coventry City Council bin calendar parser."""
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from uk_bin_collection.uk_bin_collection.councils.CoventryCityCouncil import (
+    CouncilClass,
+)
+
+MODULE_PATH = "uk_bin_collection.uk_bin_collection.councils.CoventryCityCouncil"
+
+LINK_PAGE_HTML = b"""
+<html><body>
+<a href="https://www.coventry.gov.uk/WednesdayBbincollectioncalendar">Find out which bin will be collected when and sign up for a free email reminder.</a>
+</body></html>
+"""
+
+VALID_CALENDAR_HTML = b"""
+<html><body>
+<div class="editor">
+<h2>August 2026</h2>
+<table>
+<thead><tr><th>Day and date</th><th>Recycling (blue-lidded bin)</th></tr></thead>
+<tbody><tr><td>Wednesday 5 August</td><td>Yes</td></tr></tbody>
+</table>
+</div>
+</body></html>
+"""
+
+CALENDAR_HTML_EMPTY_HEADING = b"""
+<html><body>
+<div class="editor">
+<h2></h2>
+<table>
+<thead><tr><th>Day and date</th><th>Recycling (blue-lidded bin)</th></tr></thead>
+<tbody><tr><td>Wednesday 5 August</td><td>Yes</td></tr></tbody>
+</table>
+</div>
+</body></html>
+"""
+
+CALENDAR_HTML_NO_BIN_HEADERS = b"""
+<html><body>
+<div class="editor">
+<h2>August 2026</h2>
+<table>
+<thead><tr><th>Day and date</th></tr></thead>
+<tbody><tr><td>Wednesday 5 August</td></tr></tbody>
+</table>
+</div>
+</body></html>
+"""
+
+
+def parse_fixture(calendar_html: bytes):
+    page = SimpleNamespace(content=LINK_PAGE_HTML)
+    calendar_response = SimpleNamespace(content=calendar_html)
+    with patch(f"{MODULE_PATH}.requests.get", return_value=calendar_response):
+        return CouncilClass().parse_data(page)
+
+
+def test_parse_data_parses_a_well_formed_calendar():
+    result = parse_fixture(VALID_CALENDAR_HTML)
+
+    assert result == {
+        "bins": [{"type": "Recycling", "collectionDate": "05/08/2026"}]
+    }
+
+
+def test_parse_data_raises_on_heading_with_no_year():
+    with pytest.raises(ValueError, match="heading has no year"):
+        parse_fixture(CALENDAR_HTML_EMPTY_HEADING)
+
+
+def test_parse_data_raises_on_missing_bin_type_headers():
+    with pytest.raises(ValueError, match="no bin-type headers found"):
+        parse_fixture(CALENDAR_HTML_NO_BIN_HEADERS)

--- a/uk_bin_collection/uk_bin_collection/councils/CoventryCityCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/CoventryCityCouncil.py
@@ -1,6 +1,5 @@
 import requests
 from bs4 import BeautifulSoup
-from dateutil.relativedelta import relativedelta
 
 from uk_bin_collection.uk_bin_collection.common import *
 from uk_bin_collection.uk_bin_collection.get_bin_data import AbstractGetBinDataClass
@@ -17,7 +16,6 @@ class CouncilClass(AbstractGetBinDataClass):
     def parse_data(self, page: str, **kwargs) -> dict:
 
         bindata = {"bins": []}
-        curr_date = datetime.today()
 
         headers = {
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36"
@@ -36,22 +34,45 @@ class CouncilClass(AbstractGetBinDataClass):
             soup = BeautifulSoup(response.content, features="html.parser")
             divs = soup.find_all("div", {"class": "editor"})
             for div in divs:
-                lis = div.find_all("li")
-                for li in lis:
-                    collection = li.text.split(":")
-                    collection_date = datetime.strptime(
-                        collection[0],
-                        "%A %d %B",
-                    ).replace(year=curr_date.year)
-                    if curr_date.month == 12 and collection_date.month == 1:
-                        collection_date = collection_date + relativedelta(years=1)
-                    bin_types = collection[1].split(" and ")
-                    for bin_type in bin_types:
-                        dict_data = {
-                            "type": bin_type,
-                            "collectionDate": collection_date.strftime("%d/%m/%Y"),
-                        }
-                        bindata["bins"].append(dict_data)
+                for table in div.find_all("table"):
+                    heading = table.find_previous_sibling("h2")
+                    if not heading:
+                        continue
+                    year = heading.get_text(strip=True).split()[-1]
+
+                    thead = table.find("thead")
+                    tbody = table.find("tbody")
+                    if not thead or not tbody:
+                        continue
+
+                    bin_types = [
+                        re.sub(
+                            r"\s*\(.*?\)$",
+                            "",
+                            th.get_text(separator=" ", strip=True),
+                        )
+                        for th in thead.find_all("th")[1:]
+                    ]
+
+                    for row in tbody.find_all("tr"):
+                        cells = row.find_all("td")
+                        if not cells:
+                            continue
+                        date_text = cells[0].get_text(strip=True)
+                        collection_date = datetime.strptime(
+                            f"{date_text} {year}",
+                            "%A %d %B %Y",
+                        )
+                        for bin_type, cell in zip(bin_types, cells[1:]):
+                            if cell.get_text(strip=True).lower() == "yes":
+                                bindata["bins"].append(
+                                    {
+                                        "type": bin_type,
+                                        "collectionDate": collection_date.strftime(
+                                            date_format
+                                        ),
+                                    }
+                                )
         else:
             print("Failed to find bin schedule")
 

--- a/uk_bin_collection/uk_bin_collection/councils/CoventryCityCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/CoventryCityCouncil.py
@@ -42,7 +42,13 @@ class CouncilClass(AbstractGetBinDataClass):
                             "no preceding month/year heading — page structure "
                             "may have changed"
                         )
-                    year = heading.get_text(strip=True).split()[-1]
+                    heading_words = heading.get_text(strip=True).split()
+                    if not heading_words:
+                        raise ValueError(
+                            "Coventry bin calendar: schedule heading has no "
+                            "year — page structure may have changed"
+                        )
+                    year = heading_words[-1]
 
                     thead = table.find("thead")
                     tbody = table.find("tbody")
@@ -60,6 +66,11 @@ class CouncilClass(AbstractGetBinDataClass):
                         )
                         for th in thead.find_all("th")[1:]
                     ]
+                    if not any(bin_types):
+                        raise ValueError(
+                            "Coventry bin calendar: no bin-type headers found "
+                            "in schedule table — page structure may have changed"
+                        )
 
                     for row in tbody.find_all("tr"):
                         cells = row.find_all("td")

--- a/uk_bin_collection/uk_bin_collection/councils/CoventryCityCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/CoventryCityCouncil.py
@@ -37,13 +37,20 @@ class CouncilClass(AbstractGetBinDataClass):
                 for table in div.find_all("table"):
                     heading = table.find_previous_sibling("h2")
                     if not heading:
-                        continue
+                        raise ValueError(
+                            "Coventry bin calendar: found a schedule table with "
+                            "no preceding month/year heading — page structure "
+                            "may have changed"
+                        )
                     year = heading.get_text(strip=True).split()[-1]
 
                     thead = table.find("thead")
                     tbody = table.find("tbody")
                     if not thead or not tbody:
-                        continue
+                        raise ValueError(
+                            "Coventry bin calendar: schedule table is missing "
+                            "a thead/tbody — page structure may have changed"
+                        )
 
                     bin_types = [
                         re.sub(
@@ -56,14 +63,20 @@ class CouncilClass(AbstractGetBinDataClass):
 
                     for row in tbody.find_all("tr"):
                         cells = row.find_all("td")
-                        if not cells:
-                            continue
+                        if len(cells) != len(bin_types) + 1:
+                            raise ValueError(
+                                f"Coventry bin calendar: expected 1 date cell "
+                                f"plus {len(bin_types)} bin cells, found "
+                                f"{len(cells)} — page structure may have changed"
+                            )
                         date_text = cells[0].get_text(strip=True)
                         collection_date = datetime.strptime(
                             f"{date_text} {year}",
                             "%A %d %B %Y",
                         )
-                        for bin_type, cell in zip(bin_types, cells[1:]):
+                        for bin_type, cell in zip(
+                            bin_types, cells[1:], strict=True
+                        ):
                             if cell.get_text(strip=True).lower() == "yes":
                                 bindata["bins"].append(
                                     {


### PR DESCRIPTION
Coventry City Council have introduced a new page structure after the food waste caddy was added to the schedule. Previously, the calendar page used `<div class="editor">` sections with colon-separated text lines (Day: waste type). The site now uses a plain `<table>` per month, with Yes/No cells per waste type across named columns.

This PR updates the parser to read the new table structure and adds support for the new Food waste caddy collection type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Coventry collection schedule parsing from council webpages.
  * Collection dates now reflect the year shown in section headings and bin types listed in table headers.
  * Invalid or incomplete schedule sections are now reported instead of being silently ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->