### PR TITLE
fix: update date parsing in TestValleyBoroughCouncil

### DIFF
--- a/uk_bin_collection/uk_bin_collection/councils/TestValleyBoroughCouncil.py
+++ b/uk_bin_collection/uk_bin_collection/councils/TestValleyBoroughCouncil.py
@@ -49,6 +49,7 @@ class CouncilClass(AbstractGetBinDataClass):
             ).click()
 
             import time
+
             time.sleep(8)
 
             soup = BeautifulSoup(driver.page_source, features="html.parser")
@@ -68,10 +69,12 @@ class CouncilClass(AbstractGetBinDataClass):
 
                 next_date = self._parse_date(next_collection_text)
                 if next_date:
-                    data["bins"].append({
-                        "type": bin_type,
-                        "collectionDate": next_date.strftime(date_format),
-                    })
+                    data["bins"].append(
+                        {
+                            "type": bin_type,
+                            "collectionDate": next_date.strftime(date_format),
+                        }
+                    )
 
                 followed_div = collection.find(
                     lambda t: (
@@ -82,13 +85,17 @@ class CouncilClass(AbstractGetBinDataClass):
                 if followed_div:
                     following_text = followed_div.get_text(strip=True)
                     following_date = self._parse_date(
-                        following_text.replace("followed by ", "").replace("Followed by ", "")
+                        following_text.replace("followed by ", "").replace(
+                            "Followed by ", ""
+                        )
                     )
                     if following_date:
-                        data["bins"].append({
-                            "type": bin_type,
-                            "collectionDate": following_date.strftime(date_format),
-                        })
+                        data["bins"].append(
+                            {
+                                "type": bin_type,
+                                "collectionDate": following_date.strftime(date_format),
+                            }
+                        )
 
         except Exception as e:
             print(f"An error occurred: {e}")
@@ -101,7 +108,8 @@ class CouncilClass(AbstractGetBinDataClass):
     @staticmethod
     def _parse_date(text: str):
         import re
-        text = re.sub(r"(st|nd|rd|th)", "", text).strip()
+
+        # text = re.sub(r"(st|nd|rd|th)", "", text).strip()
         try:
             parsed = dt.datetime.strptime(text, "%A %d %B").date()
         except ValueError:


### PR DESCRIPTION
fix: Test Valley appear to have updated the date format to no longer include nd, th, rd, etc in the collection dates. This caused the date parser to strip letters out of the day of the week and subsequently fail to parse the date. Commented out regex substitution which now allows dates to correctly parse.

Fixes #2194

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formatting and handling of bin collection results.
  * Updated date parsing to correctly support dates that include ordinal suffixes such as “st”, “nd”, “rd”, and “th”.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->